### PR TITLE
dyninst: add len() and isEmpty() expression support

### DIFF
--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -278,8 +278,9 @@ func (g *generator) addConditionHandler(
 			ops = opsAfter
 		case *ir.DereferenceOp:
 			ops = append(ops, ExprDereferencePtrOp{
-				Bias: op.Bias,
-				Len:  op.ByteSize,
+				Bias:      op.Bias,
+				Len:       op.ByteSize,
+				NilBitIdx: ^uint32(0),
 			})
 		case *ir.ExprPushOffsetOp:
 			ops = append(ops, ExprPushOffsetOp{ByteSize: op.ByteSize})
@@ -353,8 +354,9 @@ func (g *generator) addExpressionHandler(injectionPC uint64, rootType *ir.EventR
 			}
 			lastOpSize = op.ByteSize
 			ops = append(ops, ExprDereferencePtrOp{
-				Bias: op.Bias,
-				Len:  op.ByteSize,
+				Bias:      op.Bias,
+				Len:       op.ByteSize,
+				NilBitIdx: 2*exprIdx + 1,
 			})
 		default:
 			panic(fmt.Sprintf("unexpected ir.Operation: %#v", op))

--- a/pkg/dyninst/compiler/generate.go
+++ b/pkg/dyninst/compiler/generate.go
@@ -358,6 +358,16 @@ func (g *generator) addExpressionHandler(injectionPC uint64, rootType *ir.EventR
 				Len:       op.ByteSize,
 				NilBitIdx: 2*exprIdx + 1,
 			})
+		case *ir.ExprPushOffsetOp:
+			ops = append(ops, ExprPushOffsetOp{ByteSize: op.ByteSize})
+		case *ir.ExprLoadLiteralOp:
+			ops = append(ops, ExprLoadLiteralOp{Data: op.Data})
+		case *ir.ExprReadStringOp:
+			ops = append(ops, ExprReadStringOp{MaxLen: op.MaxLen})
+		case *ir.ExprCmpEqBaseOp:
+			ops = append(ops, ExprCmpEqBaseOp{ByteSize: op.ByteSize})
+		case *ir.ExprCmpEqStringOp:
+			ops = append(ops, ExprCmpEqStringOp{})
 		default:
 			panic(fmt.Sprintf("unexpected ir.Operation: %#v", op))
 		}

--- a/pkg/dyninst/compiler/instructions.go
+++ b/pkg/dyninst/compiler/instructions.go
@@ -47,8 +47,8 @@ func makeInstruction(op Op) codeFragment {
 		e := op.EventRootType.Expressions[op.ExprIdx]
 		bytes = binary.LittleEndian.AppendUint32(bytes, e.Offset)
 		bytes = binary.LittleEndian.AppendUint32(bytes, e.Expression.Type.GetByteSize())
-		// Presence bit index.
-		bytes = binary.LittleEndian.AppendUint32(bytes, op.ExprIdx)
+		// Presence bit index (2 bits per expression).
+		bytes = binary.LittleEndian.AppendUint32(bytes, 2*op.ExprIdx)
 		return staticInstruction{
 			opcode: OpcodeExprSave,
 			bytes:  bytes,
@@ -74,9 +74,10 @@ func makeInstruction(op Op) codeFragment {
 		}
 
 	case ExprDereferencePtrOp:
-		bytes := make([]byte, 0, 8)
+		bytes := make([]byte, 0, 12)
 		bytes = binary.LittleEndian.AppendUint32(bytes, op.Bias)
 		bytes = binary.LittleEndian.AppendUint32(bytes, op.Len)
+		bytes = binary.LittleEndian.AppendUint32(bytes, op.NilBitIdx)
 		return staticInstruction{
 			opcode: OpcodeExprDereferencePtr,
 			bytes:  bytes,

--- a/pkg/dyninst/compiler/ops.go
+++ b/pkg/dyninst/compiler/ops.go
@@ -77,8 +77,9 @@ type ExprReadRegisterOp struct {
 
 type ExprDereferencePtrOp struct {
 	baseOp
-	Bias uint32
-	Len  uint32
+	Bias      uint32
+	Len       uint32
+	NilBitIdx uint32
 }
 
 // Special type processing ops, that evaluate data of a specific type (already

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a6126]
 	PrepareEventRoot 4d 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6170]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a71d3]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a78ee]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a79ae]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a73aa]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a746a]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a752a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a752a]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a752a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a72ea]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	PrepareEventRoot 14 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*main.condFields]
+	Call 61 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	PrepareEventRoot 09 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a7fea]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@4a7fea]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@4a7fea]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	PrepareEventRoot 0f 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@4a805a]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@4a805a]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@4a7fea]
+// 0x767: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@4a805a]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@4a805a]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	PrepareEventRoot 01 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*main.condFields]
+	Call 61 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	PrepareEventRoot 05 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	PrepareEventRoot 0b 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
 	PrepareEventRoot 0e 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0x964: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@4a7b2a]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0x9a8: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@4a7b2a]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0xa05: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot ef 00 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@4a7b2a]
+// 0xa67: ProcessEvent[Probe[main.condString]@4a7b2a]
 	PrepareEventRoot f1 00 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0xa85: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@4a7b2a]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0xaeb: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot f3 00 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 15 1c 00 00 // ProcessType[main.condFields]
+	Call 35 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	PrepareEventRoot ff 00 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@4a76aa]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@4a76aa]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a771a]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@4a76aa]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a771a]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a776a]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@4a776a]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@4a776a]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a77da]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@4a776a]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@4a776a]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a77da]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a782a]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@4a782a]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@4a782a]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a789a]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@4a782a]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@4a782a]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a789a]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@4a75ea]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@4a75ea]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@4a75ea]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@4a5eee]
+// 0x106e: ProcessEvent[Probe[main.inlined]@4a5eee]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@4a70aa]
+// 0x1093: ProcessEvent[Probe[main.inlined]@4a70aa]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@4a70ea]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a70ea]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@4a6d8a]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@4a6d8a]
 	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a6dca]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4a6dca]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
 	PrepareEventRoot b2 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
 	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[3]string]
+	Call e3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
 	PrepareEventRoot 41 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
 	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 15 1c 00 00 // ProcessType[main.condFields]
+	Call 35 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
 	PrepareEventRoot 45 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
 	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
 	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@4a86ce]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@4a86ce]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
 	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@4a86ce]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@4a86ce]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4a880e]
 	PrepareEventRoot 27 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 89 1a 00 00 // ProcessType[*string]
+	Call a9 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4a880e]
 	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
 	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*main.lenFields]
+	Call 67 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
 	PrepareEventRoot 39 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
 	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
 	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
 	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
 	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
 	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@4a8573]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@4a8573]
 	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4a8573]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4a8573]
 	PrepareEventRoot 21 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4a8413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x1525: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@4a8413]
+// 0x1559: ProcessEvent[Probe[main.lenString]@4a8413]
 	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0x4a8413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@4a8413]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@4a8413]
 	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@4a8413]
+// 0x1642: ProcessEvent[Probe[main.lenString]@4a8413]
 	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 20 1c 00 00 // ProcessType[main.lenFields]
+	Call 40 1c 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 2b 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 2e 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4a8933]
 	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,437 +1495,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	PrepareEventRoot 37 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
 	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@4a716a]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@4a716a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4a719f]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4a719f]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@4a728a]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@4a728a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[3]string]
+	Call e3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]string]
+	Call 49 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 86 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
 	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a19: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*bucket<string,int>]
+// 0x1a1f: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1a25: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a2b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a31: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*error]
+// 0x1a37: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*float32]
+// 0x1a3d: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*float64]
+// 0x1a43: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*int]
+// 0x1a49: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*int32]
+// 0x1a4f: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*int64]
+// 0x1a55: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*main.bigStruct]
+// 0x1a5b: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*main.condFields]
+// 0x1a61: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*main.lenFields]
+// 0x1a67: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime._defer]
+// 0x1a6d: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime._panic]
+// 0x1a73: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.cgoCallers]
+// 0x1a79: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.coro]
+// 0x1a7f: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.g]
+// 0x1a85: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.m]
+// 0x1a8b: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*runtime.mapextra]
+// 0x1a91: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*runtime.sudog]
+// 0x1a97: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*runtime.timer]
+// 0x1a9d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*runtime.traceBuf]
+// 0x1aa3: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*string]
+// 0x1aa9: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint]
+// 0x1aaf: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint16]
+// 0x1ab5: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint32]
+// 0x1abb: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint64]
+// 0x1ac1: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint8]
+// 0x1ac7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uintptr]
+// 0x1acd: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 83 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call a3 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ac3: ProcessType[[3]string]
+// 0x1ae3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1af3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 73 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 93 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[]bucket<string,int>.array]
+// 0x1aff: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 1b 00 00 // ProcessType[bucket<string,int>]
+	Call 9e 1b 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aeb: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x1b0b: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 93 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call b3 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af7: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b17: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call c8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b03: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b23: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call bd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call dd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0f: ProcessType[[]int]
+// 0x1b2f: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]key<string>]
+// 0x1b39: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]string]
+// 0x1b49: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1b33: ProcessType[[]string.array]
+// 0x1b53: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]uint8]
+// 0x1b5f: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]uintptr]
+// 0x1b69: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]val<main.bigStruct>]
+// 0x1b73: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 5b 1a 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b63: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1b83: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 6e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b73: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1b93: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call f9 19 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 1a 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1b7e: ProcessType[bucket<string,int>]
+// 0x1b9e: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call ff 19 00 00 // ProcessType[*bucket<string,int>]
+	Call 1f 1a 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1b93: ProcessType[bucket<string,main.bigStruct>]
+// 0x1bb3: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
-	Call 53 1b 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 05 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 73 1b 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 25 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1ba8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bc8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
-	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 0b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bbd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bdd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 11 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 31 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bcd: ProcessType[error]
+// 0x1bed: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1bcf: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x1bef: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1bdd: ProcessType[hash<string,int>]
+// 0x1bfd: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1beb: ProcessType[hash<string,main.bigStruct>]
+// 0x1c0b: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1bf9: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c19: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c07: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c27: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1c15: ProcessType[main.condFields]
+// 0x1c35: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c20: ProcessType[main.lenFields]
-	Call 42 1d 00 00 // ProcessType[string]
+// 0x1c40: ProcessType[main.lenFields]
+	Call 62 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 89 1a 00 00 // ProcessType[*string]
+	Call a9 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c4e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c6e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1c54: ProcessType[map[string]int]
+// 0x1c74: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1c5a: ProcessType[map[string]main.bigStruct]
+// 0x1c7a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c60: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c80: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c66: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c86: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1c6c: ProcessType[runtime.g]
+// 0x1c8c: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime._panic]
+	Call 73 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime._defer]
+	Call 6d 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 3f 1b 00 00 // ProcessType[[]uint8]
+	Call 5f 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 77 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 97 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*runtime.timer]
+	Call 9d 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.coro]
+	Call 7f 1a 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x1cc7: ProcessType[runtime.m]
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+// 0x1ce7: ProcessType[runtime.m]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 79 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 27 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 47 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 52 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d27: ProcessType[runtime.mLockProfile]
+// 0x1d47: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d32: ProcessType[runtime.mTraceState]
+// 0x1d52: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d42: ProcessType[string]
+// 0x1d62: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2194,12 +2194,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6643
-ID: 6 Len: 8 Enqueue: 6823
+ID: 5 Len: 8 Enqueue: 6675
+ID: 6 Len: 8 Enqueue: 6855
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 6829
+ID: 8 Len: 8 Enqueue: 6861
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 7490
+ID: 10 Len: 16 Enqueue: 7522
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -2207,18 +2207,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 7117
+ID: 18 Len: 16 Enqueue: 7149
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6703
-ID: 21 Len: 8 Enqueue: 6811
-ID: 22 Len: 432 Enqueue: 7276
+ID: 20 Len: 8 Enqueue: 6735
+ID: 21 Len: 8 Enqueue: 6843
+ID: 22 Len: 432 Enqueue: 7308
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6739
+ID: 24 Len: 8 Enqueue: 6771
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6733
+ID: 26 Len: 8 Enqueue: 6765
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6763
-ID: 29 Len: 1760 Enqueue: 7367
+ID: 28 Len: 8 Enqueue: 6795
+ID: 29 Len: 1760 Enqueue: 7399
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2227,41 +2227,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 6975
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7007
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6775
+ID: 41 Len: 8 Enqueue: 6807
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 6985
-ID: 44 Len: 8 Enqueue: 6781
+ID: 43 Len: 24 Enqueue: 7017
+ID: 44 Len: 8 Enqueue: 6813
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6751
+ID: 47 Len: 8 Enqueue: 6783
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 6757
+ID: 53 Len: 8 Enqueue: 6789
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 6745
+ID: 60 Len: 8 Enqueue: 6777
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 7463
+ID: 64 Len: 64 Enqueue: 7495
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 7474
+ID: 69 Len: 32 Enqueue: 7506
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 6835
-ID: 72 Len: 8 Enqueue: 6787
+ID: 71 Len: 16 Enqueue: 6867
+ID: 72 Len: 8 Enqueue: 6819
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2277,53 +2277,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 6793
+ID: 88 Len: 8 Enqueue: 6825
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 6691
-ID: 92 Len: 8 Enqueue: 6709
-ID: 93 Len: 8 Enqueue: 6697
-ID: 94 Len: 8 Enqueue: 6817
-ID: 95 Len: 8 Enqueue: 6679
+ID: 91 Len: 8 Enqueue: 6723
+ID: 92 Len: 8 Enqueue: 6741
+ID: 93 Len: 8 Enqueue: 6729
+ID: 94 Len: 8 Enqueue: 6849
+ID: 95 Len: 8 Enqueue: 6711
 ID: 96 Len: 2 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 6685
-ID: 98 Len: 8 Enqueue: 6799
-ID: 99 Len: 8 Enqueue: 6805
-ID: 100 Len: 24 Enqueue: 6927
+ID: 97 Len: 8 Enqueue: 6717
+ID: 98 Len: 8 Enqueue: 6831
+ID: 99 Len: 8 Enqueue: 6837
+ID: 100 Len: 24 Enqueue: 6959
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 6953
-ID: 103 Len: 48 Enqueue: 6851
-ID: 104 Len: 8 Enqueue: 7252
+ID: 102 Len: 24 Enqueue: 6985
+ID: 103 Len: 48 Enqueue: 6883
+ID: 104 Len: 8 Enqueue: 7284
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 7133
-ID: 107 Len: 8 Enqueue: 6655
-ID: 108 Len: 208 Enqueue: 7038
-ID: 109 Len: 8 Enqueue: 6769
+ID: 106 Len: 48 Enqueue: 7165
+ID: 107 Len: 8 Enqueue: 6687
+ID: 108 Len: 208 Enqueue: 7070
+ID: 109 Len: 8 Enqueue: 6801
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 7258
+ID: 111 Len: 8 Enqueue: 7290
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7147
-ID: 114 Len: 8 Enqueue: 6661
-ID: 115 Len: 208 Enqueue: 7059
-ID: 116 Len: 80 Enqueue: 7189
+ID: 113 Len: 48 Enqueue: 7179
+ID: 114 Len: 8 Enqueue: 6693
+ID: 115 Len: 208 Enqueue: 7091
+ID: 116 Len: 80 Enqueue: 7221
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6721
-ID: 119 Len: 72 Enqueue: 7200
-ID: 120 Len: 8 Enqueue: 6631
-ID: 121 Len: 8 Enqueue: 6727
-ID: 122 Len: 8 Enqueue: 7270
+ID: 118 Len: 8 Enqueue: 6753
+ID: 119 Len: 72 Enqueue: 7232
+ID: 120 Len: 8 Enqueue: 6663
+ID: 121 Len: 8 Enqueue: 6759
+ID: 122 Len: 8 Enqueue: 7302
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 7175
-ID: 125 Len: 8 Enqueue: 6673
-ID: 126 Len: 88 Enqueue: 7101
-ID: 127 Len: 8 Enqueue: 7264
+ID: 124 Len: 48 Enqueue: 7207
+ID: 125 Len: 8 Enqueue: 6705
+ID: 126 Len: 88 Enqueue: 7133
+ID: 127 Len: 8 Enqueue: 7296
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7161
-ID: 130 Len: 8 Enqueue: 6667
-ID: 131 Len: 208 Enqueue: 7080
-ID: 132 Len: 8 Enqueue: 6607
-ID: 133 Len: 8 Enqueue: 6613
-ID: 134 Len: 8 Enqueue: 6625
+ID: 129 Len: 48 Enqueue: 7193
+ID: 130 Len: 8 Enqueue: 6699
+ID: 131 Len: 208 Enqueue: 7112
+ID: 132 Len: 8 Enqueue: 6639
+ID: 133 Len: 8 Enqueue: 6645
+ID: 134 Len: 8 Enqueue: 6657
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2332,30 +2332,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 6963
+ID: 143 Len: 16 Enqueue: 6995
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 6937
+ID: 146 Len: 128 Enqueue: 6969
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 6879
-ID: 149 Len: 64 Enqueue: 6995
-ID: 150 Len: 8 Enqueue: 6715
+ID: 148 Len: 208 Enqueue: 6911
+ID: 149 Len: 64 Enqueue: 7027
+ID: 150 Len: 8 Enqueue: 6747
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 6891
+ID: 152 Len: 208 Enqueue: 6923
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7011
-ID: 155 Len: 8 Enqueue: 7246
+ID: 154 Len: 64 Enqueue: 7043
+ID: 155 Len: 8 Enqueue: 7278
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 7119
-ID: 158 Len: 8 Enqueue: 6649
-ID: 159 Len: 144 Enqueue: 7027
-ID: 160 Len: 88 Enqueue: 6915
-ID: 161 Len: 208 Enqueue: 6903
+ID: 157 Len: 48 Enqueue: 7151
+ID: 158 Len: 8 Enqueue: 6681
+ID: 159 Len: 144 Enqueue: 7059
+ID: 160 Len: 88 Enqueue: 6947
+ID: 161 Len: 208 Enqueue: 6935
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 6867
-ID: 166 Len: 8 Enqueue: 6619
+ID: 165 Len: 144 Enqueue: 6899
+ID: 166 Len: 8 Enqueue: 6651
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a6126]
-	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	PrepareEventRoot 5d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6170]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a71d3]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a78ee]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a79ae]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a73aa]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a746a]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a752a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a752a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a752a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a72ea]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
@@ -377,7 +377,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	PrepareEventRoot 14 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*main.condFields]
+	Call b8 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	PrepareEventRoot 09 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
@@ -470,7 +470,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
@@ -520,7 +520,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*main.condFields]
+	Call b8 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	PrepareEventRoot 05 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@4a7b2a]
 	PrepareEventRoot f1 00 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 35 1c 00 00 // ProcessType[main.condFields]
+	Call 8c 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	PrepareEventRoot ff 00 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
@@ -877,7 +877,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@4a776a]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
@@ -921,7 +921,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@4a776a]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@4a782a]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
@@ -965,7 +965,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@4a782a]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@4a5eee]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@4a70aa]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a70ea]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[3]string]
+	Call 3a 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
+	Call 86 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
-	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	PrepareEventRoot 51 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 35 1c 00 00 // ProcessType[main.condFields]
+	Call 8c 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
-	PrepareEventRoot 45 01 00 00 61 00 00 00 
+	PrepareEventRoot 55 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	PrepareEventRoot 29 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 2b 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	PrepareEventRoot 2d 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 31 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4a880e]
-	PrepareEventRoot 27 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a9 1a 00 00 // ProcessType[*string]
+	Call 00 1e 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4a880e]
-	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 35 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*main.lenFields]
+	Call be 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 39 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 49 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 4d 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 05 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	PrepareEventRoot 21 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@4a8413]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+	PrepareEventRoot 23 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@4a8413]
-	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 86 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 27 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0x4a8413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4a8413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 1b 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@4a8413]
+// 0x1898: ProcessEvent[Probe[main.lenString]@4a8413]
 	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@4a8505]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4a8505]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 40 1c 00 00 // ProcessType[main.lenFields]
+	Call 97 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 2b 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 37 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 39 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 41 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 43 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 45 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,437 +1689,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
-	PrepareEventRoot 37 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 47 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@4a716a]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@4a716a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4a719f]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4a719f]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@4a728a]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@4a728a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[3]string]
+	Call 3a 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]string]
+	Call a0 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 86 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call dd 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d70: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*bucket<string,int>]
+// 0x1d76: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1d7c: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d82: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d88: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*error]
+// 0x1d8e: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*float32]
+// 0x1d94: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*float64]
+// 0x1d9a: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*int]
+// 0x1da0: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*int32]
+// 0x1da6: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*int64]
+// 0x1dac: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*main.bigStruct]
+// 0x1db2: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*main.condFields]
+// 0x1db8: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*main.lenFields]
+// 0x1dbe: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime._defer]
+// 0x1dc4: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime._panic]
+// 0x1dca: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.cgoCallers]
+// 0x1dd0: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.coro]
+// 0x1dd6: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.g]
+// 0x1ddc: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.m]
+// 0x1de2: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*runtime.mapextra]
+// 0x1de8: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*runtime.sudog]
+// 0x1dee: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*runtime.timer]
+// 0x1df4: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*runtime.traceBuf]
+// 0x1dfa: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*string]
+// 0x1e00: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint]
+// 0x1e06: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint16]
+// 0x1e0c: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint32]
+// 0x1e12: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint64]
+// 0x1e18: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint8]
+// 0x1e1e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uintptr]
+// 0x1e24: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
+// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call a3 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call fa 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[3]string]
+// 0x1e3a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1af3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e4a: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 93 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call ea 1e 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aff: ProcessType[[]bucket<string,int>.array]
+// 0x1e56: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9e 1b 00 00 // ProcessType[bucket<string,int>]
+	Call f5 1e 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0b: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x1e62: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call b3 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 0a 1f 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b17: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e6e: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call c8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1f 1f 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b23: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e7a: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call dd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 34 1f 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b2f: ProcessType[[]int]
+// 0x1e86: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1b39: ProcessType[[]key<string>]
+// 0x1e90: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]string]
+// 0x1ea0: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]string.array]
+// 0x1eaa: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]uint8]
+// 0x1eb6: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b69: ProcessType[[]uintptr]
+// 0x1ec0: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b73: ProcessType[[]val<main.bigStruct>]
+// 0x1eca: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*main.bigStruct]
+	Call b2 1d 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1eda: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 6e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call c5 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b93: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1eea: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 19 1a 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 70 1d 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1b9e: ProcessType[bucket<string,int>]
+// 0x1ef5: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 1f 1a 00 00 // ProcessType[*bucket<string,int>]
+	Call 76 1d 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1bb3: ProcessType[bucket<string,main.bigStruct>]
+// 0x1f0a: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
-	Call 73 1b 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 25 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call ca 1e 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 7c 1d 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1bc8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f1f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
-	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 2b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 82 1d 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bdd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f34: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 31 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 88 1d 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bed: ProcessType[error]
+// 0x1f44: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1bef: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f46: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1bfd: ProcessType[hash<string,int>]
+// 0x1f54: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c0b: ProcessType[hash<string,main.bigStruct>]
+// 0x1f62: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c19: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f70: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c27: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f7e: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1c35: ProcessType[main.condFields]
+// 0x1f8c: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1c40: ProcessType[main.lenFields]
-	Call 62 1d 00 00 // ProcessType[string]
+// 0x1f97: ProcessType[main.lenFields]
+	Call b9 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
+	Call 86 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call a9 1a 00 00 // ProcessType[*string]
+	Call 00 1e 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c6e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fc5: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1c74: ProcessType[map[string]int]
+// 0x1fcb: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1c7a: ProcessType[map[string]main.bigStruct]
+// 0x1fd1: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c80: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fd7: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c86: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fdd: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1c8c: ProcessType[runtime.g]
+// 0x1fe3: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime._panic]
+	Call ca 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime._defer]
+	Call c4 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 5f 1b 00 00 // ProcessType[[]uint8]
+	Call b6 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 97 1a 00 00 // ProcessType[*runtime.sudog]
+	Call ee 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*runtime.timer]
+	Call f4 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.coro]
+	Call d6 1d 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x1ce7: ProcessType[runtime.m]
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+// 0x203e: ProcessType[runtime.m]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d0 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 47 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 9e 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 52 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call a9 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d47: ProcessType[runtime.mLockProfile]
+// 0x209e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d52: ProcessType[runtime.mTraceState]
+// 0x20a9: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d62: ProcessType[string]
+// 0x20b9: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2194,12 +2388,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6675
-ID: 6 Len: 8 Enqueue: 6855
+ID: 5 Len: 8 Enqueue: 7530
+ID: 6 Len: 8 Enqueue: 7710
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 6861
+ID: 8 Len: 8 Enqueue: 7716
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 7522
+ID: 10 Len: 16 Enqueue: 8377
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -2207,18 +2401,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 7149
+ID: 18 Len: 16 Enqueue: 8004
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6735
-ID: 21 Len: 8 Enqueue: 6843
-ID: 22 Len: 432 Enqueue: 7308
+ID: 20 Len: 8 Enqueue: 7590
+ID: 21 Len: 8 Enqueue: 7698
+ID: 22 Len: 432 Enqueue: 8163
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6771
+ID: 24 Len: 8 Enqueue: 7626
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6765
+ID: 26 Len: 8 Enqueue: 7620
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6795
-ID: 29 Len: 1760 Enqueue: 7399
+ID: 28 Len: 8 Enqueue: 7650
+ID: 29 Len: 1760 Enqueue: 8254
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2227,41 +2421,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7007
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7862
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6807
+ID: 41 Len: 8 Enqueue: 7662
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7017
-ID: 44 Len: 8 Enqueue: 6813
+ID: 43 Len: 24 Enqueue: 7872
+ID: 44 Len: 8 Enqueue: 7668
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6783
+ID: 47 Len: 8 Enqueue: 7638
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 6789
+ID: 53 Len: 8 Enqueue: 7644
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 6777
+ID: 60 Len: 8 Enqueue: 7632
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 7495
+ID: 64 Len: 64 Enqueue: 8350
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 7506
+ID: 69 Len: 32 Enqueue: 8361
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 6867
-ID: 72 Len: 8 Enqueue: 6819
+ID: 71 Len: 16 Enqueue: 7722
+ID: 72 Len: 8 Enqueue: 7674
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2277,53 +2471,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 6825
+ID: 88 Len: 8 Enqueue: 7680
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 6723
-ID: 92 Len: 8 Enqueue: 6741
-ID: 93 Len: 8 Enqueue: 6729
-ID: 94 Len: 8 Enqueue: 6849
-ID: 95 Len: 8 Enqueue: 6711
+ID: 91 Len: 8 Enqueue: 7578
+ID: 92 Len: 8 Enqueue: 7596
+ID: 93 Len: 8 Enqueue: 7584
+ID: 94 Len: 8 Enqueue: 7704
+ID: 95 Len: 8 Enqueue: 7566
 ID: 96 Len: 2 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 6717
-ID: 98 Len: 8 Enqueue: 6831
-ID: 99 Len: 8 Enqueue: 6837
-ID: 100 Len: 24 Enqueue: 6959
+ID: 97 Len: 8 Enqueue: 7572
+ID: 98 Len: 8 Enqueue: 7686
+ID: 99 Len: 8 Enqueue: 7692
+ID: 100 Len: 24 Enqueue: 7814
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 6985
-ID: 103 Len: 48 Enqueue: 6883
-ID: 104 Len: 8 Enqueue: 7284
+ID: 102 Len: 24 Enqueue: 7840
+ID: 103 Len: 48 Enqueue: 7738
+ID: 104 Len: 8 Enqueue: 8139
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 7165
-ID: 107 Len: 8 Enqueue: 6687
-ID: 108 Len: 208 Enqueue: 7070
-ID: 109 Len: 8 Enqueue: 6801
+ID: 106 Len: 48 Enqueue: 8020
+ID: 107 Len: 8 Enqueue: 7542
+ID: 108 Len: 208 Enqueue: 7925
+ID: 109 Len: 8 Enqueue: 7656
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 7290
+ID: 111 Len: 8 Enqueue: 8145
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7179
-ID: 114 Len: 8 Enqueue: 6693
-ID: 115 Len: 208 Enqueue: 7091
-ID: 116 Len: 80 Enqueue: 7221
+ID: 113 Len: 48 Enqueue: 8034
+ID: 114 Len: 8 Enqueue: 7548
+ID: 115 Len: 208 Enqueue: 7946
+ID: 116 Len: 80 Enqueue: 8076
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6753
-ID: 119 Len: 72 Enqueue: 7232
-ID: 120 Len: 8 Enqueue: 6663
-ID: 121 Len: 8 Enqueue: 6759
-ID: 122 Len: 8 Enqueue: 7302
+ID: 118 Len: 8 Enqueue: 7608
+ID: 119 Len: 72 Enqueue: 8087
+ID: 120 Len: 8 Enqueue: 7518
+ID: 121 Len: 8 Enqueue: 7614
+ID: 122 Len: 8 Enqueue: 8157
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 7207
-ID: 125 Len: 8 Enqueue: 6705
-ID: 126 Len: 88 Enqueue: 7133
-ID: 127 Len: 8 Enqueue: 7296
+ID: 124 Len: 48 Enqueue: 8062
+ID: 125 Len: 8 Enqueue: 7560
+ID: 126 Len: 88 Enqueue: 7988
+ID: 127 Len: 8 Enqueue: 8151
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7193
-ID: 130 Len: 8 Enqueue: 6699
-ID: 131 Len: 208 Enqueue: 7112
-ID: 132 Len: 8 Enqueue: 6639
-ID: 133 Len: 8 Enqueue: 6645
-ID: 134 Len: 8 Enqueue: 6657
+ID: 129 Len: 48 Enqueue: 8048
+ID: 130 Len: 8 Enqueue: 7554
+ID: 131 Len: 208 Enqueue: 7967
+ID: 132 Len: 8 Enqueue: 7494
+ID: 133 Len: 8 Enqueue: 7500
+ID: 134 Len: 8 Enqueue: 7512
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2332,30 +2526,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 6995
+ID: 143 Len: 16 Enqueue: 7850
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 6969
+ID: 146 Len: 128 Enqueue: 7824
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 6911
-ID: 149 Len: 64 Enqueue: 7027
-ID: 150 Len: 8 Enqueue: 6747
+ID: 148 Len: 208 Enqueue: 7766
+ID: 149 Len: 64 Enqueue: 7882
+ID: 150 Len: 8 Enqueue: 7602
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 6923
+ID: 152 Len: 208 Enqueue: 7778
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7043
-ID: 155 Len: 8 Enqueue: 7278
+ID: 154 Len: 64 Enqueue: 7898
+ID: 155 Len: 8 Enqueue: 8133
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 7151
-ID: 158 Len: 8 Enqueue: 6681
-ID: 159 Len: 144 Enqueue: 7059
-ID: 160 Len: 88 Enqueue: 6947
-ID: 161 Len: 208 Enqueue: 6935
+ID: 157 Len: 48 Enqueue: 8006
+ID: 158 Len: 8 Enqueue: 7536
+ID: 159 Len: 144 Enqueue: 7914
+ID: 160 Len: 88 Enqueue: 7802
+ID: 161 Len: 208 Enqueue: 7790
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 6899
-ID: 166 Len: 8 Enqueue: 6651
+ID: 165 Len: 144 Enqueue: 7754
+ID: 166 Len: 8 Enqueue: 7506
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
@@ -2476,51 +2670,67 @@ ID: 283 Len: 9 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
 ID: 285 Len: 33 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 9 Enqueue: 0
+ID: 287 Len: 17 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 41 Enqueue: 0
+ID: 289 Len: 9 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
+ID: 291 Len: 17 Enqueue: 0
 ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
+ID: 293 Len: 9 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 9 Enqueue: 0
+ID: 295 Len: 41 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 25 Enqueue: 0
+ID: 297 Len: 17 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 89 Enqueue: 0
+ID: 299 Len: 9 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 0 Enqueue: 0
+ID: 301 Len: 17 Enqueue: 0
 ID: 302 Len: 0 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 9 Enqueue: 0
+ID: 305 Len: 25 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 9 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 9 Enqueue: 0
+ID: 309 Len: 25 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 17 Enqueue: 0
+ID: 311 Len: 89 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 25 Enqueue: 0
+ID: 313 Len: 9 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 0 Enqueue: 0
+ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
 ID: 317 Len: 9 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
 ID: 319 Len: 9 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 25 Enqueue: 0
+ID: 321 Len: 9 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 0 Enqueue: 0
+ID: 323 Len: 17 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
-ID: 325 Len: 97 Enqueue: 0
+ID: 325 Len: 17 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 0 Enqueue: 0
+ID: 327 Len: 17 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
-ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 9 Enqueue: 0
+ID: 329 Len: 25 Enqueue: 0
+ID: 330 Len: 0 Enqueue: 0
 ID: 331 Len: 9 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 17 Enqueue: 0
-ID: 334 Len: 9 Enqueue: 0
+ID: 333 Len: 9 Enqueue: 0
+ID: 334 Len: 0 Enqueue: 0
+ID: 335 Len: 9 Enqueue: 0
+ID: 336 Len: 0 Enqueue: 0
+ID: 337 Len: 25 Enqueue: 0
+ID: 338 Len: 0 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 97 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
+ID: 347 Len: 9 Enqueue: 0
+ID: 348 Len: 0 Enqueue: 0
+ID: 349 Len: 17 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a6126]
-	PrepareEventRoot 5d 01 00 00 11 00 00 00 
+	PrepareEventRoot 6d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6170]
-	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	PrepareEventRoot 6e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a71d3]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a78ee]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a79ae]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a73aa]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a746a]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a752a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a752a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a752a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a72ea]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a80c1]
-	PrepareEventRoot 14 01 00 00 19 00 00 00 
+	PrepareEventRoot 18 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0b 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*main.condFields]
+	Call d7 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
-	PrepareEventRoot 09 01 00 00 19 00 00 00 
+	PrepareEventRoot 0d 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
-	PrepareEventRoot 0f 01 00 00 19 00 00 00 
+	PrepareEventRoot 13 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@4a805a]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4a7fea]
-	PrepareEventRoot 11 01 00 00 19 00 00 00 
+	PrepareEventRoot 15 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@4a805a]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
-	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	PrepareEventRoot 05 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
-	PrepareEventRoot 03 01 00 00 11 00 00 00 
+	PrepareEventRoot 07 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*main.condFields]
+	Call d7 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
-	PrepareEventRoot 05 01 00 00 19 00 00 00 
+	PrepareEventRoot 09 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
-	PrepareEventRoot 0b 01 00 00 09 00 00 00 
+	PrepareEventRoot 0f 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
-	PrepareEventRoot 0e 01 00 00 09 00 00 00 
+	PrepareEventRoot 12 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@4a7b2a]
+	PrepareEventRoot f1 00 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@4a7b2a]
+	PrepareEventRoot f3 00 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call d8 22 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@4a7b2a]
-	PrepareEventRoot f1 00 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@4a7b2a]
+	PrepareEventRoot f5 00 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0x4a7b2a]
+// 0xb11: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@4a7b2a]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
-	PrepareEventRoot f3 00 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
+	PrepareEventRoot f7 00 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@4a7b9f]
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f9 00 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+	PrepareEventRoot ff 00 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
+	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 8c 1f 00 00 // ProcessType[main.condFields]
+	Call ab 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	PrepareEventRoot ff 00 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	PrepareEventRoot 03 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@4a76aa]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@4a76aa]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4a771a]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@4a76aa]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4a771a]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4a776a]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@4a776a]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@4a776a]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4a77da]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@4a776a]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@4a776a]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4a77da]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4a782a]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@4a782a]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@4a782a]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4a789a]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@4a782a]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@4a782a]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4a789a]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@4a75ea]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@4a75ea]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@4a75ea]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4a765a]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@4a5eee]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@4a5eee]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@4a70aa]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a70ea]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@4a6d8a]
+// 0x111f: ProcessEvent[Probe[main.inlined]@4a70aa]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@4a70ea]
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@4a6d8a]
 	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4a6dca]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@4a6dca]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
 	PrepareEventRoot b2 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
 	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[3]string]
+	Call 59 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
-	PrepareEventRoot 51 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+	PrepareEventRoot 61 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 8c 1f 00 00 // ProcessType[main.condFields]
+	Call ab 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
-	PrepareEventRoot 55 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+	PrepareEventRoot 65 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
-	PrepareEventRoot 29 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	PrepareEventRoot 37 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 39 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	PrepareEventRoot 2b 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0x4a86ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
-	PrepareEventRoot 2d 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4a86ce]
+	PrepareEventRoot 3d 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@4a86ce]
-	PrepareEventRoot 31 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4a880e]
-	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 43 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 00 1e 00 00 // ProcessType[*string]
+	Call 1f 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4a880e]
-	PrepareEventRoot 35 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 45 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call be 1d 00 00 // ProcessType[*main.lenFields]
+	Call dd 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 49 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 59 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 4d 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 5d 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
-	PrepareEventRoot 4f 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
-	PrepareEventRoot 1f 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 2d 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0x4a8573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
-	PrepareEventRoot 23 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4a8573]
+	PrepareEventRoot 31 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@4a8573]
-	PrepareEventRoot 27 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 35 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 19 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 1b 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 1d 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0x4a8413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 21 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@4a8413]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 23 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4a8413]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0x4a8413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@4a8413]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 25 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@4a8413]
-	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 27 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@4a8413]
-	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 29 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4a8505]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 97 1f 00 00 // ProcessType[main.lenFields]
+	Call b6 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 37 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 47 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 39 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 3b 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 4d 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	PrepareEventRoot 41 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
-	PrepareEventRoot 43 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 53 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
-	PrepareEventRoot 45 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 55 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,437 +1812,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4a8933]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
-	PrepareEventRoot 47 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 57 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@4a716a]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@4a716a]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4a719f]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@4a719f]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@4a728a]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@4a728a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[3]string]
+	Call 59 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]string]
+	Call bf 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dd 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call fc 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f8f: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*bucket<string,int>]
+// 0x1f95: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1f9b: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1fa1: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1fa7: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*error]
+// 0x1fad: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*float32]
+// 0x1fb3: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*float64]
+// 0x1fb9: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*int]
+// 0x1fbf: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*int32]
+// 0x1fc5: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*int64]
+// 0x1fcb: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*main.bigStruct]
+// 0x1fd1: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*main.condFields]
+// 0x1fd7: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*main.lenFields]
+// 0x1fdd: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime._defer]
+// 0x1fe3: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime._panic]
+// 0x1fe9: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.cgoCallers]
+// 0x1fef: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.coro]
+// 0x1ff5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.g]
+// 0x1ffb: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.m]
+// 0x2001: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*runtime.mapextra]
+// 0x2007: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*runtime.sudog]
+// 0x200d: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*runtime.timer]
+// 0x2013: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*runtime.traceBuf]
+// 0x2019: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*string]
+// 0x201f: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint]
+// 0x2025: ProcessType[*uint]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint16]
+// 0x202b: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint32]
+// 0x2031: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint64]
+// 0x2037: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint8]
+// 0x203d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uintptr]
+// 0x2043: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
+// 0x2049: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call fa 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 19 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e3a: ProcessType[[3]string]
+// 0x2059: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e4a: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x2069: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ea 1e 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 09 21 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e56: ProcessType[[]bucket<string,int>.array]
+// 0x2075: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f5 1e 00 00 // ProcessType[bucket<string,int>]
+	Call 14 21 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e62: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x2081: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 0a 1f 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 29 21 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e6e: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x208d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 1f 1f 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3e 21 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7a: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x2099: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 34 1f 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 53 21 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e86: ProcessType[[]int]
+// 0x20a5: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1e90: ProcessType[[]key<string>]
+// 0x20af: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]string]
+// 0x20bf: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1eaa: ProcessType[[]string.array]
+// 0x20c9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]uint8]
+// 0x20d5: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1ec0: ProcessType[[]uintptr]
+// 0x20df: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1eca: ProcessType[[]val<main.bigStruct>]
+// 0x20e9: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eda: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x20f9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call c5 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call e4 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eea: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x2109: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 70 1d 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 1f 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1ef5: ProcessType[bucket<string,int>]
+// 0x2114: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 76 1d 00 00 // ProcessType[*bucket<string,int>]
+	Call 95 1f 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1f0a: ProcessType[bucket<string,main.bigStruct>]
+// 0x2129: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
-	Call ca 1e 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 7c 1d 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
+	Call e9 20 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 9b 1f 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1f1f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x213e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
-	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 82 1d 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
+	Call f9 20 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call a1 1f 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1f34: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2153: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 88 1d 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 20 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call a7 1f 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1f44: ProcessType[error]
+// 0x2163: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1f46: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x2165: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1f54: ProcessType[hash<string,int>]
+// 0x2173: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f62: ProcessType[hash<string,main.bigStruct>]
+// 0x2181: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f70: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x218f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f7e: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x219d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1f8c: ProcessType[main.condFields]
+// 0x21ab: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1f97: ProcessType[main.lenFields]
-	Call b9 20 00 00 // ProcessType[string]
+// 0x21b6: ProcessType[main.lenFields]
+	Call d8 22 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 1e 00 00 // ProcessType[*string]
+	Call 1f 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1fc5: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1fcb: ProcessType[map[string]int]
+// 0x21ea: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1fd1: ProcessType[map[string]main.bigStruct]
+// 0x21f0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1fd7: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21f6: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1fdd: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21fc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1fe3: ProcessType[runtime.g]
+// 0x2202: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime._panic]
+	Call e9 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime._defer]
+	Call e3 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b6 1e 00 00 // ProcessType[[]uint8]
+	Call d5 20 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ee 1d 00 00 // ProcessType[*runtime.sudog]
+	Call 0d 20 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*runtime.timer]
+	Call 13 20 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.coro]
+	Call f5 1f 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x203e: ProcessType[runtime.m]
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+// 0x225d: ProcessType[runtime.m]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ef 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 9e 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call bd 22 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a9 20 00 00 // ProcessType[runtime.mTraceState]
+	Call c8 22 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x209e: ProcessType[runtime.mLockProfile]
+// 0x22bd: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20a9: ProcessType[runtime.mTraceState]
+// 0x22c8: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 49 20 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x20b9: ProcessType[string]
+// 0x22d8: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2388,12 +2511,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7530
-ID: 6 Len: 8 Enqueue: 7710
+ID: 5 Len: 8 Enqueue: 8073
+ID: 6 Len: 8 Enqueue: 8253
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 7716
+ID: 8 Len: 8 Enqueue: 8259
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 8377
+ID: 10 Len: 16 Enqueue: 8920
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -2401,18 +2524,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 8004
+ID: 18 Len: 16 Enqueue: 8547
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 7590
-ID: 21 Len: 8 Enqueue: 7698
-ID: 22 Len: 432 Enqueue: 8163
+ID: 20 Len: 8 Enqueue: 8133
+ID: 21 Len: 8 Enqueue: 8241
+ID: 22 Len: 432 Enqueue: 8706
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7626
+ID: 24 Len: 8 Enqueue: 8169
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7620
+ID: 26 Len: 8 Enqueue: 8163
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7650
-ID: 29 Len: 1760 Enqueue: 8254
+ID: 28 Len: 8 Enqueue: 8193
+ID: 29 Len: 1760 Enqueue: 8797
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2421,41 +2544,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7862
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8405
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7662
+ID: 41 Len: 8 Enqueue: 8205
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7872
-ID: 44 Len: 8 Enqueue: 7668
+ID: 43 Len: 24 Enqueue: 8415
+ID: 44 Len: 8 Enqueue: 8211
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7638
+ID: 47 Len: 8 Enqueue: 8181
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 7644
+ID: 53 Len: 8 Enqueue: 8187
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 7632
+ID: 60 Len: 8 Enqueue: 8175
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 8350
+ID: 64 Len: 64 Enqueue: 8893
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 8361
+ID: 69 Len: 32 Enqueue: 8904
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 7722
-ID: 72 Len: 8 Enqueue: 7674
+ID: 71 Len: 16 Enqueue: 8265
+ID: 72 Len: 8 Enqueue: 8217
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2471,53 +2594,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 7680
+ID: 88 Len: 8 Enqueue: 8223
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 7578
-ID: 92 Len: 8 Enqueue: 7596
-ID: 93 Len: 8 Enqueue: 7584
-ID: 94 Len: 8 Enqueue: 7704
-ID: 95 Len: 8 Enqueue: 7566
+ID: 91 Len: 8 Enqueue: 8121
+ID: 92 Len: 8 Enqueue: 8139
+ID: 93 Len: 8 Enqueue: 8127
+ID: 94 Len: 8 Enqueue: 8247
+ID: 95 Len: 8 Enqueue: 8109
 ID: 96 Len: 2 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 7572
-ID: 98 Len: 8 Enqueue: 7686
-ID: 99 Len: 8 Enqueue: 7692
-ID: 100 Len: 24 Enqueue: 7814
+ID: 97 Len: 8 Enqueue: 8115
+ID: 98 Len: 8 Enqueue: 8229
+ID: 99 Len: 8 Enqueue: 8235
+ID: 100 Len: 24 Enqueue: 8357
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 7840
-ID: 103 Len: 48 Enqueue: 7738
-ID: 104 Len: 8 Enqueue: 8139
+ID: 102 Len: 24 Enqueue: 8383
+ID: 103 Len: 48 Enqueue: 8281
+ID: 104 Len: 8 Enqueue: 8682
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 8020
-ID: 107 Len: 8 Enqueue: 7542
-ID: 108 Len: 208 Enqueue: 7925
-ID: 109 Len: 8 Enqueue: 7656
+ID: 106 Len: 48 Enqueue: 8563
+ID: 107 Len: 8 Enqueue: 8085
+ID: 108 Len: 208 Enqueue: 8468
+ID: 109 Len: 8 Enqueue: 8199
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 8145
+ID: 111 Len: 8 Enqueue: 8688
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 8034
-ID: 114 Len: 8 Enqueue: 7548
-ID: 115 Len: 208 Enqueue: 7946
-ID: 116 Len: 80 Enqueue: 8076
+ID: 113 Len: 48 Enqueue: 8577
+ID: 114 Len: 8 Enqueue: 8091
+ID: 115 Len: 208 Enqueue: 8489
+ID: 116 Len: 80 Enqueue: 8619
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 7608
-ID: 119 Len: 72 Enqueue: 8087
-ID: 120 Len: 8 Enqueue: 7518
-ID: 121 Len: 8 Enqueue: 7614
-ID: 122 Len: 8 Enqueue: 8157
+ID: 118 Len: 8 Enqueue: 8151
+ID: 119 Len: 72 Enqueue: 8630
+ID: 120 Len: 8 Enqueue: 8061
+ID: 121 Len: 8 Enqueue: 8157
+ID: 122 Len: 8 Enqueue: 8700
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 8062
-ID: 125 Len: 8 Enqueue: 7560
-ID: 126 Len: 88 Enqueue: 7988
-ID: 127 Len: 8 Enqueue: 8151
+ID: 124 Len: 48 Enqueue: 8605
+ID: 125 Len: 8 Enqueue: 8103
+ID: 126 Len: 88 Enqueue: 8531
+ID: 127 Len: 8 Enqueue: 8694
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 8048
-ID: 130 Len: 8 Enqueue: 7554
-ID: 131 Len: 208 Enqueue: 7967
-ID: 132 Len: 8 Enqueue: 7494
-ID: 133 Len: 8 Enqueue: 7500
-ID: 134 Len: 8 Enqueue: 7512
+ID: 129 Len: 48 Enqueue: 8591
+ID: 130 Len: 8 Enqueue: 8097
+ID: 131 Len: 208 Enqueue: 8510
+ID: 132 Len: 8 Enqueue: 8037
+ID: 133 Len: 8 Enqueue: 8043
+ID: 134 Len: 8 Enqueue: 8055
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2526,30 +2649,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 7850
+ID: 143 Len: 16 Enqueue: 8393
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 7824
+ID: 146 Len: 128 Enqueue: 8367
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 7766
-ID: 149 Len: 64 Enqueue: 7882
-ID: 150 Len: 8 Enqueue: 7602
+ID: 148 Len: 208 Enqueue: 8309
+ID: 149 Len: 64 Enqueue: 8425
+ID: 150 Len: 8 Enqueue: 8145
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 7778
+ID: 152 Len: 208 Enqueue: 8321
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7898
-ID: 155 Len: 8 Enqueue: 8133
+ID: 154 Len: 64 Enqueue: 8441
+ID: 155 Len: 8 Enqueue: 8676
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 8006
-ID: 158 Len: 8 Enqueue: 7536
-ID: 159 Len: 144 Enqueue: 7914
-ID: 160 Len: 88 Enqueue: 7802
-ID: 161 Len: 208 Enqueue: 7790
+ID: 157 Len: 48 Enqueue: 8549
+ID: 158 Len: 8 Enqueue: 8079
+ID: 159 Len: 144 Enqueue: 8457
+ID: 160 Len: 88 Enqueue: 8345
+ID: 161 Len: 208 Enqueue: 8333
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 7754
-ID: 166 Len: 8 Enqueue: 7506
+ID: 165 Len: 144 Enqueue: 8297
+ID: 166 Len: 8 Enqueue: 8049
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
@@ -2624,13 +2747,13 @@ ID: 237 Len: 17 Enqueue: 0
 ID: 238 Len: 0 Enqueue: 0
 ID: 239 Len: 17 Enqueue: 0
 ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 33 Enqueue: 0
+ID: 241 Len: 2 Enqueue: 0
 ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 33 Enqueue: 0
+ID: 243 Len: 2 Enqueue: 0
 ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 17 Enqueue: 0
+ID: 245 Len: 33 Enqueue: 0
 ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
+ID: 247 Len: 33 Enqueue: 0
 ID: 248 Len: 0 Enqueue: 0
 ID: 249 Len: 17 Enqueue: 0
 ID: 250 Len: 0 Enqueue: 0
@@ -2638,81 +2761,81 @@ ID: 251 Len: 17 Enqueue: 0
 ID: 252 Len: 0 Enqueue: 0
 ID: 253 Len: 17 Enqueue: 0
 ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 97 Enqueue: 0
+ID: 255 Len: 17 Enqueue: 0
 ID: 256 Len: 0 Enqueue: 0
 ID: 257 Len: 17 Enqueue: 0
 ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 17 Enqueue: 0
+ID: 259 Len: 97 Enqueue: 0
 ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 25 Enqueue: 0
+ID: 261 Len: 17 Enqueue: 0
 ID: 262 Len: 0 Enqueue: 0
 ID: 263 Len: 17 Enqueue: 0
 ID: 264 Len: 0 Enqueue: 0
 ID: 265 Len: 25 Enqueue: 0
 ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 9 Enqueue: 0
+ID: 267 Len: 17 Enqueue: 0
 ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
-ID: 270 Len: 9 Enqueue: 0
-ID: 271 Len: 25 Enqueue: 0
+ID: 269 Len: 25 Enqueue: 0
+ID: 270 Len: 0 Enqueue: 0
+ID: 271 Len: 9 Enqueue: 0
 ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 25 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 17 Enqueue: 0
-ID: 276 Len: 25 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
+ID: 273 Len: 17 Enqueue: 0
+ID: 274 Len: 9 Enqueue: 0
+ID: 275 Len: 25 Enqueue: 0
+ID: 276 Len: 0 Enqueue: 0
+ID: 277 Len: 25 Enqueue: 0
 ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 9 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
+ID: 279 Len: 17 Enqueue: 0
+ID: 280 Len: 25 Enqueue: 0
+ID: 281 Len: 2 Enqueue: 0
 ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 9 Enqueue: 0
+ID: 283 Len: 2 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
-ID: 285 Len: 33 Enqueue: 0
+ID: 285 Len: 2 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 17 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 9 Enqueue: 0
+ID: 289 Len: 2 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 17 Enqueue: 0
+ID: 291 Len: 9 Enqueue: 0
 ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 9 Enqueue: 0
+ID: 293 Len: 17 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 41 Enqueue: 0
+ID: 295 Len: 9 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 17 Enqueue: 0
+ID: 297 Len: 33 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 9 Enqueue: 0
+ID: 299 Len: 17 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 17 Enqueue: 0
+ID: 301 Len: 2 Enqueue: 0
 ID: 302 Len: 0 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 25 Enqueue: 0
+ID: 305 Len: 17 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 9 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 25 Enqueue: 0
+ID: 309 Len: 41 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 89 Enqueue: 0
+ID: 311 Len: 17 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 9 Enqueue: 0
+ID: 313 Len: 2 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
 ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 9 Enqueue: 0
+ID: 317 Len: 17 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
 ID: 319 Len: 9 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 9 Enqueue: 0
+ID: 321 Len: 25 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 17 Enqueue: 0
+ID: 323 Len: 9 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
-ID: 325 Len: 17 Enqueue: 0
+ID: 325 Len: 25 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 17 Enqueue: 0
+ID: 327 Len: 89 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
-ID: 329 Len: 25 Enqueue: 0
+ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
 ID: 331 Len: 9 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
@@ -2720,17 +2843,33 @@ ID: 333 Len: 9 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
 ID: 335 Len: 9 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
-ID: 337 Len: 25 Enqueue: 0
+ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
-ID: 339 Len: 0 Enqueue: 0
+ID: 339 Len: 17 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
-ID: 341 Len: 97 Enqueue: 0
+ID: 341 Len: 17 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 0 Enqueue: 0
+ID: 343 Len: 17 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 9 Enqueue: 0
+ID: 345 Len: 25 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
 ID: 347 Len: 9 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 17 Enqueue: 0
-ID: 350 Len: 9 Enqueue: 0
+ID: 349 Len: 9 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0
+ID: 352 Len: 0 Enqueue: 0
+ID: 353 Len: 25 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 97 Enqueue: 0
+ID: 358 Len: 0 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 9 Enqueue: 0
+ID: 363 Len: 9 Enqueue: 0
+ID: 364 Len: 0 Enqueue: 0
+ID: 365 Len: 17 Enqueue: 0
+ID: 366 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -30,27 +30,27 @@
 	PrepareEventRoot 17 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6170.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a6bf3.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a6bf3.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@4a6bf3]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@4a71d3]
 	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6bf3.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a6bf3.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a6c7e]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a725e]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0x4a748a]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@4a748a]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a748a]
+// 0x103: ProcessEvent[Probe[main.condBool]@4a7a6a]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@4a74fa]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@4a7ada]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0x4a748a]
+// 0x121: ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@4a748a]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a748a]
+// 0x159: ProcessEvent[Probe[main.condBool]@4a7a6a]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	PrepareEventRoot e6 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@4a74fa]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@4a7ada]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0x4a748a.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@4a748a]
+// 0x1af: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	PrepareEventRoot e8 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a748a.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a748a.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a74fa]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a7ada]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a730e.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a78ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a730e]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a78ee]
 	PrepareEventRoot e0 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a730e.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a78ee.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a7385]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a7965]
 	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a73ce.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a79ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@4a73ce]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@4a79ae]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a73ce.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a79ae.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a7446]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a7a26]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0x4a6dca]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0x4a73aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@4a6dca]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a6dca]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@4a73aa]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a73aa]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@4a6e3a]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@4a741a]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@4a6dca]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	PrepareEventRoot c2 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a6dca.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a6e3a]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a741a]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a6e8a]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@4a6e8a]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a6e8a]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@4a746a]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	PrepareEventRoot c4 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a6efa]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a74da]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0x4a6e8a]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@4a6e8a]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a6e8a]
+// 0x384: ProcessEvent[Probe[main.condInt32]@4a746a]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	PrepareEventRoot c6 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@4a6efa]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@4a74da]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@4a6e8a]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@4a746a]
 	PrepareEventRoot c8 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a6e8a.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a6efa]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a74da]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a6f4a]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a752a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@4a6f4a]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a6f4a]
+// 0x437: ProcessEvent[Probe[main.condInt64]@4a752a]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a752a]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a6fba]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a759a]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@4a6f4a]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@4a752a]
 	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a6f4a.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a6fba]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a759a]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a6d0a]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a72ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,42 +311,42 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@4a6d0a]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a6d0a]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@4a72ea]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a72ea]
 	PrepareEventRoot bc 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a6d7a]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a735a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@4a6d0a]
+// 0x539: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	PrepareEventRoot be 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a6d0a.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a6d7a]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a735a]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4a7ae7]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -355,36 +355,36 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x596: ProcessEvent[Probe[main.condLine]Line@4a7ae7]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a7ae7]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@4a80c1]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	Return 
-// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a7ae7]
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
-	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[0]]
-	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a7ae7.expr[1]]
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[1]]
 	Return 
-// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0x4a78ae]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -394,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a78ae]
-	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a78ae]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
 	PrepareEventRoot 04 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a792e]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call ab 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a78ae]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	PrepareEventRoot 06 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a78ae.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a792e]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a7a0a]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@4a7a0a]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7a0a]
+// 0x708: ProcessEvent[Probe[main.condOnly]@4a7fea]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	PrepareEventRoot 0c 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@4a7a7a]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@4a805a]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@4a7a0a]
+// 0x763: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	PrepareEventRoot 0e 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7a0a.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@4a7a7a]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@4a805a]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a774e]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -490,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a774e]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a774e]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7865]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a774e]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -515,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a774e]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a774e]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7865]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call ab 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a774e]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	PrepareEventRoot 02 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a774e.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7865]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a796a]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a796a]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a796a]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	PrepareEventRoot 08 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a79d5]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a796a]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a796a.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a79d5.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a79d5]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
 	PrepareEventRoot 0b 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a79d5.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0x958: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@4a754a]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0x99c: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot ea 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@4a75bf]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@4a754a]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0x9f9: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@4a75bf]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0x4a754a.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@4a754a]
+// 0xa5b: ProcessEvent[Probe[main.condString]@4a7b2a]
 	PrepareEventRoot ee 00 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@4a75bf]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0xa79: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0x4a754a.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@4a754a]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a754a]
+// 0xadf: ProcessEvent[Probe[main.condString]@4a7b2a]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	PrepareEventRoot f0 00 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a754a.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@4a75bf]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@4a7b9f]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@4a760e]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a760e]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@4a760e]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@4a760e]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot f8 00 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a760e]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a760e]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a7bee]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
 	Call 79 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@4a760e]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	PrepareEventRoot fc 00 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a760e.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a7716]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a70ca]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@4a70ca]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a70ca]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@4a76aa]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a713a]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@4a70ca]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a70ca.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a713a]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a771a]
 	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a718a]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@4a718a]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a718a]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@4a776a]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	PrepareEventRoot d8 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a71fa]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@4a718a]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@4a776a]
 	PrepareEventRoot da 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a718a.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a71fa]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a77da]
 	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a724a]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@4a724a]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a724a]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@4a782a]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	PrepareEventRoot dc 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a72ba]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@4a724a]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@4a782a]
 	PrepareEventRoot de 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a724a.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a72ba]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a789a]
 	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a700a]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@4a700a]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a700a]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a707a]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a700a]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,39 +1008,39 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@4a700a]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a700a]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@4a75ea]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	PrepareEventRoot d0 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a707a]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@4a700a]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a700a.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a707a]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a765a]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
@@ -1052,53 +1052,53 @@
 	PrepareEventRoot 14 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0x4a6aca.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@4a6aca]
+// 0x1087: ProcessEvent[Probe[main.inlined]@4a70aa]
 	PrepareEventRoot 14 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a6aca.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@4a6b0a]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@4a70ea]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a67aa.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@4a67aa]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@4a6d8a]
 	PrepareEventRoot a5 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a67aa.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a67ea]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a6dca]
 	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a692a.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a692a]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
 	PrepareEventRoot af 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a692a.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a6976]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
 	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6aa0.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
 	Call 27 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a6aa0]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
 	PrepareEventRoot b5 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a6aa0.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a68aa.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
@@ -1106,95 +1106,95 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Call 73 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a68aa]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
 	PrepareEventRoot ad 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a68aa.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a68ef]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
 	PrepareEventRoot ae 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@4a682a]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4a686f]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot a8 00 00 00 00 00 00 00 
 	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@4a682a]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4a686f]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot aa 00 00 00 00 00 00 00 
 	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4a6b8a.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4a6b8a.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@4a6b8a]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@4a716a]
 	PrepareEventRoot b6 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a6b8a.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a6b8a.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4a6bbf]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4a719f]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@4a6caa]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@4a728a]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4a6ce6]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@4a682a]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@4a6e0a]
 	PrepareEventRoot ab 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a682a.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4a686f]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4a6a2a.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
 	Call 27 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4a6a2a]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
 	PrepareEventRoot b3 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a6a2a.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4a6a76]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
 	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4a69aa.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
@@ -1202,25 +1202,25 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Call 8d 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4a69aa]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
 	PrepareEventRoot b1 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a69aa.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4a69ef]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
 	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a7e16]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a7fce.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 9c 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a7fce]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
 	PrepareEventRoot 13 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a7fce.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
 	Return 
 // 0x133f: ProcessType[*****int]
 	ProcessPointer 82 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a6126]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a6126.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a6170]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a6170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a71d3]
-	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a71d3.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a725e]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
-	PrepareEventRoot e4 00 00 00 11 00 00 00 
+	PrepareEventRoot e7 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@4a7ada]
-	PrepareEventRoot e5 00 00 00 00 00 00 00 
+	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0x4a7a6a]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a7a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a7a6a]
-	PrepareEventRoot e6 00 00 00 11 00 00 00 
+	PrepareEventRoot e9 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@4a7ada]
-	PrepareEventRoot e7 00 00 00 00 00 00 00 
+	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a7a6a]
-	PrepareEventRoot e8 00 00 00 12 00 00 00 
+	PrepareEventRoot eb 00 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a7a6a.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a7ada]
-	PrepareEventRoot e9 00 00 00 00 00 00 00 
+	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a78ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a78ee]
-	PrepareEventRoot e0 00 00 00 11 00 00 00 
+	PrepareEventRoot e3 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a78ee.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a7965]
-	PrepareEventRoot e1 00 00 00 00 00 00 00 
+	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a79ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a79ae]
-	PrepareEventRoot e2 00 00 00 11 00 00 00 
+	PrepareEventRoot e5 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a79ae.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a7a26]
-	PrepareEventRoot e3 00 00 00 00 00 00 00 
+	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0x4a73aa]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a73aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a73aa]
-	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	PrepareEventRoot c3 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@4a741a]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a73aa]
-	PrepareEventRoot c2 00 00 00 13 00 00 00 
+	PrepareEventRoot c5 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a73aa.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a741a]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
-	PrepareEventRoot c4 00 00 00 11 00 00 00 
+	PrepareEventRoot c7 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a74da]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0x4a746a]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a746a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a746a]
-	PrepareEventRoot c6 00 00 00 11 00 00 00 
+	PrepareEventRoot c9 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@4a74da]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a746a]
-	PrepareEventRoot c8 00 00 00 15 00 00 00 
+	PrepareEventRoot cb 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a746a.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a74da]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a752a]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a752a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a752a]
-	PrepareEventRoot ca 00 00 00 11 00 00 00 
+	PrepareEventRoot cd 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a759a]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a752a]
-	PrepareEventRoot cc 00 00 00 19 00 00 00 
+	PrepareEventRoot cf 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a752a.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a759a]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a72ea]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a72ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a72ea]
-	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a735a]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a72ea]
-	PrepareEventRoot be 00 00 00 12 00 00 00 
+	PrepareEventRoot c1 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a72ea.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a735a]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4a80c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a80c1]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4a80c1]
-	PrepareEventRoot 11 01 00 00 19 00 00 00 
+	PrepareEventRoot 14 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a80c1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a7e8e]
-	PrepareEventRoot 04 01 00 00 11 00 00 00 
+	PrepareEventRoot 07 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 13 00 00 // ProcessType[*main.condFields]
+	Call 41 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a7e8e]
-	PrepareEventRoot 06 01 00 00 19 00 00 00 
+	PrepareEventRoot 09 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a7e8e.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a7f0e]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a7fea]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@4a7fea]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a7fea]
-	PrepareEventRoot 0c 01 00 00 19 00 00 00 
+	PrepareEventRoot 0f 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@4a805a]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@4a7fea]
-	PrepareEventRoot 0e 01 00 00 19 00 00 00 
+	PrepareEventRoot 11 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a7fea.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@4a805a]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
-	PrepareEventRoot fe 00 00 00 11 00 00 00 
+	PrepareEventRoot 01 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot ff 00 00 00 00 00 00 00 
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a7d2e]
-	PrepareEventRoot 00 01 00 00 11 00 00 00 
+	PrepareEventRoot 03 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot 01 01 00 00 00 00 00 00 
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 13 00 00 // ProcessType[*main.condFields]
+	Call 41 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a7d2e]
-	PrepareEventRoot 02 01 00 00 19 00 00 00 
+	PrepareEventRoot 05 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a7d2e.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a7e45]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a7f4a]
-	PrepareEventRoot 08 01 00 00 09 00 00 00 
+	PrepareEventRoot 0b 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a7f4a]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	PrepareEventRoot 0d 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a7f4a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a7fb5]
-	PrepareEventRoot 0b 01 00 00 09 00 00 00 
+	PrepareEventRoot 0e 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a7fb5.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0x4a7b2a]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
-	PrepareEventRoot ea 00 00 00 11 00 00 00 
+	PrepareEventRoot ed 00 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot eb 00 00 00 00 00 00 00 
+	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
-	PrepareEventRoot ec 00 00 00 11 00 00 00 
+	PrepareEventRoot ef 00 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot ed 00 00 00 00 00 00 00 
+	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@4a7b2a]
-	PrepareEventRoot ee 00 00 00 21 00 00 00 
+	PrepareEventRoot f1 00 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot ef 00 00 00 00 00 00 00 
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0x4a7b2a]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@4a7b2a]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a7b2a]
-	PrepareEventRoot f0 00 00 00 21 00 00 00 
+	PrepareEventRoot f3 00 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a7b2a.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@4a7b9f]
-	PrepareEventRoot f1 00 00 00 00 00 00 00 
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f2 00 00 00 11 00 00 00 
+	PrepareEventRoot f5 00 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f3 00 00 00 00 00 00 00 
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f4 00 00 00 11 00 00 00 
+	PrepareEventRoot f7 00 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f5 00 00 00 00 00 00 00 
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f6 00 00 00 11 00 00 00 
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f7 00 00 00 00 00 00 00 
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot f8 00 00 00 11 00 00 00 
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot f9 00 00 00 00 00 00 00 
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a7bee]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a7bee]
-	PrepareEventRoot fa 00 00 00 11 00 00 00 
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot fb 00 00 00 00 00 00 00 
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 79 15 00 00 // ProcessType[main.condFields]
+	Call 15 1c 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@4a7bee]
-	PrepareEventRoot fc 00 00 00 61 00 00 00 
+	PrepareEventRoot ff 00 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a7bee.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a7cf6]
-	PrepareEventRoot fd 00 00 00 00 00 00 00 
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a76aa]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@4a76aa]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a76aa]
-	PrepareEventRoot d4 00 00 00 11 00 00 00 
+	PrepareEventRoot d7 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a771a]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@4a76aa]
-	PrepareEventRoot d6 00 00 00 13 00 00 00 
+	PrepareEventRoot d9 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a76aa.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a771a]
-	PrepareEventRoot d7 00 00 00 00 00 00 00 
+	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a776a]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@4a776a]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a776a]
-	PrepareEventRoot d8 00 00 00 11 00 00 00 
+	PrepareEventRoot db 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a77da]
-	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@4a776a]
-	PrepareEventRoot da 00 00 00 15 00 00 00 
+	PrepareEventRoot dd 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a776a.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a77da]
-	PrepareEventRoot db 00 00 00 00 00 00 00 
+	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a782a]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@4a782a]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a782a]
-	PrepareEventRoot dc 00 00 00 11 00 00 00 
+	PrepareEventRoot df 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a789a]
-	PrepareEventRoot dd 00 00 00 00 00 00 00 
+	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@4a782a]
-	PrepareEventRoot de 00 00 00 19 00 00 00 
+	PrepareEventRoot e1 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a782a.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a789a]
-	PrepareEventRoot df 00 00 00 00 00 00 00 
+	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
-	PrepareEventRoot ce 00 00 00 11 00 00 00 
+	PrepareEventRoot d1 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a765a]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a75ea]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@4a75ea]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a75ea]
-	PrepareEventRoot d0 00 00 00 11 00 00 00 
+	PrepareEventRoot d3 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a765a]
-	PrepareEventRoot d1 00 00 00 00 00 00 00 
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@4a75ea]
-	PrepareEventRoot d2 00 00 00 12 00 00 00 
+	PrepareEventRoot d5 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a75ea.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a765a]
-	PrepareEventRoot d3 00 00 00 00 00 00 00 
+	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@4a5eee]
-	PrepareEventRoot 14 01 00 00 09 00 00 00 
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a5eee.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@4a70aa]
-	PrepareEventRoot 14 01 00 00 09 00 00 00 
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a70aa.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@4a70ea]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@4a6d8a]
-	PrepareEventRoot a5 00 00 00 09 00 00 00 
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a6d8a.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a6dca]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a6f0a]
-	PrepareEventRoot af 00 00 00 19 00 00 00 
+	PrepareEventRoot b2 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a6f0a.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a6f56]
-	PrepareEventRoot b0 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 27 14 00 00 // ProcessType[[3]string]
+	Call c3 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a7080]
-	PrepareEventRoot b5 00 00 00 31 00 00 00 
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a7080.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
@@ -1104,415 +1104,829 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 73 14 00 00 // ProcessType[[]int]
+	Call 0f 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a6e8a]
-	PrepareEventRoot ad 00 00 00 19 00 00 00 
+	PrepareEventRoot b0 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a6e8a.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a6ecf]
-	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@4a6e0a]
-	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
-	PrepareEventRoot a8 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@4a6e0a]
-	PrepareEventRoot a9 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
-	PrepareEventRoot aa 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 8a 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@4a716a]
-	PrepareEventRoot b6 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4a8cb3.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4a719f]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@4a728a]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call 15 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@4a6e0a]
-	PrepareEventRoot ab 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+	PrepareEventRoot 45 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4a8df3.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4a8cb3]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4a8d9c]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4a8df3]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4a8ef6]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 27 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
-	PrepareEventRoot b3 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
-	PrepareEventRoot b4 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@4a86ce]
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4a86ce.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4a87bc]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 27 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 89 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4a880e]
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4a880e.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4a88e5]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 47 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 39 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4a8b13]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4a8b13.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4a8c5c]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 1f 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 8d 14 00 00 // ProcessType[[]string]
+	Call 0f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
-	PrepareEventRoot b1 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4a8573]
+	PrepareEventRoot 21 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4a8573.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4a8676]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4a8413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0x4a8413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@4a8413]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4a8413]
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 1b 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@4a8413]
+	PrepareEventRoot 1d 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4a8413.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@4a8505]
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call 20 1c 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 2b 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	PrepareEventRoot 35 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4a8933]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4a8933]
+	PrepareEventRoot 37 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4a8933.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4a8ac8]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+	PrepareEventRoot aa 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+	PrepareEventRoot ab 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9c 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
-	PrepareEventRoot 13 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 82 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@4a716a]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a716a.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer a3 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4a719f]
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 83 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@4a728a]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4a72c6]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@4a6e0a]
+	PrepareEventRoot ae 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a6e0a.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4a6e4f]
+	PrepareEventRoot af 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call c3 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4a700a]
+	PrepareEventRoot b6 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a700a.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4a7056]
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 29 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4a6f8a]
+	PrepareEventRoot b4 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a6f8a.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4a6fcf]
+	PrepareEventRoot b5 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a8f36]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 66 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a90ee]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a90ee.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 85 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer a6 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 86 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 5d 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 64 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 9c 00 00 00 
+// 0x19f9: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1369: ProcessType[*bucket<string,int>]
+// 0x19ff: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x136f: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1a05: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1375: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 80 00 00 00 
+// 0x1a0b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 83 00 00 00 
 	Return 
-// 0x137b: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 7b 00 00 00 
-	Return 
-// 0x1381: ProcessType[*error]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x1387: ProcessType[*float32]
-	ProcessPointer 10 00 00 00 
-	Return 
-// 0x138d: ProcessType[*float64]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1393: ProcessType[*int]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x1399: ProcessType[*int32]
-	ProcessPointer 0c 00 00 00 
-	Return 
-// 0x139f: ProcessType[*int64]
-	ProcessPointer 0d 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*main.bigStruct]
-	ProcessPointer 94 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*main.condFields]
-	ProcessPointer 74 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 3d 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*runtime.mapextra]
-	ProcessPointer 6e 00 00 00 
-	Return 
-// 0x13db: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*runtime.traceBuf]
-	ProcessPointer 49 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*string]
-	ProcessPointer 0a 00 00 00 
-	Return 
-// 0x13f3: ProcessType[*uint]
-	ProcessPointer 0f 00 00 00 
-	Return 
-// 0x13f9: ProcessType[*uint16]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x13ff: ProcessType[*uint32]
-	ProcessPointer 02 00 00 00 
-	Return 
-// 0x1405: ProcessType[*uint64]
-	ProcessPointer 0b 00 00 00 
-	Return 
-// 0x140b: ProcessType[*uint8]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x1411: ProcessType[*uintptr]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x1417: ProcessType[[2]*runtime.traceBuf]
-	ProcessArrayDataPrep 10 00 00 00 
-	Call e7 13 00 00 // ProcessType[*runtime.traceBuf]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1427: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x1437: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call d7 14 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1443: ProcessType[[]bucket<string,int>.array]
-	ProcessSliceDataPrep 
-	Call e2 14 00 00 // ProcessType[bucket<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x144f: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call f7 14 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x145b: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call 0c 15 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1467: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call 21 15 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1473: ProcessType[[]int]
-	ProcessSlice 8a 00 00 00 08 00 00 00 
-	Return 
-// 0x147d: ProcessType[[]key<string>]
-	ProcessArrayDataPrep 80 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]string]
-	ProcessSlice 8c 00 00 00 10 00 00 00 
-	Return 
-// 0x1497: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]uint8]
-	ProcessSlice 86 00 00 00 01 00 00 00 
-	Return 
-// 0x14ad: ProcessType[[]uintptr]
-	ProcessSlice 88 00 00 00 08 00 00 00 
-	Return 
-// 0x14b7: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call a5 13 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x14c7: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call 84 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x14d7: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 88 00 00 00 
-	Call 63 13 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x14e2: ProcessType[bucket<string,int>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	IncrementOutputOffset 40 00 00 00 
-	Call 69 13 00 00 // ProcessType[*bucket<string,int>]
-	Return 
-// 0x14f7: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	Call b7 14 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 6f 13 00 00 // ProcessType[*bucket<string,main.bigStruct>]
-	Return 
-// 0x150c: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	Call c7 14 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 75 13 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x1521: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 10 00 00 00 
-	Call c7 14 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 7b 13 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x1531: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x1533: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap a2 00 00 00 90 00 00 00 08 09 10 18 
-	Return 
-// 0x1541: ProcessType[hash<string,int>]
-	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x154f: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 95 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x155d: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 9e 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x156b: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 9d 00 00 00 58 00 00 00 08 09 10 18 
-	Return 
-// 0x1579: ProcessType[main.condFields]
-	IncrementOutputOffset 38 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	Return 
-// 0x1584: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 9a 00 00 00 
-	Return 
-// 0x158a: ProcessType[map[string]int]
-	ProcessPointer 6a 00 00 00 
-	Return 
-// 0x1590: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 71 00 00 00 
-	Return 
-// 0x1596: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1a11: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x159c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 79 00 00 00 
+// 0x1a17: ProcessType[*error]
+	ProcessPointer 12 00 00 00 
 	Return 
-// 0x15a2: ProcessType[runtime.g]
-	IncrementOutputOffset 20 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime._panic]
-	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime._defer]
-	IncrementOutputOffset 08 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
-	IncrementOutputOffset b8 00 00 00 
-	Call a3 14 00 00 // ProcessType[[]uint8]
-	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
-	IncrementOutputOffset 18 00 00 00 
-	Call db 13 00 00 // ProcessType[*runtime.sudog]
-	IncrementOutputOffset 08 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
-	IncrementOutputOffset 20 00 00 00 
-	Call e1 13 00 00 // ProcessType[*runtime.timer]
-	IncrementOutputOffset 18 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.coro]
+// 0x1a1d: ProcessType[*float32]
+	ProcessPointer 10 00 00 00 
 	Return 
-// 0x15fd: ProcessType[runtime.m]
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 50 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 70 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 38 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+// 0x1a23: ProcessType[*float64]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*int]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*int32]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*int64]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*main.bigStruct]
+	ProcessPointer 97 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*main.condFields]
+	ProcessPointer 74 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*main.lenFields]
+	ProcessPointer 77 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 3d 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*runtime.mapextra]
+	ProcessPointer 6e 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*runtime.traceBuf]
+	ProcessPointer 49 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*string]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*uint]
+	ProcessPointer 0f 00 00 00 
+	Return 
+// 0x1a95: ProcessType[*uint16]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x1a9b: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x1aa1: ProcessType[*uint64]
+	ProcessPointer 0b 00 00 00 
+	Return 
+// 0x1aa7: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x1aad: ProcessType[*uintptr]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+	ProcessArrayDataPrep 10 00 00 00 
+	Call 83 1a 00 00 // ProcessType[*runtime.traceBuf]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1ac3: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1ad3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 73 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1adf: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 7e 1b 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1aeb: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 93 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1af7: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call a8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b03: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call bd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b0f: ProcessType[[]int]
+	ProcessSlice 8d 00 00 00 08 00 00 00 
+	Return 
+// 0x1b19: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]string]
+	ProcessSlice 8f 00 00 00 10 00 00 00 
+	Return 
+// 0x1b33: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]uint8]
+	ProcessSlice 89 00 00 00 01 00 00 00 
+	Return 
+// 0x1b49: ProcessType[[]uintptr]
+	ProcessSlice 8b 00 00 00 08 00 00 00 
+	Return 
+// 0x1b53: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 3b 1a 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b63: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 4e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b73: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call f9 19 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1b7e: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ff 19 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x1b93: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 53 1b 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 05 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x1ba8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1bbd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 11 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1bcd: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x1bcf: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
+	Return 
+// 0x1bdd: ProcessType[hash<string,int>]
+	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1beb: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1bf9: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1c07: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x1c15: ProcessType[main.condFields]
+	IncrementOutputOffset 38 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1c20: ProcessType[main.lenFields]
+	Call 42 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0f 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 89 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
+	Return 
+// 0x1c4e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 9d 00 00 00 
+	Return 
+// 0x1c54: ProcessType[map[string]int]
+	ProcessPointer 6a 00 00 00 
+	Return 
+// 0x1c5a: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 71 00 00 00 
+	Return 
+// 0x1c60: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 81 00 00 00 
+	Return 
+// 0x1c66: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7c 00 00 00 
+	Return 
+// 0x1c6c: ProcessType[runtime.g]
+	IncrementOutputOffset 20 00 00 00 
+	Call 53 1a 00 00 // ProcessType[*runtime._panic]
+	IncrementOutputOffset 08 00 00 00 
+	Call 4d 1a 00 00 // ProcessType[*runtime._defer]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	IncrementOutputOffset b8 00 00 00 
+	Call 3f 1b 00 00 // ProcessType[[]uint8]
+	IncrementOutputOffset 40 00 00 00 
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	IncrementOutputOffset 18 00 00 00 
+	Call 77 1a 00 00 // ProcessType[*runtime.sudog]
+	IncrementOutputOffset 08 00 00 00 
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	IncrementOutputOffset 20 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*runtime.timer]
+	IncrementOutputOffset 18 00 00 00 
+	Call 5f 1a 00 00 // ProcessType[*runtime.coro]
+	Return 
+// 0x1cc7: ProcessType[runtime.m]
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 50 00 00 00 
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 70 00 00 00 
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 38 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 40 00 00 00 
+	Call 59 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	IncrementOutputOffset 10 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 5d 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 27 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 68 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 32 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x165d: ProcessType[runtime.mLockProfile]
+// 0x1d27: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1668: ProcessType[runtime.mTraceState]
+// 0x1d32: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1678: ProcessType[string]
-	ProcessString 84 00 00 00 
+// 0x1d42: ProcessType[string]
+	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1780,12 +2194,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 4957
-ID: 6 Len: 8 Enqueue: 5131
+ID: 5 Len: 8 Enqueue: 6643
+ID: 6 Len: 8 Enqueue: 6823
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 5137
+ID: 8 Len: 8 Enqueue: 6829
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 5752
+ID: 10 Len: 16 Enqueue: 7490
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
@@ -1793,18 +2207,18 @@ ID: 14 Len: 1 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 5425
+ID: 18 Len: 16 Enqueue: 7117
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 5017
-ID: 21 Len: 8 Enqueue: 5119
-ID: 22 Len: 432 Enqueue: 5538
+ID: 20 Len: 8 Enqueue: 6703
+ID: 21 Len: 8 Enqueue: 6811
+ID: 22 Len: 432 Enqueue: 7276
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5047
+ID: 24 Len: 8 Enqueue: 6739
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5041
+ID: 26 Len: 8 Enqueue: 6733
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5071
-ID: 29 Len: 1760 Enqueue: 5629
+ID: 28 Len: 8 Enqueue: 6763
+ID: 29 Len: 1760 Enqueue: 7367
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1813,41 +2227,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5283
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 6975
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5083
+ID: 41 Len: 8 Enqueue: 6775
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5293
-ID: 44 Len: 8 Enqueue: 5089
+ID: 43 Len: 24 Enqueue: 6985
+ID: 44 Len: 8 Enqueue: 6781
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5059
+ID: 47 Len: 8 Enqueue: 6751
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 5065
+ID: 53 Len: 8 Enqueue: 6757
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 5053
+ID: 60 Len: 8 Enqueue: 6745
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 5725
+ID: 64 Len: 64 Enqueue: 7463
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 5736
+ID: 69 Len: 32 Enqueue: 7474
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 5143
-ID: 72 Len: 8 Enqueue: 5095
+ID: 71 Len: 16 Enqueue: 6835
+ID: 72 Len: 8 Enqueue: 6787
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -1863,195 +2277,250 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 5101
+ID: 88 Len: 8 Enqueue: 6793
 ID: 89 Len: 8 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
-ID: 91 Len: 8 Enqueue: 5005
-ID: 92 Len: 8 Enqueue: 5023
-ID: 93 Len: 8 Enqueue: 5011
-ID: 94 Len: 8 Enqueue: 5125
-ID: 95 Len: 8 Enqueue: 4993
+ID: 91 Len: 8 Enqueue: 6691
+ID: 92 Len: 8 Enqueue: 6709
+ID: 93 Len: 8 Enqueue: 6697
+ID: 94 Len: 8 Enqueue: 6817
+ID: 95 Len: 8 Enqueue: 6679
 ID: 96 Len: 2 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 4999
-ID: 98 Len: 8 Enqueue: 5107
-ID: 99 Len: 8 Enqueue: 5113
-ID: 100 Len: 24 Enqueue: 5235
+ID: 97 Len: 8 Enqueue: 6685
+ID: 98 Len: 8 Enqueue: 6799
+ID: 99 Len: 8 Enqueue: 6805
+ID: 100 Len: 24 Enqueue: 6927
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 5261
-ID: 103 Len: 48 Enqueue: 5159
-ID: 104 Len: 8 Enqueue: 5514
+ID: 102 Len: 24 Enqueue: 6953
+ID: 103 Len: 48 Enqueue: 6851
+ID: 104 Len: 8 Enqueue: 7252
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 5441
-ID: 107 Len: 8 Enqueue: 4969
-ID: 108 Len: 208 Enqueue: 5346
-ID: 109 Len: 8 Enqueue: 5077
+ID: 106 Len: 48 Enqueue: 7133
+ID: 107 Len: 8 Enqueue: 6655
+ID: 108 Len: 208 Enqueue: 7038
+ID: 109 Len: 8 Enqueue: 6769
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 5520
+ID: 111 Len: 8 Enqueue: 7258
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5455
-ID: 114 Len: 8 Enqueue: 4975
-ID: 115 Len: 208 Enqueue: 5367
-ID: 116 Len: 80 Enqueue: 5497
+ID: 113 Len: 48 Enqueue: 7147
+ID: 114 Len: 8 Enqueue: 6661
+ID: 115 Len: 208 Enqueue: 7059
+ID: 116 Len: 80 Enqueue: 7189
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5035
-ID: 119 Len: 8 Enqueue: 5532
-ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 5483
-ID: 122 Len: 8 Enqueue: 4987
-ID: 123 Len: 88 Enqueue: 5409
-ID: 124 Len: 8 Enqueue: 5526
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5469
-ID: 127 Len: 8 Enqueue: 4981
-ID: 128 Len: 208 Enqueue: 5388
-ID: 129 Len: 8 Enqueue: 4927
-ID: 130 Len: 8 Enqueue: 4933
-ID: 131 Len: 8 Enqueue: 4945
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 1 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 118 Len: 8 Enqueue: 6721
+ID: 119 Len: 72 Enqueue: 7200
+ID: 120 Len: 8 Enqueue: 6631
+ID: 121 Len: 8 Enqueue: 6727
+ID: 122 Len: 8 Enqueue: 7270
+ID: 123 Len: 8 Enqueue: 0
+ID: 124 Len: 48 Enqueue: 7175
+ID: 125 Len: 8 Enqueue: 6673
+ID: 126 Len: 88 Enqueue: 7101
+ID: 127 Len: 8 Enqueue: 7264
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 48 Enqueue: 7161
+ID: 130 Len: 8 Enqueue: 6667
+ID: 131 Len: 208 Enqueue: 7080
+ID: 132 Len: 8 Enqueue: 6607
+ID: 133 Len: 8 Enqueue: 6613
+ID: 134 Len: 8 Enqueue: 6625
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 8 Enqueue: 0
+ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 5271
+ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 128 Enqueue: 5245
-ID: 144 Len: 64 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 5187
-ID: 146 Len: 64 Enqueue: 5303
-ID: 147 Len: 8 Enqueue: 5029
-ID: 148 Len: 184 Enqueue: 0
-ID: 149 Len: 208 Enqueue: 5199
-ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 64 Enqueue: 5319
-ID: 152 Len: 8 Enqueue: 5508
+ID: 143 Len: 16 Enqueue: 6963
+ID: 144 Len: 8 Enqueue: 0
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 128 Enqueue: 6937
+ID: 147 Len: 64 Enqueue: 0
+ID: 148 Len: 208 Enqueue: 6879
+ID: 149 Len: 64 Enqueue: 6995
+ID: 150 Len: 8 Enqueue: 6715
+ID: 151 Len: 184 Enqueue: 0
+ID: 152 Len: 208 Enqueue: 6891
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 48 Enqueue: 5427
-ID: 155 Len: 8 Enqueue: 4963
-ID: 156 Len: 144 Enqueue: 5335
-ID: 157 Len: 88 Enqueue: 5223
-ID: 158 Len: 208 Enqueue: 5211
-ID: 159 Len: 64 Enqueue: 0
-ID: 160 Len: 64 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 144 Enqueue: 5175
-ID: 163 Len: 8 Enqueue: 4939
-ID: 164 Len: 128 Enqueue: 0
-ID: 165 Len: 9 Enqueue: 0
-ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 17 Enqueue: 0
-ID: 168 Len: 0 Enqueue: 0
+ID: 154 Len: 64 Enqueue: 7011
+ID: 155 Len: 8 Enqueue: 7246
+ID: 156 Len: 8 Enqueue: 0
+ID: 157 Len: 48 Enqueue: 7119
+ID: 158 Len: 8 Enqueue: 6649
+ID: 159 Len: 144 Enqueue: 7027
+ID: 160 Len: 88 Enqueue: 6915
+ID: 161 Len: 208 Enqueue: 6903
+ID: 162 Len: 64 Enqueue: 0
+ID: 163 Len: 64 Enqueue: 0
+ID: 164 Len: 8 Enqueue: 0
+ID: 165 Len: 144 Enqueue: 6867
+ID: 166 Len: 8 Enqueue: 6619
+ID: 167 Len: 128 Enqueue: 0
+ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
-ID: 170 Len: 0 Enqueue: 0
-ID: 171 Len: 33 Enqueue: 0
+ID: 170 Len: 17 Enqueue: 0
+ID: 171 Len: 0 Enqueue: 0
 ID: 172 Len: 0 Enqueue: 0
-ID: 173 Len: 25 Enqueue: 0
-ID: 174 Len: 0 Enqueue: 0
-ID: 175 Len: 25 Enqueue: 0
-ID: 176 Len: 0 Enqueue: 0
-ID: 177 Len: 25 Enqueue: 0
-ID: 178 Len: 0 Enqueue: 0
-ID: 179 Len: 49 Enqueue: 0
-ID: 180 Len: 0 Enqueue: 0
-ID: 181 Len: 49 Enqueue: 0
-ID: 182 Len: 17 Enqueue: 0
+ID: 173 Len: 0 Enqueue: 0
+ID: 174 Len: 33 Enqueue: 0
+ID: 175 Len: 0 Enqueue: 0
+ID: 176 Len: 25 Enqueue: 0
+ID: 177 Len: 0 Enqueue: 0
+ID: 178 Len: 25 Enqueue: 0
+ID: 179 Len: 0 Enqueue: 0
+ID: 180 Len: 25 Enqueue: 0
+ID: 181 Len: 0 Enqueue: 0
+ID: 182 Len: 49 Enqueue: 0
 ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 17 Enqueue: 0
-ID: 185 Len: 0 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 17 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 18 Enqueue: 0
-ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 17 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 19 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 17 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 17 Enqueue: 0
-ID: 199 Len: 0 Enqueue: 0
-ID: 200 Len: 21 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 17 Enqueue: 0
-ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 25 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 17 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
-ID: 208 Len: 17 Enqueue: 0
-ID: 209 Len: 0 Enqueue: 0
-ID: 210 Len: 18 Enqueue: 0
-ID: 211 Len: 0 Enqueue: 0
-ID: 212 Len: 17 Enqueue: 0
-ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 19 Enqueue: 0
-ID: 215 Len: 0 Enqueue: 0
-ID: 216 Len: 17 Enqueue: 0
-ID: 217 Len: 0 Enqueue: 0
-ID: 218 Len: 21 Enqueue: 0
-ID: 219 Len: 0 Enqueue: 0
-ID: 220 Len: 17 Enqueue: 0
-ID: 221 Len: 0 Enqueue: 0
-ID: 222 Len: 25 Enqueue: 0
-ID: 223 Len: 0 Enqueue: 0
-ID: 224 Len: 17 Enqueue: 0
-ID: 225 Len: 0 Enqueue: 0
-ID: 226 Len: 17 Enqueue: 0
-ID: 227 Len: 0 Enqueue: 0
-ID: 228 Len: 17 Enqueue: 0
-ID: 229 Len: 0 Enqueue: 0
-ID: 230 Len: 17 Enqueue: 0
-ID: 231 Len: 0 Enqueue: 0
-ID: 232 Len: 18 Enqueue: 0
-ID: 233 Len: 0 Enqueue: 0
-ID: 234 Len: 17 Enqueue: 0
-ID: 235 Len: 0 Enqueue: 0
-ID: 236 Len: 17 Enqueue: 0
-ID: 237 Len: 0 Enqueue: 0
-ID: 238 Len: 33 Enqueue: 0
-ID: 239 Len: 0 Enqueue: 0
-ID: 240 Len: 33 Enqueue: 0
-ID: 241 Len: 0 Enqueue: 0
-ID: 242 Len: 17 Enqueue: 0
-ID: 243 Len: 0 Enqueue: 0
-ID: 244 Len: 17 Enqueue: 0
-ID: 245 Len: 0 Enqueue: 0
-ID: 246 Len: 17 Enqueue: 0
-ID: 247 Len: 0 Enqueue: 0
-ID: 248 Len: 17 Enqueue: 0
-ID: 249 Len: 0 Enqueue: 0
-ID: 250 Len: 17 Enqueue: 0
-ID: 251 Len: 0 Enqueue: 0
-ID: 252 Len: 97 Enqueue: 0
-ID: 253 Len: 0 Enqueue: 0
-ID: 254 Len: 17 Enqueue: 0
-ID: 255 Len: 0 Enqueue: 0
-ID: 256 Len: 17 Enqueue: 0
-ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 25 Enqueue: 0
-ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 17 Enqueue: 0
-ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 25 Enqueue: 0
-ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 9 Enqueue: 0
-ID: 265 Len: 0 Enqueue: 0
-ID: 266 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 18 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 17 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 19 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 17 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 17 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 21 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 17 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 25 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 17 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 17 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 18 Enqueue: 0
+ID: 214 Len: 0 Enqueue: 0
+ID: 215 Len: 17 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 19 Enqueue: 0
+ID: 218 Len: 0 Enqueue: 0
+ID: 219 Len: 17 Enqueue: 0
+ID: 220 Len: 0 Enqueue: 0
+ID: 221 Len: 21 Enqueue: 0
+ID: 222 Len: 0 Enqueue: 0
+ID: 223 Len: 17 Enqueue: 0
+ID: 224 Len: 0 Enqueue: 0
+ID: 225 Len: 25 Enqueue: 0
+ID: 226 Len: 0 Enqueue: 0
+ID: 227 Len: 17 Enqueue: 0
+ID: 228 Len: 0 Enqueue: 0
+ID: 229 Len: 17 Enqueue: 0
+ID: 230 Len: 0 Enqueue: 0
+ID: 231 Len: 17 Enqueue: 0
+ID: 232 Len: 0 Enqueue: 0
+ID: 233 Len: 17 Enqueue: 0
+ID: 234 Len: 0 Enqueue: 0
+ID: 235 Len: 18 Enqueue: 0
+ID: 236 Len: 0 Enqueue: 0
+ID: 237 Len: 17 Enqueue: 0
+ID: 238 Len: 0 Enqueue: 0
+ID: 239 Len: 17 Enqueue: 0
+ID: 240 Len: 0 Enqueue: 0
+ID: 241 Len: 33 Enqueue: 0
+ID: 242 Len: 0 Enqueue: 0
+ID: 243 Len: 33 Enqueue: 0
+ID: 244 Len: 0 Enqueue: 0
+ID: 245 Len: 17 Enqueue: 0
+ID: 246 Len: 0 Enqueue: 0
+ID: 247 Len: 17 Enqueue: 0
+ID: 248 Len: 0 Enqueue: 0
+ID: 249 Len: 17 Enqueue: 0
+ID: 250 Len: 0 Enqueue: 0
+ID: 251 Len: 17 Enqueue: 0
+ID: 252 Len: 0 Enqueue: 0
+ID: 253 Len: 17 Enqueue: 0
+ID: 254 Len: 0 Enqueue: 0
+ID: 255 Len: 97 Enqueue: 0
+ID: 256 Len: 0 Enqueue: 0
+ID: 257 Len: 17 Enqueue: 0
+ID: 258 Len: 0 Enqueue: 0
+ID: 259 Len: 17 Enqueue: 0
+ID: 260 Len: 0 Enqueue: 0
+ID: 261 Len: 25 Enqueue: 0
+ID: 262 Len: 0 Enqueue: 0
+ID: 263 Len: 17 Enqueue: 0
+ID: 264 Len: 0 Enqueue: 0
+ID: 265 Len: 25 Enqueue: 0
+ID: 266 Len: 0 Enqueue: 0
 ID: 267 Len: 9 Enqueue: 0
-ID: 268 Len: 25 Enqueue: 0
-ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 25 Enqueue: 0
-ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
+ID: 268 Len: 0 Enqueue: 0
+ID: 269 Len: 17 Enqueue: 0
+ID: 270 Len: 9 Enqueue: 0
+ID: 271 Len: 25 Enqueue: 0
+ID: 272 Len: 0 Enqueue: 0
 ID: 273 Len: 25 Enqueue: 0
 ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 9 Enqueue: 0
-ID: 276 Len: 9 Enqueue: 0
-ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 17 Enqueue: 0
+ID: 275 Len: 17 Enqueue: 0
+ID: 276 Len: 25 Enqueue: 0
+ID: 277 Len: 17 Enqueue: 0
+ID: 278 Len: 0 Enqueue: 0
 ID: 279 Len: 9 Enqueue: 0
+ID: 280 Len: 0 Enqueue: 0
+ID: 281 Len: 17 Enqueue: 0
+ID: 282 Len: 0 Enqueue: 0
+ID: 283 Len: 9 Enqueue: 0
+ID: 284 Len: 0 Enqueue: 0
+ID: 285 Len: 33 Enqueue: 0
+ID: 286 Len: 0 Enqueue: 0
+ID: 287 Len: 9 Enqueue: 0
+ID: 288 Len: 0 Enqueue: 0
+ID: 289 Len: 41 Enqueue: 0
+ID: 290 Len: 0 Enqueue: 0
+ID: 291 Len: 0 Enqueue: 0
+ID: 292 Len: 0 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 0 Enqueue: 0
+ID: 295 Len: 9 Enqueue: 0
+ID: 296 Len: 0 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 0 Enqueue: 0
+ID: 299 Len: 89 Enqueue: 0
+ID: 300 Len: 0 Enqueue: 0
+ID: 301 Len: 0 Enqueue: 0
+ID: 302 Len: 0 Enqueue: 0
+ID: 303 Len: 9 Enqueue: 0
+ID: 304 Len: 0 Enqueue: 0
+ID: 305 Len: 9 Enqueue: 0
+ID: 306 Len: 0 Enqueue: 0
+ID: 307 Len: 9 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 9 Enqueue: 0
+ID: 310 Len: 0 Enqueue: 0
+ID: 311 Len: 17 Enqueue: 0
+ID: 312 Len: 0 Enqueue: 0
+ID: 313 Len: 25 Enqueue: 0
+ID: 314 Len: 0 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 0 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 9 Enqueue: 0
+ID: 320 Len: 0 Enqueue: 0
+ID: 321 Len: 25 Enqueue: 0
+ID: 322 Len: 0 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 0 Enqueue: 0
+ID: 325 Len: 97 Enqueue: 0
+ID: 326 Len: 0 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
+ID: 331 Len: 9 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8126]
-	PrepareEventRoot 5e 01 00 00 11 00 00 00 
+	PrepareEventRoot 6e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8170]
-	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	PrepareEventRoot 6f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a91d3]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a98ea]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a99aa]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a93aa]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a946a]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a952a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a952a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a952a]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a92ea]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
@@ -377,7 +377,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	PrepareEventRoot 1a 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
@@ -470,7 +470,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
@@ -520,7 +520,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	PrepareEventRoot 16 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@4a9b2a]
 	PrepareEventRoot 02 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b7 1b 00 00 // ProcessType[main.condFields]
+	Call 0e 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	PrepareEventRoot 10 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
@@ -877,7 +877,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@4a976a]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
@@ -921,7 +921,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@4a976a]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@4a982a]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
@@ -965,7 +965,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@4a982a]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@4a7eee]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@4a90aa]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a90ea]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ed 1a 00 00 // ProcessType[[3]string]
+	Call 44 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
+	Call 84 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
-	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	PrepareEventRoot 62 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b7 1b 00 00 // ProcessType[main.condFields]
+	Call 0e 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
-	PrepareEventRoot 56 01 00 00 61 00 00 00 
+	PrepareEventRoot 66 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 3c 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	PrepareEventRoot 3e 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	PrepareEventRoot 36 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 42 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
-	PrepareEventRoot 38 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*string]
+	Call e2 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
-	PrepareEventRoot 3a 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 46 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.lenFields]
+	Call a0 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 4a 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 5a 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	PrepareEventRoot 30 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 05 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	PrepareEventRoot 32 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@4aa413]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 29 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
-	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@4aa413]
-	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 84 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 38 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0x4aa413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4aa413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 2a 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2c 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@4aa413]
+// 0x1898: ProcessEvent[Probe[main.lenString]@4aa413]
 	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call c2 1b 00 00 // ProcessType[main.lenFields]
+	Call 19 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 3c 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 48 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 52 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 54 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 56 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,471 +1689,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
-	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 58 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@4a916a]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@4a916a]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4a919f]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4a919f]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@4a928a]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@4a928a]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ed 1a 00 00 // ProcessType[[3]string]
+	Call 44 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]string]
+	Call b2 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 32 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 89 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*main.bigStruct]
+// 0x1d94: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.condFields]
+// 0x1d9a: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.lenFields]
+// 0x1da0: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*runtime._defer]
+// 0x1da6: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._panic]
+// 0x1dac: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime.cgoCallers]
+// 0x1db2: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.coro]
+// 0x1db8: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.g]
+// 0x1dbe: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.m]
+// 0x1dc4: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.sudog]
+// 0x1dca: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.synctestGroup]
+// 0x1dd0: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.timer]
+// 0x1dd6: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.traceBuf]
+// 0x1ddc: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*string]
+// 0x1de2: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1de8: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*table<string,int>]
+// 0x1dee: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*table<string,main.bigStruct>]
+// 0x1df4: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1dfa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*uint]
+// 0x1e00: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint16]
+// 0x1e06: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint32]
+// 0x1e0c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint64]
+// 0x1e12: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint8]
+// 0x1e18: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uintptr]
+// 0x1e1e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1acd: ProcessType[[2]*runtime.traceBuf]
+// 0x1e24: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call dc 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1add: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e34: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 24 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1aed: ProcessType[[3]string]
+// 0x1e44: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1afd: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e54: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 91 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e8 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b09: ProcessType[[]*table<string,int>.array]
+// 0x1e60: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 97 1a 00 00 // ProcessType[*table<string,int>]
+	Call ee 1d 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b15: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e6c: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 9d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f4 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b21: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e78: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fa 1d 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b2d: ProcessType[[]int]
+// 0x1e84: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b37: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1e8e: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 68 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call bf 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b43: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1e9a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 73 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call ca 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ea6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 7e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call d5 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b5b: ProcessType[[]string]
+// 0x1eb2: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1b65: ProcessType[[]string.array]
+// 0x1ebc: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b71: ProcessType[[]uint8]
+// 0x1ec8: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1b7b: ProcessType[[]uintptr]
+// 0x1ed2: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1b85: ProcessType[error]
+// 0x1edc: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b87: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1ede: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b93: ProcessType[groupReference<string,int>]
+// 0x1eea: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b9f: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1ef6: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bab: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f02: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bb7: ProcessType[main.condFields]
+// 0x1f0e: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1bc2: ProcessType[main.lenFields]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1f19: ProcessType[main.lenFields]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
+	Call 84 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*string]
+	Call e2 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bf0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f47: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1bfc: ProcessType[map<string,int>]
+// 0x1f53: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1c08: ProcessType[map<string,main.bigStruct>]
+// 0x1f5f: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1c14: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f6b: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c20: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f77: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1c26: ProcessType[map[string]int]
+// 0x1f7d: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1c2c: ProcessType[map[string]main.bigStruct]
+// 0x1f83: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1c32: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f89: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1c38: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1f8f: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 89 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call e0 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c48: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1f9f: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 99 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call f0 1f 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c58: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1faf: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 9f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call f6 1f 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c68: ProcessType[noalg.map.group[string]int]
+// 0x1fbf: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 9f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c73: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1fca: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 8f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c7e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fd5: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 58 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call af 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c89: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1fe0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c99: ProcessType[noalg.struct { key string; elem int }]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1ff0: ProcessType[noalg.struct { key string; elem int }]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1c9f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1ff6: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 77 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1caa: ProcessType[runtime.g]
+// 0x2001: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._panic]
+	Call ac 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
+	Call a6 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 71 1b 00 00 // ProcessType[[]uint8]
+	Call c8 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.sudog]
+	Call ca 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.timer]
+	Call d6 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.coro]
+	Call b8 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.synctestGroup]
+	Call d0 1d 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1d0f: ProcessType[runtime.m]
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+// 0x2066: ProcessType[runtime.m]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 6f 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call c6 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7a 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call d1 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d6f: ProcessType[runtime.mLockProfile]
+// 0x20c6: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d7a: ProcessType[runtime.mTraceState]
+// 0x20d1: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call dd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call 34 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d8a: ProcessType[string]
+// 0x20e1: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x1d90: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x20e7: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call de 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1d9b: ProcessType[table<string,int>]
+// 0x20f2: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 93 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call ea 1e 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1da6: ProcessType[table<string,main.bigStruct>]
+// 0x20fd: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f6 1e 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1db1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2108: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ab 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 02 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2227,31 +2421,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6849
+ID: 5 Len: 8 Enqueue: 7704
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7562
+ID: 9 Len: 16 Enqueue: 8417
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6675
+ID: 11 Len: 8 Enqueue: 7530
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7045
+ID: 13 Len: 16 Enqueue: 7900
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6855
-ID: 20 Len: 8 Enqueue: 6705
-ID: 21 Len: 8 Enqueue: 6837
-ID: 22 Len: 440 Enqueue: 7338
+ID: 19 Len: 8 Enqueue: 7710
+ID: 20 Len: 8 Enqueue: 7560
+ID: 21 Len: 8 Enqueue: 7692
+ID: 22 Len: 440 Enqueue: 8193
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6741
+ID: 24 Len: 8 Enqueue: 7596
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6735
+ID: 26 Len: 8 Enqueue: 7590
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6765
-ID: 29 Len: 1808 Enqueue: 7439
+ID: 28 Len: 8 Enqueue: 7620
+ID: 29 Len: 1808 Enqueue: 8294
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2260,45 +2454,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7025
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7880
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6771
+ID: 41 Len: 8 Enqueue: 7626
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7035
-ID: 44 Len: 8 Enqueue: 6783
+ID: 43 Len: 24 Enqueue: 7890
+ID: 44 Len: 8 Enqueue: 7638
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6753
+ID: 47 Len: 8 Enqueue: 7608
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6777
+ID: 49 Len: 8 Enqueue: 7632
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6759
+ID: 55 Len: 8 Enqueue: 7614
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 6747
+ID: 62 Len: 8 Enqueue: 7602
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 7535
+ID: 67 Len: 64 Enqueue: 8390
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 7546
+ID: 72 Len: 56 Enqueue: 8401
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 6877
-ID: 75 Len: 16 Enqueue: 6861
-ID: 76 Len: 8 Enqueue: 6789
+ID: 74 Len: 32 Enqueue: 7732
+ID: 75 Len: 16 Enqueue: 7716
+ID: 76 Len: 8 Enqueue: 7644
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2315,46 +2509,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 6795
+ID: 93 Len: 8 Enqueue: 7650
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 6693
-ID: 97 Len: 8 Enqueue: 6711
-ID: 98 Len: 8 Enqueue: 6699
-ID: 99 Len: 8 Enqueue: 6843
-ID: 100 Len: 8 Enqueue: 6681
+ID: 96 Len: 8 Enqueue: 7548
+ID: 97 Len: 8 Enqueue: 7566
+ID: 98 Len: 8 Enqueue: 7554
+ID: 99 Len: 8 Enqueue: 7698
+ID: 100 Len: 8 Enqueue: 7536
 ID: 101 Len: 2 Enqueue: 0
-ID: 102 Len: 8 Enqueue: 6687
-ID: 103 Len: 8 Enqueue: 6825
-ID: 104 Len: 8 Enqueue: 6831
-ID: 105 Len: 24 Enqueue: 6957
+ID: 102 Len: 8 Enqueue: 7542
+ID: 103 Len: 8 Enqueue: 7680
+ID: 104 Len: 8 Enqueue: 7686
+ID: 105 Len: 24 Enqueue: 7812
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 7003
-ID: 108 Len: 48 Enqueue: 6893
-ID: 109 Len: 8 Enqueue: 7206
+ID: 107 Len: 24 Enqueue: 7858
+ID: 108 Len: 48 Enqueue: 7748
+ID: 109 Len: 8 Enqueue: 8061
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 7164
+ID: 111 Len: 48 Enqueue: 8019
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 6807
-ID: 114 Len: 8 Enqueue: 7212
+ID: 113 Len: 8 Enqueue: 7662
+ID: 114 Len: 8 Enqueue: 8067
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 7176
+ID: 116 Len: 48 Enqueue: 8031
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6813
-ID: 119 Len: 80 Enqueue: 7095
+ID: 118 Len: 8 Enqueue: 7668
+ID: 119 Len: 80 Enqueue: 7950
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 6723
-ID: 122 Len: 72 Enqueue: 7106
-ID: 123 Len: 8 Enqueue: 6663
-ID: 124 Len: 8 Enqueue: 6729
-ID: 125 Len: 8 Enqueue: 7218
+ID: 121 Len: 8 Enqueue: 7578
+ID: 122 Len: 72 Enqueue: 7961
+ID: 123 Len: 8 Enqueue: 7518
+ID: 124 Len: 8 Enqueue: 7584
+ID: 125 Len: 8 Enqueue: 8073
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 7188
+ID: 127 Len: 48 Enqueue: 8043
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 6819
-ID: 130 Len: 8 Enqueue: 6639
-ID: 131 Len: 8 Enqueue: 6645
-ID: 132 Len: 8 Enqueue: 6657
+ID: 129 Len: 8 Enqueue: 7674
+ID: 130 Len: 8 Enqueue: 7494
+ID: 131 Len: 8 Enqueue: 7500
+ID: 132 Len: 8 Enqueue: 7512
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2363,49 +2557,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 7013
+ID: 141 Len: 16 Enqueue: 7868
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 7579
-ID: 144 Len: 16 Enqueue: 7059
+ID: 143 Len: 32 Enqueue: 8434
+ID: 144 Len: 16 Enqueue: 7914
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 7272
-ID: 147 Len: 192 Enqueue: 7240
-ID: 148 Len: 24 Enqueue: 7321
-ID: 149 Len: 8 Enqueue: 6921
-ID: 150 Len: 200 Enqueue: 6967
-ID: 151 Len: 32 Enqueue: 7590
-ID: 152 Len: 16 Enqueue: 7071
+ID: 146 Len: 200 Enqueue: 8127
+ID: 147 Len: 192 Enqueue: 8095
+ID: 148 Len: 24 Enqueue: 8176
+ID: 149 Len: 8 Enqueue: 7776
+ID: 150 Len: 200 Enqueue: 7822
+ID: 151 Len: 32 Enqueue: 8445
+ID: 152 Len: 16 Enqueue: 7926
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 7283
-ID: 155 Len: 192 Enqueue: 7224
-ID: 156 Len: 24 Enqueue: 7305
-ID: 157 Len: 8 Enqueue: 6717
+ID: 154 Len: 200 Enqueue: 8138
+ID: 155 Len: 192 Enqueue: 8079
+ID: 156 Len: 24 Enqueue: 8160
+ID: 157 Len: 8 Enqueue: 7572
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 6933
-ID: 160 Len: 200 Enqueue: 6979
-ID: 161 Len: 32 Enqueue: 7601
-ID: 162 Len: 16 Enqueue: 7083
+ID: 159 Len: 8 Enqueue: 7788
+ID: 160 Len: 200 Enqueue: 7834
+ID: 161 Len: 32 Enqueue: 8456
+ID: 162 Len: 16 Enqueue: 7938
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 7294
-ID: 165 Len: 128 Enqueue: 7256
-ID: 166 Len: 16 Enqueue: 7327
-ID: 167 Len: 8 Enqueue: 7200
+ID: 164 Len: 136 Enqueue: 8149
+ID: 165 Len: 128 Enqueue: 8111
+ID: 166 Len: 16 Enqueue: 8182
+ID: 167 Len: 8 Enqueue: 8055
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 7152
+ID: 169 Len: 48 Enqueue: 8007
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 6801
-ID: 172 Len: 8 Enqueue: 6945
-ID: 173 Len: 136 Enqueue: 6991
-ID: 174 Len: 32 Enqueue: 7568
-ID: 175 Len: 16 Enqueue: 7047
+ID: 171 Len: 8 Enqueue: 7656
+ID: 172 Len: 8 Enqueue: 7800
+ID: 173 Len: 136 Enqueue: 7846
+ID: 174 Len: 32 Enqueue: 8423
+ID: 175 Len: 16 Enqueue: 7902
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6909
+ID: 181 Len: 8 Enqueue: 7764
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 6651
+ID: 183 Len: 8 Enqueue: 7506
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
@@ -2526,51 +2720,67 @@ ID: 300 Len: 9 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
 ID: 302 Len: 33 Enqueue: 0
 ID: 303 Len: 0 Enqueue: 0
-ID: 304 Len: 9 Enqueue: 0
+ID: 304 Len: 17 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 41 Enqueue: 0
+ID: 306 Len: 9 Enqueue: 0
 ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 0 Enqueue: 0
+ID: 308 Len: 17 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 25 Enqueue: 0
+ID: 310 Len: 9 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 9 Enqueue: 0
+ID: 312 Len: 41 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 25 Enqueue: 0
+ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 89 Enqueue: 0
+ID: 316 Len: 9 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 0 Enqueue: 0
+ID: 318 Len: 17 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
 ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 9 Enqueue: 0
+ID: 322 Len: 25 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
 ID: 324 Len: 9 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 9 Enqueue: 0
+ID: 326 Len: 25 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 17 Enqueue: 0
+ID: 328 Len: 89 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 25 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 0 Enqueue: 0
+ID: 332 Len: 9 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
 ID: 336 Len: 9 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 25 Enqueue: 0
+ID: 338 Len: 9 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 0 Enqueue: 0
+ID: 340 Len: 17 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 97 Enqueue: 0
+ID: 342 Len: 17 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 0 Enqueue: 0
+ID: 344 Len: 17 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 9 Enqueue: 0
+ID: 346 Len: 25 Enqueue: 0
+ID: 347 Len: 0 Enqueue: 0
 ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 17 Enqueue: 0
-ID: 351 Len: 9 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 9 Enqueue: 0
+ID: 353 Len: 0 Enqueue: 0
+ID: 354 Len: 25 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 0 Enqueue: 0
+ID: 358 Len: 97 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 0 Enqueue: 0
+ID: 363 Len: 9 Enqueue: 0
+ID: 364 Len: 9 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 17 Enqueue: 0
+ID: 367 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8126]
 	PrepareEventRoot 5e 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8170]
 	PrepareEventRoot 5f 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a91d3]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a98ea]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a99aa]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a93aa]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a946a]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a952a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a952a]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a952a]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a92ea]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
 	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	PrepareEventRoot 1a 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a9fea]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@4a9fea]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@4a9fea]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
 	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@4a9fea]
+// 0x767: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	PrepareEventRoot 16 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	PrepareEventRoot 1c 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
 	PrepareEventRoot 1e 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
 	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0x964: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@4a9b2a]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0x9a8: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@4a9b2a]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0xa05: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@4a9b2a]
+// 0xa67: ProcessEvent[Probe[main.condString]@4a9b2a]
 	PrepareEventRoot 02 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0xa85: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@4a9b2a]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0xaeb: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 06 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 97 1b 00 00 // ProcessType[main.condFields]
+	Call b7 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	PrepareEventRoot 10 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@4a96aa]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@4a96aa]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	PrepareEventRoot e8 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a971a]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@4a96aa]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a971a]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a976a]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@4a976a]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@4a976a]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a97da]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@4a976a]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@4a976a]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a97da]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a982a]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@4a982a]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@4a982a]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	PrepareEventRoot f0 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a989a]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@4a982a]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@4a982a]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a989a]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@4a95ea]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@4a95ea]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@4a95ea]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@4a7eee]
+// 0x106e: ProcessEvent[Probe[main.inlined]@4a7eee]
 	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@4a90aa]
+// 0x1093: ProcessEvent[Probe[main.inlined]@4a90aa]
 	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@4a90ea]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a90ea]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@4a8d8a]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@4a8d8a]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a8dca]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4a8dca]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[3]string]
+	Call ed 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
 	PrepareEventRoot 52 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
 	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 97 1b 00 00 // ProcessType[main.condFields]
+	Call b7 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
 	PrepareEventRoot 56 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
 	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
 	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
 	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
 	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@4aa6ce]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
 	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@4aa6ce]
 	PrepareEventRoot 36 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
 	PrepareEventRoot 38 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*string]
+	Call 8b 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
 	PrepareEventRoot 3a 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Call 49 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
 	PrepareEventRoot 4a 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
 	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
 	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
 	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
 	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@4aa573]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@4aa573]
 	PrepareEventRoot 30 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
 	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4aa573]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4aa573]
 	PrepareEventRoot 32 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
 	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4aa413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x1525: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
 	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@4aa413]
+// 0x1559: ProcessEvent[Probe[main.lenString]@4aa413]
 	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 29 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0x4aa413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
 	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@4aa413]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@4aa413]
 	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@4aa413]
+// 0x1642: ProcessEvent[Probe[main.lenString]@4aa413]
 	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@4aa505]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@4aa505]
 	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call a2 1b 00 00 // ProcessType[main.lenFields]
+	Call c2 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 3c 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4aa933]
 	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,471 +1495,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@4a916a]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@4a916a]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4a919f]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4a919f]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@4a928a]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@4a928a]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[3]string]
+	Call ed 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3b 1b 00 00 // ProcessType[[]string]
+	Call 5b 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
 	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 12 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 32 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
 	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*main.bigStruct]
+// 0x1a3d: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.condFields]
+// 0x1a43: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.lenFields]
+// 0x1a49: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*runtime._defer]
+// 0x1a4f: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._panic]
+// 0x1a55: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime.cgoCallers]
+// 0x1a5b: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.coro]
+// 0x1a61: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.g]
+// 0x1a67: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.m]
+// 0x1a6d: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.sudog]
+// 0x1a73: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.synctestGroup]
+// 0x1a79: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.timer]
+// 0x1a7f: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.traceBuf]
+// 0x1a85: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*string]
+// 0x1a8b: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a91: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*table<string,int>]
+// 0x1a97: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*table<string,main.bigStruct>]
+// 0x1a9d: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1aa3: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*uint]
+// 0x1aa9: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint16]
+// 0x1aaf: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint32]
+// 0x1ab5: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint64]
+// 0x1abb: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint8]
+// 0x1ac1: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uintptr]
+// 0x1ac7: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1aad: ProcessType[[2]*runtime.traceBuf]
+// 0x1acd: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 85 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1abd: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1add: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ad 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call cd 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1acd: ProcessType[[3]string]
+// 0x1aed: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1add: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1afd: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 71 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 91 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae9: ProcessType[[]*table<string,int>.array]
+// 0x1b09: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 77 1a 00 00 // ProcessType[*table<string,int>]
+	Call 97 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af5: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b15: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b01: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b21: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a3 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0d: ProcessType[[]int]
+// 0x1b2d: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b17: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b37: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 48 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 68 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b23: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b43: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 53 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 73 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b2f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b4f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 5e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 7e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b3b: ProcessType[[]string]
+// 0x1b5b: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1b45: ProcessType[[]string.array]
+// 0x1b65: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b51: ProcessType[[]uint8]
+// 0x1b71: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1b5b: ProcessType[[]uintptr]
+// 0x1b7b: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1b65: ProcessType[error]
+// 0x1b85: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b67: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1b87: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b73: ProcessType[groupReference<string,int>]
+// 0x1b93: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b7f: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1b9f: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b8b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bab: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b97: ProcessType[main.condFields]
+// 0x1bb7: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1ba2: ProcessType[main.lenFields]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1bc2: ProcessType[main.lenFields]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*string]
+	Call 8b 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bd0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1bf0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1bdc: ProcessType[map<string,int>]
+// 0x1bfc: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1be8: ProcessType[map<string,main.bigStruct>]
+// 0x1c08: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1bf4: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c14: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c00: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c20: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1c06: ProcessType[map[string]int]
+// 0x1c26: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1c0c: ProcessType[map[string]main.bigStruct]
+// 0x1c2c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1c12: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c32: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1c18: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c38: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 69 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 89 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c28: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c48: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 79 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 99 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c38: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c58: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 7f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c48: ProcessType[noalg.map.group[string]int]
+// 0x1c68: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 48 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c53: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c73: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c5e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c7e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 58 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c69: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1c89: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c79: ProcessType[noalg.struct { key string; elem int }]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1c99: ProcessType[noalg.struct { key string; elem int }]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c7f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c9f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 20 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1c8a: ProcessType[runtime.g]
+// 0x1caa: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._panic]
+	Call 55 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
+	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 51 1b 00 00 // ProcessType[[]uint8]
+	Call 71 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 73 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.timer]
+	Call 7f 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.coro]
+	Call 61 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 79 1a 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1cef: ProcessType[runtime.m]
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d0f: ProcessType[runtime.m]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 4f 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 6f 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 7a 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d4f: ProcessType[runtime.mLockProfile]
+// 0x1d6f: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d5a: ProcessType[runtime.mTraceState]
+// 0x1d7a: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call dd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d6a: ProcessType[string]
+// 0x1d8a: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x1d70: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d90: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 67 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 87 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1d7b: ProcessType[table<string,int>]
+// 0x1d9b: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 73 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 93 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1d86: ProcessType[table<string,main.bigStruct>]
+// 0x1da6: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1d91: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1db1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8b 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2227,31 +2227,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6817
+ID: 5 Len: 8 Enqueue: 6849
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7530
+ID: 9 Len: 16 Enqueue: 7562
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6643
+ID: 11 Len: 8 Enqueue: 6675
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7013
+ID: 13 Len: 16 Enqueue: 7045
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6823
-ID: 20 Len: 8 Enqueue: 6673
-ID: 21 Len: 8 Enqueue: 6805
-ID: 22 Len: 440 Enqueue: 7306
+ID: 19 Len: 8 Enqueue: 6855
+ID: 20 Len: 8 Enqueue: 6705
+ID: 21 Len: 8 Enqueue: 6837
+ID: 22 Len: 440 Enqueue: 7338
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6709
+ID: 24 Len: 8 Enqueue: 6741
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6703
+ID: 26 Len: 8 Enqueue: 6735
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6733
-ID: 29 Len: 1808 Enqueue: 7407
+ID: 28 Len: 8 Enqueue: 6765
+ID: 29 Len: 1808 Enqueue: 7439
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2260,45 +2260,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 6993
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7025
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6739
+ID: 41 Len: 8 Enqueue: 6771
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7003
-ID: 44 Len: 8 Enqueue: 6751
+ID: 43 Len: 24 Enqueue: 7035
+ID: 44 Len: 8 Enqueue: 6783
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6721
+ID: 47 Len: 8 Enqueue: 6753
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6745
+ID: 49 Len: 8 Enqueue: 6777
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6727
+ID: 55 Len: 8 Enqueue: 6759
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 6715
+ID: 62 Len: 8 Enqueue: 6747
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 7503
+ID: 67 Len: 64 Enqueue: 7535
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 7514
+ID: 72 Len: 56 Enqueue: 7546
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 6845
-ID: 75 Len: 16 Enqueue: 6829
-ID: 76 Len: 8 Enqueue: 6757
+ID: 74 Len: 32 Enqueue: 6877
+ID: 75 Len: 16 Enqueue: 6861
+ID: 76 Len: 8 Enqueue: 6789
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2315,46 +2315,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 6763
+ID: 93 Len: 8 Enqueue: 6795
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 6661
-ID: 97 Len: 8 Enqueue: 6679
-ID: 98 Len: 8 Enqueue: 6667
-ID: 99 Len: 8 Enqueue: 6811
-ID: 100 Len: 8 Enqueue: 6649
+ID: 96 Len: 8 Enqueue: 6693
+ID: 97 Len: 8 Enqueue: 6711
+ID: 98 Len: 8 Enqueue: 6699
+ID: 99 Len: 8 Enqueue: 6843
+ID: 100 Len: 8 Enqueue: 6681
 ID: 101 Len: 2 Enqueue: 0
-ID: 102 Len: 8 Enqueue: 6655
-ID: 103 Len: 8 Enqueue: 6793
-ID: 104 Len: 8 Enqueue: 6799
-ID: 105 Len: 24 Enqueue: 6925
+ID: 102 Len: 8 Enqueue: 6687
+ID: 103 Len: 8 Enqueue: 6825
+ID: 104 Len: 8 Enqueue: 6831
+ID: 105 Len: 24 Enqueue: 6957
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 6971
-ID: 108 Len: 48 Enqueue: 6861
-ID: 109 Len: 8 Enqueue: 7174
+ID: 107 Len: 24 Enqueue: 7003
+ID: 108 Len: 48 Enqueue: 6893
+ID: 109 Len: 8 Enqueue: 7206
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 7132
+ID: 111 Len: 48 Enqueue: 7164
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 6775
-ID: 114 Len: 8 Enqueue: 7180
+ID: 113 Len: 8 Enqueue: 6807
+ID: 114 Len: 8 Enqueue: 7212
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 7144
+ID: 116 Len: 48 Enqueue: 7176
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6781
-ID: 119 Len: 80 Enqueue: 7063
+ID: 118 Len: 8 Enqueue: 6813
+ID: 119 Len: 80 Enqueue: 7095
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 6691
-ID: 122 Len: 72 Enqueue: 7074
-ID: 123 Len: 8 Enqueue: 6631
-ID: 124 Len: 8 Enqueue: 6697
-ID: 125 Len: 8 Enqueue: 7186
+ID: 121 Len: 8 Enqueue: 6723
+ID: 122 Len: 72 Enqueue: 7106
+ID: 123 Len: 8 Enqueue: 6663
+ID: 124 Len: 8 Enqueue: 6729
+ID: 125 Len: 8 Enqueue: 7218
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 7156
+ID: 127 Len: 48 Enqueue: 7188
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 6787
-ID: 130 Len: 8 Enqueue: 6607
-ID: 131 Len: 8 Enqueue: 6613
-ID: 132 Len: 8 Enqueue: 6625
+ID: 129 Len: 8 Enqueue: 6819
+ID: 130 Len: 8 Enqueue: 6639
+ID: 131 Len: 8 Enqueue: 6645
+ID: 132 Len: 8 Enqueue: 6657
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2363,49 +2363,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 6981
+ID: 141 Len: 16 Enqueue: 7013
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 7547
-ID: 144 Len: 16 Enqueue: 7027
+ID: 143 Len: 32 Enqueue: 7579
+ID: 144 Len: 16 Enqueue: 7059
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 7240
-ID: 147 Len: 192 Enqueue: 7208
-ID: 148 Len: 24 Enqueue: 7289
-ID: 149 Len: 8 Enqueue: 6889
-ID: 150 Len: 200 Enqueue: 6935
-ID: 151 Len: 32 Enqueue: 7558
-ID: 152 Len: 16 Enqueue: 7039
+ID: 146 Len: 200 Enqueue: 7272
+ID: 147 Len: 192 Enqueue: 7240
+ID: 148 Len: 24 Enqueue: 7321
+ID: 149 Len: 8 Enqueue: 6921
+ID: 150 Len: 200 Enqueue: 6967
+ID: 151 Len: 32 Enqueue: 7590
+ID: 152 Len: 16 Enqueue: 7071
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 7251
-ID: 155 Len: 192 Enqueue: 7192
-ID: 156 Len: 24 Enqueue: 7273
-ID: 157 Len: 8 Enqueue: 6685
+ID: 154 Len: 200 Enqueue: 7283
+ID: 155 Len: 192 Enqueue: 7224
+ID: 156 Len: 24 Enqueue: 7305
+ID: 157 Len: 8 Enqueue: 6717
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 6901
-ID: 160 Len: 200 Enqueue: 6947
-ID: 161 Len: 32 Enqueue: 7569
-ID: 162 Len: 16 Enqueue: 7051
+ID: 159 Len: 8 Enqueue: 6933
+ID: 160 Len: 200 Enqueue: 6979
+ID: 161 Len: 32 Enqueue: 7601
+ID: 162 Len: 16 Enqueue: 7083
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 7262
-ID: 165 Len: 128 Enqueue: 7224
-ID: 166 Len: 16 Enqueue: 7295
-ID: 167 Len: 8 Enqueue: 7168
+ID: 164 Len: 136 Enqueue: 7294
+ID: 165 Len: 128 Enqueue: 7256
+ID: 166 Len: 16 Enqueue: 7327
+ID: 167 Len: 8 Enqueue: 7200
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 7120
+ID: 169 Len: 48 Enqueue: 7152
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 6769
-ID: 172 Len: 8 Enqueue: 6913
-ID: 173 Len: 136 Enqueue: 6959
-ID: 174 Len: 32 Enqueue: 7536
-ID: 175 Len: 16 Enqueue: 7015
+ID: 171 Len: 8 Enqueue: 6801
+ID: 172 Len: 8 Enqueue: 6945
+ID: 173 Len: 136 Enqueue: 6991
+ID: 174 Len: 32 Enqueue: 7568
+ID: 175 Len: 16 Enqueue: 7047
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6877
+ID: 181 Len: 8 Enqueue: 6909
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 6619
+ID: 183 Len: 8 Enqueue: 6651
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8126]
-	PrepareEventRoot 27 01 00 00 11 00 00 00 
+	PrepareEventRoot 5e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8170]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a91d3]
-	PrepareEventRoot c9 00 00 00 11 00 00 00 
+	PrepareEventRoot cc 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a925e]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
-	PrepareEventRoot f5 00 00 00 11 00 00 00 
+	PrepareEventRoot f8 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@4a9ada]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
+	PrepareEventRoot fa 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@4a9ada]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a9a6a]
-	PrepareEventRoot f9 00 00 00 12 00 00 00 
+	PrepareEventRoot fc 00 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a9ada]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a98ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a98ea]
-	PrepareEventRoot f1 00 00 00 11 00 00 00 
+	PrepareEventRoot f4 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a98ea.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a995e]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a99aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a99aa]
-	PrepareEventRoot f3 00 00 00 11 00 00 00 
+	PrepareEventRoot f6 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a99aa.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a9a1f]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0x4a93aa]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a93aa]
-	PrepareEventRoot d1 00 00 00 11 00 00 00 
+	PrepareEventRoot d4 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@4a941a]
-	PrepareEventRoot d2 00 00 00 00 00 00 00 
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a93aa]
-	PrepareEventRoot d3 00 00 00 13 00 00 00 
+	PrepareEventRoot d6 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a941a]
-	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
-	PrepareEventRoot d5 00 00 00 11 00 00 00 
+	PrepareEventRoot d8 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a94da]
-	PrepareEventRoot d6 00 00 00 00 00 00 00 
+	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
-	PrepareEventRoot d7 00 00 00 11 00 00 00 
+	PrepareEventRoot da 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@4a94da]
-	PrepareEventRoot d8 00 00 00 00 00 00 00 
+	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a946a]
-	PrepareEventRoot d9 00 00 00 15 00 00 00 
+	PrepareEventRoot dc 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a94da]
-	PrepareEventRoot da 00 00 00 00 00 00 00 
+	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a952a]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a952a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a952a]
-	PrepareEventRoot db 00 00 00 11 00 00 00 
+	PrepareEventRoot de 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a959a]
-	PrepareEventRoot dc 00 00 00 00 00 00 00 
+	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a952a]
-	PrepareEventRoot dd 00 00 00 19 00 00 00 
+	PrepareEventRoot e0 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a959a]
-	PrepareEventRoot de 00 00 00 00 00 00 00 
+	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a92ea]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a92ea]
-	PrepareEventRoot cd 00 00 00 11 00 00 00 
+	PrepareEventRoot d0 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a935a]
-	PrepareEventRoot ce 00 00 00 00 00 00 00 
+	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a92ea]
-	PrepareEventRoot cf 00 00 00 12 00 00 00 
+	PrepareEventRoot d2 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a935a]
-	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
-	PrepareEventRoot 21 01 00 00 11 00 00 00 
+	PrepareEventRoot 24 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
-	PrepareEventRoot 17 01 00 00 19 00 00 00 
+	PrepareEventRoot 1a 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
-	PrepareEventRoot 1d 01 00 00 19 00 00 00 
+	PrepareEventRoot 20 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@4a9fea]
-	PrepareEventRoot 1f 01 00 00 19 00 00 00 
+	PrepareEventRoot 22 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
-	PrepareEventRoot 13 01 00 00 19 00 00 00 
+	PrepareEventRoot 16 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
-	PrepareEventRoot 19 01 00 00 09 00 00 00 
+	PrepareEventRoot 1c 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
-	PrepareEventRoot 1b 01 00 00 11 00 00 00 
+	PrepareEventRoot 1e 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
-	PrepareEventRoot 1c 01 00 00 09 00 00 00 
+	PrepareEventRoot 1f 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	PrepareEventRoot fe 00 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	PrepareEventRoot 00 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@4a9b2a]
-	PrepareEventRoot ff 00 00 00 21 00 00 00 
+	PrepareEventRoot 02 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
-	PrepareEventRoot 01 01 00 00 21 00 00 00 
+	PrepareEventRoot 04 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 03 01 00 00 11 00 00 00 
+	PrepareEventRoot 06 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 05 01 00 00 11 00 00 00 
+	PrepareEventRoot 08 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 09 01 00 00 11 00 00 00 
+	PrepareEventRoot 0c 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 0b 01 00 00 11 00 00 00 
+	PrepareEventRoot 0e 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call fb 14 00 00 // ProcessType[main.condFields]
+	Call 97 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	PrepareEventRoot 0d 01 00 00 61 00 00 00 
+	PrepareEventRoot 10 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
-	PrepareEventRoot e5 00 00 00 11 00 00 00 
+	PrepareEventRoot e8 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a971a]
-	PrepareEventRoot e6 00 00 00 00 00 00 00 
+	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@4a96aa]
-	PrepareEventRoot e7 00 00 00 13 00 00 00 
+	PrepareEventRoot ea 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a971a]
-	PrepareEventRoot e8 00 00 00 00 00 00 00 
+	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@4a976a]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
-	PrepareEventRoot e9 00 00 00 11 00 00 00 
+	PrepareEventRoot ec 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a97da]
-	PrepareEventRoot ea 00 00 00 00 00 00 00 
+	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@4a976a]
-	PrepareEventRoot eb 00 00 00 15 00 00 00 
+	PrepareEventRoot ee 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a97da]
-	PrepareEventRoot ec 00 00 00 00 00 00 00 
+	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@4a982a]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
-	PrepareEventRoot ed 00 00 00 11 00 00 00 
+	PrepareEventRoot f0 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a989a]
-	PrepareEventRoot ee 00 00 00 00 00 00 00 
+	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@4a982a]
-	PrepareEventRoot ef 00 00 00 19 00 00 00 
+	PrepareEventRoot f2 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a989a]
-	PrepareEventRoot f0 00 00 00 00 00 00 00 
+	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
-	PrepareEventRoot df 00 00 00 11 00 00 00 
+	PrepareEventRoot e2 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a965a]
-	PrepareEventRoot e0 00 00 00 00 00 00 00 
+	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
-	PrepareEventRoot e1 00 00 00 11 00 00 00 
+	PrepareEventRoot e4 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a965a]
-	PrepareEventRoot e2 00 00 00 00 00 00 00 
+	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@4a95ea]
-	PrepareEventRoot e3 00 00 00 12 00 00 00 
+	PrepareEventRoot e6 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a965a]
-	PrepareEventRoot e4 00 00 00 00 00 00 00 
+	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@4a7eee]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@4a90aa]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@4a90ea]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@4a8d8a]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a8dca]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
-	PrepareEventRoot c0 00 00 00 19 00 00 00 
+	PrepareEventRoot c3 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 31 14 00 00 // ProcessType[[3]string]
+	Call cd 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
-	PrepareEventRoot c6 00 00 00 31 00 00 00 
+	PrepareEventRoot c9 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
@@ -1104,448 +1104,862 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 71 14 00 00 // ProcessType[[]int]
+	Call 0d 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
-	PrepareEventRoot be 00 00 00 19 00 00 00 
+	PrepareEventRoot c1 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@4a8e0a]
-	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@4a8e0a]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3c 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@4a916a]
-	PrepareEventRoot c7 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4a919f]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@4a928a]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
-	PrepareEventRoot cc 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call 97 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@4a8e0a]
-	PrepareEventRoot bc 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+	PrepareEventRoot 56 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 31 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
-	PrepareEventRoot c4 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 36 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 38 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 3a 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 4a 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 30 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 14 00 00 // ProcessType[[]string]
+	Call 0d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
-	PrepareEventRoot c2 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 32 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4aa413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0x4aa413]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 2a 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2c 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2e 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call a2 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 3c 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 46 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 48 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
-	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 80 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@4a916a]
+	PrepareEventRoot ca 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer b4 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4a919f]
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 81 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@4a928a]
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+	PrepareEventRoot bf 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call cd 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
+	PrepareEventRoot c7 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 3b 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 12 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 83 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer b7 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 84 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 69 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1387: ProcessType[*main.bigStruct]
-	ProcessPointer 9b 00 00 00 
-	Return 
-// 0x138d: ProcessType[*main.condFields]
-	ProcessPointer 77 00 00 00 
-	Return 
-// 0x1393: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 3f 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.synctestGroup]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.traceBuf]
-	ProcessPointer 4d 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer ab 00 00 00 
-	Return 
-// 0x13db: ProcessType[*table<string,int>]
-	ProcessPointer 8c 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 94 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a1d: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x13ed: ProcessType[*uint]
+// 0x1a23: ProcessType[*main.condFields]
+	ProcessPointer 77 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*main.lenFields]
+	ProcessPointer 7a 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 3f 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.synctestGroup]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.traceBuf]
+	ProcessPointer 4d 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ae 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*table<string,int>]
+	ProcessPointer 8f 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 97 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a1 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x13f3: ProcessType[*uint16]
+// 0x1a8f: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x13f9: ProcessType[*uint32]
+// 0x1a95: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint64]
+// 0x1a9b: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint8]
+// 0x1aa1: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uintptr]
+// 0x1aa7: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1411: ProcessType[[2]*runtime.traceBuf]
+// 0x1aad: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 65 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1421: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1abd: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 11 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call ad 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1431: ProcessType[[3]string]
+// 0x1acd: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1441: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1add: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call d5 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 71 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x144d: ProcessType[[]*table<string,int>.array]
+// 0x1ae9: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call db 13 00 00 // ProcessType[*table<string,int>]
+	Call 77 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1459: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1af5: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e1 13 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 7d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1465: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b01: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 83 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1471: ProcessType[[]int]
-	ProcessSlice 88 00 00 00 08 00 00 00 
+// 0x1b0d: ProcessType[[]int]
+	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x147b: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b17: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 7e 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 48 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1487: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b23: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 89 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 53 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1493: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b2f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 94 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 5e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x149f: ProcessType[[]string]
-	ProcessSlice 8a 00 00 00 10 00 00 00 
+// 0x1b3b: ProcessType[[]string]
+	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x14a9: ProcessType[[]string.array]
+// 0x1b45: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14b5: ProcessType[[]uint8]
-	ProcessSlice 84 00 00 00 01 00 00 00 
+// 0x1b51: ProcessType[[]uint8]
+	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x14bf: ProcessType[[]uintptr]
-	ProcessSlice 86 00 00 00 08 00 00 00 
+// 0x1b5b: ProcessType[[]uintptr]
+	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x14c9: ProcessType[error]
+// 0x1b65: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14cb: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b3 00 00 00 88 00 00 00 00 08 
+// 0x1b67: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14d7: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 93 00 00 00 c8 00 00 00 00 08 
+// 0x1b73: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14e3: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
+// 0x1b7f: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14ef: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups aa 00 00 00 88 00 00 00 00 08 
+// 0x1b8b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14fb: ProcessType[main.condFields]
+// 0x1b97: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1506: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b2 00 00 00 ae 00 00 00 10 18 
+// 0x1ba2: ProcessType[main.lenFields]
+	Call 6a 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0d 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1512: ProcessType[map<string,int>]
-	ProcessGoSwissMap 92 00 00 00 8f 00 00 00 10 18 
+// 0x1bd0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x151e: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 9c 00 00 00 97 00 00 00 10 18 
+// 0x1bdc: ProcessType[map<string,int>]
+	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x152a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap a9 00 00 00 a1 00 00 00 10 18 
+// 0x1be8: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1536: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer a6 00 00 00 
+// 0x1bf4: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x153c: ProcessType[map[string]int]
+// 0x1c00: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a9 00 00 00 
+	Return 
+// 0x1c06: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1542: ProcessType[map[string]main.bigStruct]
+// 0x1c0c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1548: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 7c 00 00 00 
+// 0x1c12: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x154e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c18: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 9f 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 69 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x155e: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c28: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call af 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 79 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x156e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c38: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call b5 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 7f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x157e: ProcessType[noalg.map.group[string]int]
+// 0x1c48: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 28 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1589: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c53: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 18 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1594: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c5e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6e 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x159f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a0 16 00 00 // ProcessType[string]
+// 0x1c69: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 6a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 13 00 00 // ProcessType[*main.bigStruct]
+	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15af: ProcessType[noalg.struct { key string; elem int }]
-	Call a0 16 00 00 // ProcessType[string]
+// 0x1c79: ProcessType[noalg.struct { key string; elem int }]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15b5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c7f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 36 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 00 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15c0: ProcessType[runtime.g]
+// 0x1c8a: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._panic]
+	Call 35 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 13 00 00 // ProcessType[*runtime._defer]
+	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b5 14 00 00 // ProcessType[[]uint8]
+	Call 51 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.sudog]
+	Call 53 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.timer]
+	Call 5f 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.coro]
+	Call 41 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 59 1a 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1625: ProcessType[runtime.m]
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+// 0x1cef: ProcessType[runtime.m]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 85 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 4f 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 5a 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1685: ProcessType[runtime.mLockProfile]
+// 0x1d4f: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1690: ProcessType[runtime.mTraceState]
+// 0x1d5a: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 21 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call bd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16a0: ProcessType[string]
-	ProcessString 82 00 00 00 
+// 0x1d6a: ProcessType[string]
+	ProcessString 85 00 00 00 
 	Return 
-// 0x16a6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d70: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call cb 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 67 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16b1: ProcessType[table<string,int>]
+// 0x1d7b: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d7 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 73 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16bc: ProcessType[table<string,main.bigStruct>]
+// 0x1d86: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e3 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 7f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16c7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d91: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ef 14 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1813,31 +2227,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5125
+ID: 5 Len: 8 Enqueue: 6817
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5792
+ID: 9 Len: 16 Enqueue: 7530
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4957
+ID: 11 Len: 8 Enqueue: 6643
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 5321
+ID: 13 Len: 16 Enqueue: 7013
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5131
-ID: 20 Len: 8 Enqueue: 4987
-ID: 21 Len: 8 Enqueue: 5113
-ID: 22 Len: 440 Enqueue: 5568
+ID: 19 Len: 8 Enqueue: 6823
+ID: 20 Len: 8 Enqueue: 6673
+ID: 21 Len: 8 Enqueue: 6805
+ID: 22 Len: 440 Enqueue: 7306
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5017
+ID: 24 Len: 8 Enqueue: 6709
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5011
+ID: 26 Len: 8 Enqueue: 6703
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5041
-ID: 29 Len: 1808 Enqueue: 5669
+ID: 28 Len: 8 Enqueue: 6733
+ID: 29 Len: 1808 Enqueue: 7407
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1846,45 +2260,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5301
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 6993
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5047
+ID: 41 Len: 8 Enqueue: 6739
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5311
-ID: 44 Len: 8 Enqueue: 5059
+ID: 43 Len: 24 Enqueue: 7003
+ID: 44 Len: 8 Enqueue: 6751
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5029
+ID: 47 Len: 8 Enqueue: 6721
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5053
+ID: 49 Len: 8 Enqueue: 6745
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5035
+ID: 55 Len: 8 Enqueue: 6727
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 5023
+ID: 62 Len: 8 Enqueue: 6715
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 5765
+ID: 67 Len: 64 Enqueue: 7503
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 5776
+ID: 72 Len: 56 Enqueue: 7514
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 5153
-ID: 75 Len: 16 Enqueue: 5137
-ID: 76 Len: 8 Enqueue: 5065
+ID: 74 Len: 32 Enqueue: 6845
+ID: 75 Len: 16 Enqueue: 6829
+ID: 76 Len: 8 Enqueue: 6757
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -1901,207 +2315,262 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 5071
+ID: 93 Len: 8 Enqueue: 6763
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 4975
-ID: 97 Len: 8 Enqueue: 4993
-ID: 98 Len: 8 Enqueue: 4981
-ID: 99 Len: 8 Enqueue: 5119
-ID: 100 Len: 8 Enqueue: 4963
+ID: 96 Len: 8 Enqueue: 6661
+ID: 97 Len: 8 Enqueue: 6679
+ID: 98 Len: 8 Enqueue: 6667
+ID: 99 Len: 8 Enqueue: 6811
+ID: 100 Len: 8 Enqueue: 6649
 ID: 101 Len: 2 Enqueue: 0
-ID: 102 Len: 8 Enqueue: 4969
-ID: 103 Len: 8 Enqueue: 5101
-ID: 104 Len: 8 Enqueue: 5107
-ID: 105 Len: 24 Enqueue: 5233
+ID: 102 Len: 8 Enqueue: 6655
+ID: 103 Len: 8 Enqueue: 6793
+ID: 104 Len: 8 Enqueue: 6799
+ID: 105 Len: 24 Enqueue: 6925
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 5279
-ID: 108 Len: 48 Enqueue: 5169
-ID: 109 Len: 8 Enqueue: 5436
+ID: 107 Len: 24 Enqueue: 6971
+ID: 108 Len: 48 Enqueue: 6861
+ID: 109 Len: 8 Enqueue: 7174
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 5394
+ID: 111 Len: 48 Enqueue: 7132
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 5083
-ID: 114 Len: 8 Enqueue: 5442
+ID: 113 Len: 8 Enqueue: 6775
+ID: 114 Len: 8 Enqueue: 7180
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 5406
+ID: 116 Len: 48 Enqueue: 7144
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5089
-ID: 119 Len: 80 Enqueue: 5371
+ID: 118 Len: 8 Enqueue: 6781
+ID: 119 Len: 80 Enqueue: 7063
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 5005
-ID: 122 Len: 8 Enqueue: 5448
-ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 5418
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 5095
-ID: 127 Len: 8 Enqueue: 4927
-ID: 128 Len: 8 Enqueue: 4933
-ID: 129 Len: 8 Enqueue: 4945
-ID: 130 Len: 1 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 0
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
+ID: 121 Len: 8 Enqueue: 6691
+ID: 122 Len: 72 Enqueue: 7074
+ID: 123 Len: 8 Enqueue: 6631
+ID: 124 Len: 8 Enqueue: 6697
+ID: 125 Len: 8 Enqueue: 7186
+ID: 126 Len: 8 Enqueue: 0
+ID: 127 Len: 48 Enqueue: 7156
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 8 Enqueue: 6787
+ID: 130 Len: 8 Enqueue: 6607
+ID: 131 Len: 8 Enqueue: 6613
+ID: 132 Len: 8 Enqueue: 6625
+ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
-ID: 138 Len: 16 Enqueue: 5289
+ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 32 Enqueue: 5809
-ID: 141 Len: 16 Enqueue: 5335
+ID: 140 Len: 8 Enqueue: 0
+ID: 141 Len: 16 Enqueue: 6981
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 5502
-ID: 144 Len: 192 Enqueue: 5470
-ID: 145 Len: 24 Enqueue: 5551
-ID: 146 Len: 8 Enqueue: 5197
-ID: 147 Len: 200 Enqueue: 5243
-ID: 148 Len: 32 Enqueue: 5820
-ID: 149 Len: 16 Enqueue: 5347
-ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 5513
-ID: 152 Len: 192 Enqueue: 5454
-ID: 153 Len: 24 Enqueue: 5535
-ID: 154 Len: 8 Enqueue: 4999
-ID: 155 Len: 184 Enqueue: 0
-ID: 156 Len: 8 Enqueue: 5209
-ID: 157 Len: 200 Enqueue: 5255
-ID: 158 Len: 32 Enqueue: 5831
-ID: 159 Len: 16 Enqueue: 5359
-ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 136 Enqueue: 5524
-ID: 162 Len: 128 Enqueue: 5486
-ID: 163 Len: 16 Enqueue: 5557
-ID: 164 Len: 8 Enqueue: 5430
-ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 48 Enqueue: 5382
-ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 8 Enqueue: 5077
-ID: 169 Len: 8 Enqueue: 5221
-ID: 170 Len: 136 Enqueue: 5267
-ID: 171 Len: 32 Enqueue: 5798
-ID: 172 Len: 16 Enqueue: 5323
-ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 0
-ID: 175 Len: 128 Enqueue: 0
-ID: 176 Len: 16 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5185
-ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 4939
-ID: 181 Len: 128 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 17 Enqueue: 0
-ID: 185 Len: 0 Enqueue: 0
+ID: 143 Len: 32 Enqueue: 7547
+ID: 144 Len: 16 Enqueue: 7027
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 200 Enqueue: 7240
+ID: 147 Len: 192 Enqueue: 7208
+ID: 148 Len: 24 Enqueue: 7289
+ID: 149 Len: 8 Enqueue: 6889
+ID: 150 Len: 200 Enqueue: 6935
+ID: 151 Len: 32 Enqueue: 7558
+ID: 152 Len: 16 Enqueue: 7039
+ID: 153 Len: 8 Enqueue: 0
+ID: 154 Len: 200 Enqueue: 7251
+ID: 155 Len: 192 Enqueue: 7192
+ID: 156 Len: 24 Enqueue: 7273
+ID: 157 Len: 8 Enqueue: 6685
+ID: 158 Len: 184 Enqueue: 0
+ID: 159 Len: 8 Enqueue: 6901
+ID: 160 Len: 200 Enqueue: 6947
+ID: 161 Len: 32 Enqueue: 7569
+ID: 162 Len: 16 Enqueue: 7051
+ID: 163 Len: 8 Enqueue: 0
+ID: 164 Len: 136 Enqueue: 7262
+ID: 165 Len: 128 Enqueue: 7224
+ID: 166 Len: 16 Enqueue: 7295
+ID: 167 Len: 8 Enqueue: 7168
+ID: 168 Len: 8 Enqueue: 0
+ID: 169 Len: 48 Enqueue: 7120
+ID: 170 Len: 8 Enqueue: 0
+ID: 171 Len: 8 Enqueue: 6769
+ID: 172 Len: 8 Enqueue: 6913
+ID: 173 Len: 136 Enqueue: 6959
+ID: 174 Len: 32 Enqueue: 7536
+ID: 175 Len: 16 Enqueue: 7015
+ID: 176 Len: 8 Enqueue: 0
+ID: 177 Len: 136 Enqueue: 0
+ID: 178 Len: 128 Enqueue: 0
+ID: 179 Len: 16 Enqueue: 0
+ID: 180 Len: 8 Enqueue: 0
+ID: 181 Len: 8 Enqueue: 6877
+ID: 182 Len: 136 Enqueue: 0
+ID: 183 Len: 8 Enqueue: 6619
+ID: 184 Len: 128 Enqueue: 0
+ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 33 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 25 Enqueue: 0
-ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 25 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 25 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 49 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 49 Enqueue: 0
-ID: 199 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 33 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 25 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 25 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 49 Enqueue: 0
 ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 17 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
+ID: 201 Len: 49 Enqueue: 0
+ID: 202 Len: 17 Enqueue: 0
 ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 0 Enqueue: 0
-ID: 205 Len: 17 Enqueue: 0
+ID: 204 Len: 17 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
 ID: 206 Len: 0 Enqueue: 0
-ID: 207 Len: 18 Enqueue: 0
-ID: 208 Len: 0 Enqueue: 0
-ID: 209 Len: 17 Enqueue: 0
-ID: 210 Len: 0 Enqueue: 0
-ID: 211 Len: 19 Enqueue: 0
-ID: 212 Len: 0 Enqueue: 0
-ID: 213 Len: 17 Enqueue: 0
-ID: 214 Len: 0 Enqueue: 0
-ID: 215 Len: 17 Enqueue: 0
-ID: 216 Len: 0 Enqueue: 0
-ID: 217 Len: 21 Enqueue: 0
-ID: 218 Len: 0 Enqueue: 0
-ID: 219 Len: 17 Enqueue: 0
-ID: 220 Len: 0 Enqueue: 0
-ID: 221 Len: 25 Enqueue: 0
-ID: 222 Len: 0 Enqueue: 0
-ID: 223 Len: 17 Enqueue: 0
-ID: 224 Len: 0 Enqueue: 0
-ID: 225 Len: 17 Enqueue: 0
-ID: 226 Len: 0 Enqueue: 0
-ID: 227 Len: 18 Enqueue: 0
-ID: 228 Len: 0 Enqueue: 0
-ID: 229 Len: 17 Enqueue: 0
-ID: 230 Len: 0 Enqueue: 0
-ID: 231 Len: 19 Enqueue: 0
-ID: 232 Len: 0 Enqueue: 0
-ID: 233 Len: 17 Enqueue: 0
-ID: 234 Len: 0 Enqueue: 0
-ID: 235 Len: 21 Enqueue: 0
-ID: 236 Len: 0 Enqueue: 0
-ID: 237 Len: 17 Enqueue: 0
-ID: 238 Len: 0 Enqueue: 0
-ID: 239 Len: 25 Enqueue: 0
-ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 17 Enqueue: 0
-ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 17 Enqueue: 0
-ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 17 Enqueue: 0
-ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
-ID: 248 Len: 0 Enqueue: 0
-ID: 249 Len: 18 Enqueue: 0
-ID: 250 Len: 0 Enqueue: 0
-ID: 251 Len: 17 Enqueue: 0
-ID: 252 Len: 0 Enqueue: 0
-ID: 253 Len: 17 Enqueue: 0
-ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 33 Enqueue: 0
-ID: 256 Len: 0 Enqueue: 0
-ID: 257 Len: 33 Enqueue: 0
-ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 17 Enqueue: 0
-ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 17 Enqueue: 0
-ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 17 Enqueue: 0
-ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 17 Enqueue: 0
-ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 17 Enqueue: 0
-ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 97 Enqueue: 0
-ID: 270 Len: 0 Enqueue: 0
-ID: 271 Len: 17 Enqueue: 0
-ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 17 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 25 Enqueue: 0
-ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
-ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 25 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 9 Enqueue: 0
-ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 17 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 17 Enqueue: 0
+ID: 209 Len: 0 Enqueue: 0
+ID: 210 Len: 18 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 17 Enqueue: 0
+ID: 213 Len: 0 Enqueue: 0
+ID: 214 Len: 19 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
+ID: 216 Len: 17 Enqueue: 0
+ID: 217 Len: 0 Enqueue: 0
+ID: 218 Len: 17 Enqueue: 0
+ID: 219 Len: 0 Enqueue: 0
+ID: 220 Len: 21 Enqueue: 0
+ID: 221 Len: 0 Enqueue: 0
+ID: 222 Len: 17 Enqueue: 0
+ID: 223 Len: 0 Enqueue: 0
+ID: 224 Len: 25 Enqueue: 0
+ID: 225 Len: 0 Enqueue: 0
+ID: 226 Len: 17 Enqueue: 0
+ID: 227 Len: 0 Enqueue: 0
+ID: 228 Len: 17 Enqueue: 0
+ID: 229 Len: 0 Enqueue: 0
+ID: 230 Len: 18 Enqueue: 0
+ID: 231 Len: 0 Enqueue: 0
+ID: 232 Len: 17 Enqueue: 0
+ID: 233 Len: 0 Enqueue: 0
+ID: 234 Len: 19 Enqueue: 0
+ID: 235 Len: 0 Enqueue: 0
+ID: 236 Len: 17 Enqueue: 0
+ID: 237 Len: 0 Enqueue: 0
+ID: 238 Len: 21 Enqueue: 0
+ID: 239 Len: 0 Enqueue: 0
+ID: 240 Len: 17 Enqueue: 0
+ID: 241 Len: 0 Enqueue: 0
+ID: 242 Len: 25 Enqueue: 0
+ID: 243 Len: 0 Enqueue: 0
+ID: 244 Len: 17 Enqueue: 0
+ID: 245 Len: 0 Enqueue: 0
+ID: 246 Len: 17 Enqueue: 0
+ID: 247 Len: 0 Enqueue: 0
+ID: 248 Len: 17 Enqueue: 0
+ID: 249 Len: 0 Enqueue: 0
+ID: 250 Len: 17 Enqueue: 0
+ID: 251 Len: 0 Enqueue: 0
+ID: 252 Len: 18 Enqueue: 0
+ID: 253 Len: 0 Enqueue: 0
+ID: 254 Len: 17 Enqueue: 0
+ID: 255 Len: 0 Enqueue: 0
+ID: 256 Len: 17 Enqueue: 0
+ID: 257 Len: 0 Enqueue: 0
+ID: 258 Len: 33 Enqueue: 0
+ID: 259 Len: 0 Enqueue: 0
+ID: 260 Len: 33 Enqueue: 0
+ID: 261 Len: 0 Enqueue: 0
+ID: 262 Len: 17 Enqueue: 0
+ID: 263 Len: 0 Enqueue: 0
+ID: 264 Len: 17 Enqueue: 0
+ID: 265 Len: 0 Enqueue: 0
+ID: 266 Len: 17 Enqueue: 0
+ID: 267 Len: 0 Enqueue: 0
+ID: 268 Len: 17 Enqueue: 0
+ID: 269 Len: 0 Enqueue: 0
+ID: 270 Len: 17 Enqueue: 0
+ID: 271 Len: 0 Enqueue: 0
+ID: 272 Len: 97 Enqueue: 0
+ID: 273 Len: 0 Enqueue: 0
+ID: 274 Len: 17 Enqueue: 0
+ID: 275 Len: 0 Enqueue: 0
+ID: 276 Len: 17 Enqueue: 0
+ID: 277 Len: 0 Enqueue: 0
+ID: 278 Len: 25 Enqueue: 0
+ID: 279 Len: 0 Enqueue: 0
+ID: 280 Len: 17 Enqueue: 0
+ID: 281 Len: 0 Enqueue: 0
+ID: 282 Len: 25 Enqueue: 0
+ID: 283 Len: 0 Enqueue: 0
 ID: 284 Len: 9 Enqueue: 0
-ID: 285 Len: 25 Enqueue: 0
-ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 25 Enqueue: 0
-ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 17 Enqueue: 0
+ID: 285 Len: 0 Enqueue: 0
+ID: 286 Len: 17 Enqueue: 0
+ID: 287 Len: 9 Enqueue: 0
+ID: 288 Len: 25 Enqueue: 0
+ID: 289 Len: 0 Enqueue: 0
 ID: 290 Len: 25 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 9 Enqueue: 0
-ID: 293 Len: 9 Enqueue: 0
-ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 17 Enqueue: 0
+ID: 292 Len: 17 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 17 Enqueue: 0
+ID: 295 Len: 0 Enqueue: 0
 ID: 296 Len: 9 Enqueue: 0
+ID: 297 Len: 0 Enqueue: 0
+ID: 298 Len: 17 Enqueue: 0
+ID: 299 Len: 0 Enqueue: 0
+ID: 300 Len: 9 Enqueue: 0
+ID: 301 Len: 0 Enqueue: 0
+ID: 302 Len: 33 Enqueue: 0
+ID: 303 Len: 0 Enqueue: 0
+ID: 304 Len: 9 Enqueue: 0
+ID: 305 Len: 0 Enqueue: 0
+ID: 306 Len: 41 Enqueue: 0
+ID: 307 Len: 0 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 0 Enqueue: 0
+ID: 310 Len: 25 Enqueue: 0
+ID: 311 Len: 0 Enqueue: 0
+ID: 312 Len: 9 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 25 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 89 Enqueue: 0
+ID: 317 Len: 0 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 0 Enqueue: 0
+ID: 320 Len: 9 Enqueue: 0
+ID: 321 Len: 0 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 9 Enqueue: 0
+ID: 325 Len: 0 Enqueue: 0
+ID: 326 Len: 9 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 25 Enqueue: 0
+ID: 331 Len: 0 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 0 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0
+ID: 335 Len: 0 Enqueue: 0
+ID: 336 Len: 9 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 25 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 0 Enqueue: 0
+ID: 342 Len: 97 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
+ID: 347 Len: 9 Enqueue: 0
+ID: 348 Len: 9 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 17 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 72 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 72 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8126]
 	PrepareEventRoot 27 01 00 00 11 00 00 00 
@@ -24,33 +24,33 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 84 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8170]
 	PrepareEventRoot 28 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8170.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a8bd3.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 75 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a8bd3.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 75 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@4a8bd3]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@4a91d3]
 	PrepareEventRoot c9 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8bd3.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a8bd3.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a8c5e]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4a925e]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0x4a946a]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@4a946a]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a946a]
+// 0x103: ProcessEvent[Probe[main.condBool]@4a9a6a]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@4a94da]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@4a9ada]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0x4a946a]
+// 0x121: ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@4a946a]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a946a]
+// 0x159: ProcessEvent[Probe[main.condBool]@4a9a6a]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@4a94da]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@4a9ada]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0x4a946a.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@4a946a]
+// 0x1af: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	PrepareEventRoot f9 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a946a.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a946a.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4a9a6a.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a94da]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4a9ada]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a92ea.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4a98ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a92ea]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a98ea]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a92ea.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4a98ea.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a935e]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4a995e]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a93aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4a99aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@4a93aa]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@4a99aa]
 	PrepareEventRoot f3 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a93aa.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4a99aa.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a941f]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4a9a1f]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0x4a8daa]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0x4a93aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@4a8daa]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a8daa]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@4a93aa]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a93aa]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@4a8e1a]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@4a941a]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@4a8daa]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	PrepareEventRoot d3 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a8daa.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4a93aa.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a8e1a]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4a941a]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a8e6a]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@4a8e6a]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a8e6a]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@4a946a]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	PrepareEventRoot d5 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a8eda]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4a94da]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0x4a8e6a]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@4a8e6a]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a8e6a]
+// 0x384: ProcessEvent[Probe[main.condInt32]@4a946a]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@4a8eda]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@4a94da]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@4a8e6a]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@4a946a]
 	PrepareEventRoot d9 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a8e6a.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4a946a.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a8eda]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4a94da]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a8f2a]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4a952a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@4a8f2a]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a8f2a]
+// 0x437: ProcessEvent[Probe[main.condInt64]@4a952a]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a952a]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a8f9a]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4a959a]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@4a8f2a]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@4a952a]
 	PrepareEventRoot dd 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a8f2a.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4a952a.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a8f9a]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4a959a]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a8cea]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4a92ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,42 +311,42 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@4a8cea]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a8cea]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@4a92ea]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a92ea]
 	PrepareEventRoot cd 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a8d5a]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4a935a]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@4a8cea]
+// 0x539: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	PrepareEventRoot cf 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a8cea.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4a92ea.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a8d5a]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4a935a]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4a9ac7]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -355,42 +355,36 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x5a2: ProcessEvent[Probe[main.condLine]Line@4a9ac7]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4a9ac7]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
 	PrepareEventRoot 21 01 00 00 11 00 00 00 
-	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	Return 
-// 0x5b6: ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[1]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferenceCfa 10 00 00 00 08 00 00 00 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x5fa: ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
+	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[1]]
 	Return 
-// 0x610: ProcessEvent[Probe[main.condLine]Line@4a9ac7]
-	PrepareEventRoot 22 01 00 00 21 00 00 00 
-	Call b6 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[1]]
-	Call fa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4a9ac7.expr[2]]
-	Return 
-// 0x629: ProcessCondition[Probe[main.condNilPtrStruct]@0x4a988e]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x64b: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x66d: ProcessEvent[Probe[main.condNilPtrStruct]@4a988e]
-	Call 29 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a988e]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 4b 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Return 
-// 0x681: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a990e]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0x68b: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c0 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x6a6: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x6c8: ProcessEvent[Probe[main.condNilPtrStruct]@4a988e]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	PrepareEventRoot 17 01 00 00 19 00 00 00 
-	Call 8b 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[0]]
-	Call a6 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a988e.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	Return 
-// 0x6dc: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a990e]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessCondition[Probe[main.condOnly]@0x4a99ea]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x703: ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x719: ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x73b: ProcessEvent[Probe[main.condOnly]@4a99ea]
-	Call e6 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a99ea]
+// 0x708: ProcessEvent[Probe[main.condOnly]@4a9fea]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	PrepareEventRoot 1d 01 00 00 19 00 00 00 
-	Call 03 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[0]]
-	Call 19 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
-// 0x754: ProcessEvent[Probe[main.condOnly]Return@4a9a5a]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x75e: ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x774: ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x796: ProcessEvent[Probe[main.condOnly]@4a99ea]
+// 0x763: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
-	Call 5e 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[0]]
-	Call 74 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a99ea.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
-// 0x7aa: ProcessEvent[Probe[main.condOnly]Return@4a9a5a]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x7b4: ProcessCondition[Probe[main.condPtrStructArg]@0x4a972e]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7d6: ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x7f8: ProcessEvent[Probe[main.condPtrStructArg]@4a972e]
-	Call b4 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a972e]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call d6 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
-// 0x80c: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9845]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0x816: ProcessCondition[Probe[main.condPtrStructArg]@0x4a972e]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x83a: ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x85c: ProcessEvent[Probe[main.condPtrStructArg]@4a972e]
-	Call 16 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a972e]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 3a 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
-// 0x870: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9845]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x87a: ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call c0 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x895: ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x8b7: ProcessEvent[Probe[main.condPtrStructArg]@4a972e]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	PrepareEventRoot 13 01 00 00 19 00 00 00 
-	Call 7a 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[0]]
-	Call 95 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a972e.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	Return 
-// 0x8cb: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9845]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a994a]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8f2: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x908: ProcessEvent[Probe[main.condReturnAndLocal]@4a994a]
-	Call d5 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a994a]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	PrepareEventRoot 19 01 00 00 09 00 00 00 
-	Call f2 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Return 
-// 0x91c: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a99b5]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x926: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x93c: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x952: ProcessEvent[Probe[main.condReturnAndLocal]@4a994a]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
 	PrepareEventRoot 1b 01 00 00 11 00 00 00 
-	Call 26 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[0]]
-	Call 3c 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a994a.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	Return 
-// 0x966: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a99b5.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x97c: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a99b5]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
 	PrepareEventRoot 1c 01 00 00 09 00 00 00 
-	Call 66 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a99b5.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	Return 
-// 0x98b: ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0x958: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9ad: ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x9cf: ProcessEvent[Probe[main.condString]@4a952a]
-	Call 8b 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0x99c: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call ad 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
-// 0x9e3: ProcessEvent[Probe[main.condString]Return@4a959f]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0x9ed: ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa0a: ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa2c: ProcessEvent[Probe[main.condString]@4a952a]
-	Call ed 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0x9f9: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call 0a 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	Return 
-// 0xa40: ProcessEvent[Probe[main.condString]Return@4a959f]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xa4a: ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa6c: ProcessExpression[Probe[main.condString]@0x4a952a.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa8e: ProcessEvent[Probe[main.condString]@4a952a]
+// 0xa5b: ProcessEvent[Probe[main.condString]@4a9b2a]
 	PrepareEventRoot ff 00 00 00 21 00 00 00 
-	Call 4a 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
-	Call 6c 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xaa2: ProcessEvent[Probe[main.condString]Return@4a959f]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xaac: ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0xa79: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xace: ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xaf0: ProcessExpression[Probe[main.condString]@0x4a952a.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xb12: ProcessEvent[Probe[main.condString]@4a952a]
-	Call ac 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a952a]
+// 0xadf: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	PrepareEventRoot 01 01 00 00 21 00 00 00 
-	Call ce 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[0]]
-	Call f0 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a952a.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xb2b: ProcessEvent[Probe[main.condString]Return@4a959f]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@4a9b9f]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0xb35: ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb54: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xb76: ProcessEvent[Probe[main.condStructArg]@4a95ee]
-	Call 35 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 54 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xb8a: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0xb94: ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xbb0: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xbd2: ProcessEvent[Probe[main.condStructArg]@4a95ee]
-	Call 94 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call b0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xbe6: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0xbf0: ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc13: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xc35: ProcessEvent[Probe[main.condStructArg]@4a95ee]
-	Call f0 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call 13 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xc49: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xc53: ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc72: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xc94: ProcessEvent[Probe[main.condStructArg]@4a95ee]
-	Call 53 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 09 01 00 00 11 00 00 00 
-	Call 72 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xca8: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xcb2: ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcd3: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xcf5: ProcessEvent[Probe[main.condStructArg]@4a95ee]
-	Call b2 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a95ee]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call d3 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xd09: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xd13: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 2e 15 00 00 // ProcessType[main.condFields]
+	Call fb 14 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd34: ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xd56: ProcessEvent[Probe[main.condStructArg]@4a95ee]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@4a9bee]
 	PrepareEventRoot 0d 01 00 00 61 00 00 00 
-	Call 13 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[0]]
-	Call 34 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a95ee.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	Return 
-// 0xd6a: ProcessEvent[Probe[main.condStructArg]Return@4a96ef]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xd74: ProcessCondition[Probe[main.condUint16]@0x4a90aa]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd8b: ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xdad: ProcessEvent[Probe[main.condUint16]@4a90aa]
-	Call 74 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a90aa]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@4a96aa]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
-	Call 8b 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	Return 
-// 0xdc1: ProcessEvent[Probe[main.condUint16]Return@4a911a]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
-// 0xdcb: ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xde1: ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xe03: ProcessEvent[Probe[main.condUint16]@4a90aa]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	PrepareEventRoot e7 00 00 00 13 00 00 00 
-	Call cb 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[0]]
-	Call e1 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a90aa.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	Return 
-// 0xe17: ProcessEvent[Probe[main.condUint16]Return@4a911a]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xe21: ProcessCondition[Probe[main.condUint32]@0x4a916a]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe3a: ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xe5c: ProcessEvent[Probe[main.condUint32]@4a916a]
-	Call 21 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a916a]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@4a976a]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call 3a 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	Return 
-// 0xe70: ProcessEvent[Probe[main.condUint32]Return@4a91da]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xe7a: ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe90: ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xeb2: ProcessEvent[Probe[main.condUint32]@4a916a]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@4a976a]
 	PrepareEventRoot eb 00 00 00 15 00 00 00 
-	Call 7a 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[0]]
-	Call 90 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a916a.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	Return 
-// 0xec6: ProcessEvent[Probe[main.condUint32]Return@4a91da]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0xed0: ProcessCondition[Probe[main.condUint64]@0x4a922a]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeed: ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xf0f: ProcessEvent[Probe[main.condUint64]@4a922a]
-	Call d0 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a922a]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@4a982a]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call ed 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	Return 
-// 0xf23: ProcessEvent[Probe[main.condUint64]Return@4a929a]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xf2d: ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf43: ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xf65: ProcessEvent[Probe[main.condUint64]@4a922a]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@4a982a]
 	PrepareEventRoot ef 00 00 00 19 00 00 00 
-	Call 2d 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[0]]
-	Call 43 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a922a.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	Return 
-// 0xf79: ProcessEvent[Probe[main.condUint64]Return@4a929a]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xf83: ProcessCondition[Probe[main.condUint8]@0x4a8fea]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf99: ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xfbb: ProcessEvent[Probe[main.condUint8]@4a8fea]
-	Call 83 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a8fea]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call 99 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0xfcf: ProcessEvent[Probe[main.condUint8]Return@4a905a]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xfd9: ProcessCondition[Probe[main.condUint8]@0x4a8fea]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,544 +1008,544 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfef: ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1011: ProcessEvent[Probe[main.condUint8]@4a8fea]
-	Call d9 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a8fea]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot e1 00 00 00 11 00 00 00 
-	Call ef 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0x1025: ProcessEvent[Probe[main.condUint8]Return@4a905a]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0x102f: ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1045: ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1067: ProcessEvent[Probe[main.condUint8]@4a8fea]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	PrepareEventRoot e3 00 00 00 12 00 00 00 
-	Call 2f 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[0]]
-	Call 45 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a8fea.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	Return 
-// 0x107b: ProcessEvent[Probe[main.condUint8]Return@4a905a]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
-// 0x1085: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1095: ProcessEvent[Probe[main.inlined]@4a7eee]
+// 0x1062: ProcessEvent[Probe[main.inlined]@4a7eee]
 	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call 85 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	Return 
-// 0x10a4: ProcessExpression[Probe[main.inlined]@0x4a8aaa.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ba: ProcessEvent[Probe[main.inlined]@4a8aaa]
+// 0x1087: ProcessEvent[Probe[main.inlined]@4a90aa]
 	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call a4 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a8aaa.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	Return 
-// 0x10c9: ProcessEvent[Probe[main.inlined]Return@4a8aea]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@4a90ea]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x10d3: ProcessExpression[Probe[main.intArg]@0x4a878a.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10e9: ProcessEvent[Probe[main.intArg]@4a878a]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@4a8d8a]
 	PrepareEventRoot b6 00 00 00 09 00 00 00 
-	Call d3 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a878a.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	Return 
-// 0x10f8: ProcessEvent[Probe[main.intArg]Return@4a87ca]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4a8dca]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1102: ProcessExpression[Probe[main.intArrayArg]@0x4a890a.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x111e: ProcessEvent[Probe[main.intArrayArg]@4a890a]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
 	PrepareEventRoot c0 00 00 00 19 00 00 00 
-	Call 02 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a890a.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	Return 
-// 0x112d: ProcessEvent[Probe[main.intArrayArg]Return@4a8956]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1137: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8a80.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 64 14 00 00 // ProcessType[[3]string]
+	Call 31 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1158: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a8a80]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
 	PrepareEventRoot c6 00 00 00 31 00 00 00 
-	Call 37 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a8a80.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	Return 
-// 0x1167: ProcessExpression[Probe[main.intSliceArg]@0x4a888a.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a4 14 00 00 // ProcessType[[]int]
+	Call 71 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1190: ProcessEvent[Probe[main.intSliceArg]@4a888a]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
 	PrepareEventRoot be 00 00 00 19 00 00 00 
-	Call 67 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a888a.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	Return 
-// 0x119f: ProcessEvent[Probe[main.intSliceArg]Return@4a88cf]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x11a9: ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x11cb: ProcessEvent[Probe[main.stringArg]@4a880a]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call a9 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	Return 
-// 0x11da: ProcessEvent[Probe[main.stringArg]Return@4a884f]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0x11e4: ProcessEvent[Probe[main.stringArg]@4a880a]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x11ee: ProcessEvent[Probe[main.stringArg]Return@4a884f]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x11f8: ProcessExpression[Probe[main.mapArg]@0x4a8b6a.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6f 15 00 00 // ProcessType[map[string]int]
+	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1213: ProcessExpression[Probe[main.mapArg]@0x4a8b6a.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 6f 15 00 00 // ProcessType[map[string]int]
+	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x122e: ProcessEvent[Probe[main.mapArg]@4a8b6a]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@4a916a]
 	PrepareEventRoot c7 00 00 00 11 00 00 00 
-	Call f8 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a8b6a.expr[0]]
-	Call 13 12 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a8b6a.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	Return 
-// 0x1242: ProcessEvent[Probe[main.mapArg]Return@4a8b9f]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4a919f]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x124c: ProcessEvent[Probe[main.noArgs]@4a8c8a]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@4a928a]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x1256: ProcessEvent[Probe[main.noArgs]Return@4a8cc6]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1260: ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1282: ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x12a4: ProcessEvent[Probe[main.stringArg]@4a880a]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bc 00 00 00 21 00 00 00 
-	Call 60 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[0]]
-	Call 82 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a880a.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	Return 
-// 0x12b8: ProcessEvent[Probe[main.stringArg]Return@4a884f]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x12c2: ProcessExpression[Probe[main.stringArrayArg]@0x4a8a0a.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 64 14 00 00 // ProcessType[[3]string]
+	Call 31 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.stringArrayArg]@4a8a0a]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
 	PrepareEventRoot c4 00 00 00 31 00 00 00 
-	Call c2 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a8a0a.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringArrayArg]Return@4a8a56]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.stringSliceArg]@0x4a898a.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call d2 14 00 00 // ProcessType[[]string]
+	Call 9f 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1325: ProcessEvent[Probe[main.stringSliceArg]@4a898a]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
 	PrepareEventRoot c2 00 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a898a.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	Return 
-// 0x1334: ProcessEvent[Probe[main.stringSliceArg]Return@4a89cf]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x133e: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4a9df6]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x1348: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a9fbc.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7b 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 48 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1363: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4a9fbc]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
 	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 48 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4a9fbc.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	Return 
-// 0x1372: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x1378: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer b4 00 00 00 
 	Return 
-// 0x137e: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1384: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x138a: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1390: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1396: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x139c: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*main.bigStruct]
+// 0x1387: ProcessType[*main.bigStruct]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*main.condFields]
+// 0x138d: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime._defer]
+// 0x1393: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime._panic]
+// 0x1399: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.cgoCallers]
+// 0x139f: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.coro]
+// 0x13a5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.g]
+// 0x13ab: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.m]
+// 0x13b1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.sudog]
+// 0x13b7: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.synctestGroup]
+// 0x13bd: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*runtime.timer]
+// 0x13c3: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*runtime.traceBuf]
+// 0x13c9: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1402: ProcessType[*string]
+// 0x13cf: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1408: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13d5: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<string,int>]
+// 0x13db: ProcessType[*table<string,int>]
 	ProcessPointer 8c 00 00 00 
 	Return 
-// 0x1414: ProcessType[*table<string,main.bigStruct>]
+// 0x13e1: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x141a: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13e7: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1420: ProcessType[*uint]
+// 0x13ed: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint16]
+// 0x13f3: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint32]
+// 0x13f9: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uint64]
+// 0x13ff: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1438: ProcessType[*uint8]
+// 0x1405: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x143e: ProcessType[*uintptr]
+// 0x140b: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1444: ProcessType[[2]*runtime.traceBuf]
+// 0x1411: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call fc 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call c9 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1454: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1421: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 44 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 11 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1464: ProcessType[[3]string]
+// 0x1431: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1474: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1441: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 08 14 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call d5 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1480: ProcessType[[]*table<string,int>.array]
+// 0x144d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<string,int>]
+	Call db 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x148c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1459: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 14 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call e1 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1498: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1465: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 1a 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e7 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14a4: ProcessType[[]int]
+// 0x1471: ProcessType[[]int]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x14ae: ProcessType[[]noalg.map.group[string]int.array]
+// 0x147b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call b1 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 7e 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ba: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1487: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call bc 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 89 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14c6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1493: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call c7 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 94 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14d2: ProcessType[[]string]
+// 0x149f: ProcessType[[]string]
 	ProcessSlice 8a 00 00 00 10 00 00 00 
 	Return 
-// 0x14dc: ProcessType[[]string.array]
+// 0x14a9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14e8: ProcessType[[]uint8]
+// 0x14b5: ProcessType[[]uint8]
 	ProcessSlice 84 00 00 00 01 00 00 00 
 	Return 
-// 0x14f2: ProcessType[[]uintptr]
+// 0x14bf: ProcessType[[]uintptr]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x14fc: ProcessType[error]
+// 0x14c9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14fe: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14cb: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b3 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x150a: ProcessType[groupReference<string,int>]
+// 0x14d7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 93 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1516: ProcessType[groupReference<string,main.bigStruct>]
+// 0x14e3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1522: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x14ef: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups aa 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x152e: ProcessType[main.condFields]
+// 0x14fb: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1539: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1506: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b2 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1545: ProcessType[map<string,int>]
+// 0x1512: ProcessType[map<string,int>]
 	ProcessGoSwissMap 92 00 00 00 8f 00 00 00 10 18 
 	Return 
-// 0x1551: ProcessType[map<string,main.bigStruct>]
+// 0x151e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9c 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x155d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x152a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a9 00 00 00 a1 00 00 00 10 18 
 	Return 
-// 0x1569: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1536: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x156f: ProcessType[map[string]int]
+// 0x153c: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1575: ProcessType[map[string]main.bigStruct]
+// 0x1542: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x157b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1548: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1581: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x154e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d2 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 9f 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1591: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x155e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call e2 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call af 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x15a1: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x156e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call e8 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call b5 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15b1: ProcessType[noalg.map.group[string]int]
+// 0x157e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 5e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15bc: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1589: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 81 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 4e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15c7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1594: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call a1 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15d2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call d3 16 00 00 // ProcessType[string]
+// 0x159f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a0 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ba 13 00 00 // ProcessType[*main.bigStruct]
+	Call 87 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15e2: ProcessType[noalg.struct { key string; elem int }]
-	Call d3 16 00 00 // ProcessType[string]
+// 0x15af: ProcessType[noalg.struct { key string; elem int }]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x15e8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15b5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 69 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 36 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15f3: ProcessType[runtime.g]
+// 0x15c0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime._panic]
+	Call 99 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime._defer]
+	Call 93 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call e8 14 00 00 // ProcessType[[]uint8]
+	Call b5 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 8a 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.sudog]
+	Call b7 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call f2 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f6 13 00 00 // ProcessType[*runtime.timer]
+	Call c3 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.coro]
+	Call a5 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.synctestGroup]
+	Call bd 13 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1658: ProcessType[runtime.m]
-	Call de 13 00 00 // ProcessType[*runtime.g]
+// 0x1625: ProcessType[runtime.m]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call d3 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call b8 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 85 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call f2 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 90 16 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16b8: ProcessType[runtime.mLockProfile]
+// 0x1685: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call f2 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16c3: ProcessType[runtime.mTraceState]
+// 0x1690: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call e4 13 00 00 // ProcessType[*runtime.m]
+	Call 21 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16d3: ProcessType[string]
+// 0x16a0: ProcessType[string]
 	ProcessString 82 00 00 00 
 	Return 
-// 0x16d9: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16a6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call fe 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call cb 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16e4: ProcessType[table<string,int>]
+// 0x16b1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0a 15 00 00 // ProcessType[groupReference<string,int>]
+	Call d7 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16ef: ProcessType[table<string,main.bigStruct>]
+// 0x16bc: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 16 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call e3 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16fa: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x16c7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 22 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ef 14 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1819,31 +1813,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5176
+ID: 5 Len: 8 Enqueue: 5125
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5843
+ID: 9 Len: 16 Enqueue: 5792
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 5008
+ID: 11 Len: 8 Enqueue: 4957
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 5372
+ID: 13 Len: 16 Enqueue: 5321
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5182
-ID: 20 Len: 8 Enqueue: 5038
-ID: 21 Len: 8 Enqueue: 5164
-ID: 22 Len: 440 Enqueue: 5619
+ID: 19 Len: 8 Enqueue: 5131
+ID: 20 Len: 8 Enqueue: 4987
+ID: 21 Len: 8 Enqueue: 5113
+ID: 22 Len: 440 Enqueue: 5568
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5068
+ID: 24 Len: 8 Enqueue: 5017
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5062
+ID: 26 Len: 8 Enqueue: 5011
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5092
-ID: 29 Len: 1808 Enqueue: 5720
+ID: 28 Len: 8 Enqueue: 5041
+ID: 29 Len: 1808 Enqueue: 5669
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1852,45 +1846,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5352
-ID: 39 Len: 8 Enqueue: 5002
+ID: 38 Len: 24 Enqueue: 5301
+ID: 39 Len: 8 Enqueue: 4951
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5098
+ID: 41 Len: 8 Enqueue: 5047
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5362
-ID: 44 Len: 8 Enqueue: 5110
+ID: 43 Len: 24 Enqueue: 5311
+ID: 44 Len: 8 Enqueue: 5059
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5080
+ID: 47 Len: 8 Enqueue: 5029
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5104
+ID: 49 Len: 8 Enqueue: 5053
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5086
+ID: 55 Len: 8 Enqueue: 5035
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 5074
+ID: 62 Len: 8 Enqueue: 5023
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 5816
+ID: 67 Len: 64 Enqueue: 5765
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 5827
+ID: 72 Len: 56 Enqueue: 5776
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 5204
-ID: 75 Len: 16 Enqueue: 5188
-ID: 76 Len: 8 Enqueue: 5116
+ID: 74 Len: 32 Enqueue: 5153
+ID: 75 Len: 16 Enqueue: 5137
+ID: 76 Len: 8 Enqueue: 5065
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -1907,43 +1901,43 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 5122
+ID: 93 Len: 8 Enqueue: 5071
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 5026
-ID: 97 Len: 8 Enqueue: 5044
-ID: 98 Len: 8 Enqueue: 5032
-ID: 99 Len: 8 Enqueue: 5170
-ID: 100 Len: 8 Enqueue: 5014
+ID: 96 Len: 8 Enqueue: 4975
+ID: 97 Len: 8 Enqueue: 4993
+ID: 98 Len: 8 Enqueue: 4981
+ID: 99 Len: 8 Enqueue: 5119
+ID: 100 Len: 8 Enqueue: 4963
 ID: 101 Len: 2 Enqueue: 0
-ID: 102 Len: 8 Enqueue: 5020
-ID: 103 Len: 8 Enqueue: 5152
-ID: 104 Len: 8 Enqueue: 5158
-ID: 105 Len: 24 Enqueue: 5284
+ID: 102 Len: 8 Enqueue: 4969
+ID: 103 Len: 8 Enqueue: 5101
+ID: 104 Len: 8 Enqueue: 5107
+ID: 105 Len: 24 Enqueue: 5233
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 5330
-ID: 108 Len: 48 Enqueue: 5220
-ID: 109 Len: 8 Enqueue: 5487
+ID: 107 Len: 24 Enqueue: 5279
+ID: 108 Len: 48 Enqueue: 5169
+ID: 109 Len: 8 Enqueue: 5436
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 5445
+ID: 111 Len: 48 Enqueue: 5394
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 5134
-ID: 114 Len: 8 Enqueue: 5493
+ID: 113 Len: 8 Enqueue: 5083
+ID: 114 Len: 8 Enqueue: 5442
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 5457
+ID: 116 Len: 48 Enqueue: 5406
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5140
-ID: 119 Len: 80 Enqueue: 5422
+ID: 118 Len: 8 Enqueue: 5089
+ID: 119 Len: 80 Enqueue: 5371
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 5056
-ID: 122 Len: 8 Enqueue: 5499
+ID: 121 Len: 8 Enqueue: 5005
+ID: 122 Len: 8 Enqueue: 5448
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 5469
+ID: 124 Len: 48 Enqueue: 5418
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 5146
-ID: 127 Len: 8 Enqueue: 4978
-ID: 128 Len: 8 Enqueue: 4984
-ID: 129 Len: 8 Enqueue: 4996
+ID: 126 Len: 8 Enqueue: 5095
+ID: 127 Len: 8 Enqueue: 4927
+ID: 128 Len: 8 Enqueue: 4933
+ID: 129 Len: 8 Enqueue: 4945
 ID: 130 Len: 1 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 1 Enqueue: 0
@@ -1952,49 +1946,49 @@ ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
-ID: 138 Len: 16 Enqueue: 5340
+ID: 138 Len: 16 Enqueue: 5289
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 32 Enqueue: 5860
-ID: 141 Len: 16 Enqueue: 5386
+ID: 140 Len: 32 Enqueue: 5809
+ID: 141 Len: 16 Enqueue: 5335
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 5553
-ID: 144 Len: 192 Enqueue: 5521
-ID: 145 Len: 24 Enqueue: 5602
-ID: 146 Len: 8 Enqueue: 5248
-ID: 147 Len: 200 Enqueue: 5294
-ID: 148 Len: 32 Enqueue: 5871
-ID: 149 Len: 16 Enqueue: 5398
+ID: 143 Len: 200 Enqueue: 5502
+ID: 144 Len: 192 Enqueue: 5470
+ID: 145 Len: 24 Enqueue: 5551
+ID: 146 Len: 8 Enqueue: 5197
+ID: 147 Len: 200 Enqueue: 5243
+ID: 148 Len: 32 Enqueue: 5820
+ID: 149 Len: 16 Enqueue: 5347
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 5564
-ID: 152 Len: 192 Enqueue: 5505
-ID: 153 Len: 24 Enqueue: 5586
-ID: 154 Len: 8 Enqueue: 5050
+ID: 151 Len: 200 Enqueue: 5513
+ID: 152 Len: 192 Enqueue: 5454
+ID: 153 Len: 24 Enqueue: 5535
+ID: 154 Len: 8 Enqueue: 4999
 ID: 155 Len: 184 Enqueue: 0
-ID: 156 Len: 8 Enqueue: 5260
-ID: 157 Len: 200 Enqueue: 5306
-ID: 158 Len: 32 Enqueue: 5882
-ID: 159 Len: 16 Enqueue: 5410
+ID: 156 Len: 8 Enqueue: 5209
+ID: 157 Len: 200 Enqueue: 5255
+ID: 158 Len: 32 Enqueue: 5831
+ID: 159 Len: 16 Enqueue: 5359
 ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 136 Enqueue: 5575
-ID: 162 Len: 128 Enqueue: 5537
-ID: 163 Len: 16 Enqueue: 5608
-ID: 164 Len: 8 Enqueue: 5481
+ID: 161 Len: 136 Enqueue: 5524
+ID: 162 Len: 128 Enqueue: 5486
+ID: 163 Len: 16 Enqueue: 5557
+ID: 164 Len: 8 Enqueue: 5430
 ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 48 Enqueue: 5433
+ID: 166 Len: 48 Enqueue: 5382
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 8 Enqueue: 5128
-ID: 169 Len: 8 Enqueue: 5272
-ID: 170 Len: 136 Enqueue: 5318
-ID: 171 Len: 32 Enqueue: 5849
-ID: 172 Len: 16 Enqueue: 5374
+ID: 168 Len: 8 Enqueue: 5077
+ID: 169 Len: 8 Enqueue: 5221
+ID: 170 Len: 136 Enqueue: 5267
+ID: 171 Len: 32 Enqueue: 5798
+ID: 172 Len: 16 Enqueue: 5323
 ID: 173 Len: 8 Enqueue: 0
 ID: 174 Len: 136 Enqueue: 0
 ID: 175 Len: 128 Enqueue: 0
 ID: 176 Len: 16 Enqueue: 0
 ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5236
+ID: 178 Len: 8 Enqueue: 5185
 ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 4990
+ID: 180 Len: 8 Enqueue: 4939
 ID: 181 Len: 128 Enqueue: 0
 ID: 182 Len: 9 Enqueue: 0
 ID: 183 Len: 0 Enqueue: 0
@@ -2104,7 +2098,7 @@ ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 25 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
 ID: 289 Len: 17 Enqueue: 0
-ID: 290 Len: 33 Enqueue: 0
+ID: 290 Len: 25 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 9 Enqueue: 0
 ID: 293 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4a8126]
-	PrepareEventRoot 6e 01 00 00 11 00 00 00 
+	PrepareEventRoot 7e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4a8126.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4a8170]
-	PrepareEventRoot 6f 01 00 00 09 00 00 00 
+	PrepareEventRoot 7f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4a8170.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call a2 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4a91d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call a2 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4a91d3]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4a9a6a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4a9a6a]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4a98ea]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4a99aa]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4a93aa]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4a93aa]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4a946a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4a946a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4a946a]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4a952a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4a952a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4a952a]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4a92ea]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4a92ea]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4aa0c1]
-	PrepareEventRoot 24 01 00 00 11 00 00 00 
+	PrepareEventRoot 28 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4aa0c1]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4aa0c1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4a9e8e]
-	PrepareEventRoot 18 01 00 00 11 00 00 00 
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4a9e8e]
-	PrepareEventRoot 1a 01 00 00 19 00 00 00 
+	PrepareEventRoot 1e 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4a9e8e.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4a9f0e]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4a9fea]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4a9fea]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4a9fea]
-	PrepareEventRoot 20 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
-	PrepareEventRoot 21 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4a9fea]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 26 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4a9fea.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@4aa05a]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
-	PrepareEventRoot 12 01 00 00 11 00 00 00 
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4a9d2e]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4a9d2e]
-	PrepareEventRoot 16 01 00 00 19 00 00 00 
+	PrepareEventRoot 1a 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4a9d2e.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4a9e45]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4a9f4a]
-	PrepareEventRoot 1c 01 00 00 09 00 00 00 
+	PrepareEventRoot 20 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4a9f4a]
-	PrepareEventRoot 1e 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4a9f4a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4a9fb5]
-	PrepareEventRoot 1f 01 00 00 09 00 00 00 
+	PrepareEventRoot 23 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4a9fb5.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4a9b2a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@4a9b2a]
+	PrepareEventRoot 02 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@4a9b2a]
+	PrepareEventRoot 04 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 00 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@4a9b2a]
-	PrepareEventRoot 02 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@4a9b2a]
+	PrepareEventRoot 06 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0x4a9b2a]
+// 0xb11: ProcessCondition[Probe[main.condString]@0x4a9b2a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@4a9b2a]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
-	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@4a9b2a]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0x4a9b2a]
+	PrepareEventRoot 08 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4a9b2a.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@4a9b9f]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@4a9b9f]
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 06 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+	PrepareEventRoot 0c 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+	PrepareEventRoot 0e 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0b 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
-	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4a9bee]
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 0e 1f 00 00 // ProcessType[main.condFields]
+	Call 2d 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4a9bee]
-	PrepareEventRoot 10 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@4a9bee]
+	PrepareEventRoot 14 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4a9bee.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@4a9cef]
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@4a96aa]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@4a96aa]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4a96aa]
 	PrepareEventRoot e8 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4a971a]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@4a96aa]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@4a96aa]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4a96aa.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4a971a]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@4a971a]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4a976a]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@4a976a]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@4a976a]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4a976a]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4a97da]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@4a976a]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@4a976a]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4a976a.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4a97da]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@4a97da]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4a982a]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@4a982a]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@4a982a]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0x4a982a]
 	PrepareEventRoot f0 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4a989a]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@4a982a]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@4a982a]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4a982a.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4a989a]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@4a989a]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@4a95ea]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@4a95ea]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@4a95ea]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0x4a95ea]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@4a95ea]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@4a95ea]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4a95ea.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4a965a]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@4a965a]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@4a7eee]
-	PrepareEventRoot 6c 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@4a7eee]
+	PrepareEventRoot 7c 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a7eee.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@4a90aa]
-	PrepareEventRoot 6c 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4a90ea]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@4a8d8a]
+// 0x111f: ProcessEvent[Probe[main.inlined]@4a90aa]
+	PrepareEventRoot 7c 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0x4a90aa.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@4a90ea]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@4a8d8a]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0x4a8d8a.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4a8dca]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@4a8dca]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@4a8f0a]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4a8f0a.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@4a8f56]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 44 1e 00 00 // ProcessType[[3]string]
+	Call 63 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@4a9080]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4a9080.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@4a8e8a]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4a8e8a.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@4a8ecf]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
-	PrepareEventRoot 62 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+	PrepareEventRoot 72 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4aacb3.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 0e 1f 00 00 // ProcessType[main.condFields]
+	Call 2d 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
-	PrepareEventRoot 66 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+	PrepareEventRoot 76 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4aadf3.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@4aacb3]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
-	PrepareEventRoot 65 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@4aad9c]
+	PrepareEventRoot 75 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
-	PrepareEventRoot 68 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@4aadf3]
+	PrepareEventRoot 78 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@4aaef6]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
-	PrepareEventRoot 3a 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 4a 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	PrepareEventRoot 3c 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
-	PrepareEventRoot 3e 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4aa6ce]
+	PrepareEventRoot 4e 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@4aa6ce]
-	PrepareEventRoot 42 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@4aa6ce]
+	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4aa6ce.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@4aa7bc]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
-	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 54 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*string]
+	Call 01 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
-	PrepareEventRoot 46 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@4aa80e]
+	PrepareEventRoot 56 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4aa80e.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@4aa8e5]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.lenFields]
+	Call bf 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 5a 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 6a 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 5e 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 6e 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
-	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@4aab13]
+	PrepareEventRoot 70 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4aab13.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@4aac5c]
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+	PrepareEventRoot 3c 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 3e 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0x4aa573]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4aa573]
+	PrepareEventRoot 42 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@4aa573]
-	PrepareEventRoot 38 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@4aa573]
+	PrepareEventRoot 46 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4aa573.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@4aa676]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2a 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2c 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 2e 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0x4aa413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 32 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@4aa413]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 34 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 29 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4aa413]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0x4aa413]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@4aa413]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
-	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@4aa413]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4aa413]
+	PrepareEventRoot 36 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@4aa413]
-	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 38 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@4aa413]
-	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@4aa413]
+	PrepareEventRoot 3a 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4aa413.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4aa505]
-	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@4aa505]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 19 1f 00 00 // ProcessType[main.lenFields]
+	Call 38 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 48 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 58 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	PrepareEventRoot 52 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	PrepareEventRoot 62 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
-	PrepareEventRoot 54 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 64 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
-	PrepareEventRoot 56 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 66 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,471 +1812,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4aa933]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
-	PrepareEventRoot 58 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@4aa933]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4aa933]
+	PrepareEventRoot 68 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4aa933.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@4aaac8]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@4a916a]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@4a916a]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0x4a916a.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4a919f]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@4a919f]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@4a928a]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@4a928a]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@4a92c6]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@4a8e0a]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@4a8e0a]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4a8e0a.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@4a8e4f]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 44 1e 00 00 // ProcessType[[3]string]
+	Call 63 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@4a900a]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4a900a.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@4a9056]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b2 1e 00 00 // ProcessType[[]string]
+	Call d1 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@4a8f8a]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4a8f8a.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@4a8fcf]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
-	PrepareEventRoot 6a 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4aaf36]
+	PrepareEventRoot 7a 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 89 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a8 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
-	PrepareEventRoot 6b 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4ab0fc]
+	PrepareEventRoot 7b 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4ab0fc.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 62 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*main.bigStruct]
+// 0x1fb3: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.condFields]
+// 0x1fb9: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.lenFields]
+// 0x1fbf: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*runtime._defer]
+// 0x1fc5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._panic]
+// 0x1fcb: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime.cgoCallers]
+// 0x1fd1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.coro]
+// 0x1fd7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.g]
+// 0x1fdd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.m]
+// 0x1fe3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.sudog]
+// 0x1fe9: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.synctestGroup]
+// 0x1fef: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.timer]
+// 0x1ff5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.traceBuf]
+// 0x1ffb: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*string]
+// 0x2001: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2007: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*table<string,int>]
+// 0x200d: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*table<string,main.bigStruct>]
+// 0x2013: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2019: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*uint]
+// 0x201f: ProcessType[*uint]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint16]
+// 0x2025: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint32]
+// 0x202b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint64]
+// 0x2031: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint8]
+// 0x2037: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uintptr]
+// 0x203d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e24: ProcessType[[2]*runtime.traceBuf]
+// 0x2043: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call fb 1f 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e34: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2053: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 24 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 43 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e44: ProcessType[[3]string]
+// 0x2063: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e54: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x2073: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e8 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 07 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e60: ProcessType[[]*table<string,int>.array]
+// 0x207f: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ee 1d 00 00 // ProcessType[*table<string,int>]
+	Call 0d 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e6c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x208b: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f4 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 13 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e78: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x2097: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 19 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e84: ProcessType[[]int]
+// 0x20a3: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1e8e: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20ad: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call bf 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call de 21 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e9a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20b9: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call ca 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call e9 21 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ea6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20c5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call d5 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f4 21 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eb2: ProcessType[[]string]
+// 0x20d1: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1ebc: ProcessType[[]string.array]
+// 0x20db: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ec8: ProcessType[[]uint8]
+// 0x20e7: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1ed2: ProcessType[[]uintptr]
+// 0x20f1: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1edc: ProcessType[error]
+// 0x20fb: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1ede: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x20fd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1eea: ProcessType[groupReference<string,int>]
+// 0x2109: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ef6: ProcessType[groupReference<string,main.bigStruct>]
+// 0x2115: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f02: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2121: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f0e: ProcessType[main.condFields]
+// 0x212d: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f19: ProcessType[main.lenFields]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x2138: ProcessType[main.lenFields]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*string]
+	Call 01 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f47: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x2166: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1f53: ProcessType[map<string,int>]
+// 0x2172: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1f5f: ProcessType[map<string,main.bigStruct>]
+// 0x217e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1f6b: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x218a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1f77: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x2196: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1f7d: ProcessType[map[string]int]
+// 0x219c: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1f83: ProcessType[map[string]main.bigStruct]
+// 0x21a2: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1f89: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21a8: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1f8f: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21ae: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call e0 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ff 21 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1f9f: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21be: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call f0 1f 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 0f 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1faf: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21ce: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call f6 1f 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 15 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fbf: ProcessType[noalg.map.group[string]int]
+// 0x21de: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call be 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1fca: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x21e9: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ae 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1fd5: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21f4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call af 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call ce 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1fe0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x21ff: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b3 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1ff0: ProcessType[noalg.struct { key string; elem int }]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x220f: ProcessType[noalg.struct { key string; elem int }]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1ff6: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2215: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 96 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2001: ProcessType[runtime.g]
+// 0x2220: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._panic]
+	Call cb 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*runtime._defer]
+	Call c5 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call c8 1e 00 00 // ProcessType[[]uint8]
+	Call e7 20 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.sudog]
+	Call e9 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.timer]
+	Call f5 1f 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.coro]
+	Call d7 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.synctestGroup]
+	Call ef 1f 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x2066: ProcessType[runtime.m]
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+// 0x2285: ProcessType[runtime.m]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d1 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call c6 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call e5 22 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 20 00 00 // ProcessType[runtime.mTraceState]
+	Call f0 22 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x20c6: ProcessType[runtime.mLockProfile]
+// 0x22e5: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20d1: ProcessType[runtime.mTraceState]
+// 0x22f0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 34 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call 53 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x20e1: ProcessType[string]
+// 0x2300: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x20e7: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2306: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call de 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call fd 20 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x20f2: ProcessType[table<string,int>]
+// 0x2311: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ea 1e 00 00 // ProcessType[groupReference<string,int>]
+	Call 09 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x20fd: ProcessType[table<string,main.bigStruct>]
+// 0x231c: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f6 1e 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 15 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x2108: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2327: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 02 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 21 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2421,31 +2544,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7704
+ID: 5 Len: 8 Enqueue: 8247
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8417
+ID: 9 Len: 16 Enqueue: 8960
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 7530
+ID: 11 Len: 8 Enqueue: 8073
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7900
+ID: 13 Len: 16 Enqueue: 8443
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 7710
-ID: 20 Len: 8 Enqueue: 7560
-ID: 21 Len: 8 Enqueue: 7692
-ID: 22 Len: 440 Enqueue: 8193
+ID: 19 Len: 8 Enqueue: 8253
+ID: 20 Len: 8 Enqueue: 8103
+ID: 21 Len: 8 Enqueue: 8235
+ID: 22 Len: 440 Enqueue: 8736
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7596
+ID: 24 Len: 8 Enqueue: 8139
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7590
+ID: 26 Len: 8 Enqueue: 8133
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7620
-ID: 29 Len: 1808 Enqueue: 8294
+ID: 28 Len: 8 Enqueue: 8163
+ID: 29 Len: 1808 Enqueue: 8837
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2454,45 +2577,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7880
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8423
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7626
+ID: 41 Len: 8 Enqueue: 8169
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7890
-ID: 44 Len: 8 Enqueue: 7638
+ID: 43 Len: 24 Enqueue: 8433
+ID: 44 Len: 8 Enqueue: 8181
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7608
+ID: 47 Len: 8 Enqueue: 8151
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 7632
+ID: 49 Len: 8 Enqueue: 8175
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 7614
+ID: 55 Len: 8 Enqueue: 8157
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 7602
+ID: 62 Len: 8 Enqueue: 8145
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 8390
+ID: 67 Len: 64 Enqueue: 8933
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 8401
+ID: 72 Len: 56 Enqueue: 8944
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 7732
-ID: 75 Len: 16 Enqueue: 7716
-ID: 76 Len: 8 Enqueue: 7644
+ID: 74 Len: 32 Enqueue: 8275
+ID: 75 Len: 16 Enqueue: 8259
+ID: 76 Len: 8 Enqueue: 8187
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2509,46 +2632,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 7650
+ID: 93 Len: 8 Enqueue: 8193
 ID: 94 Len: 8 Enqueue: 0
 ID: 95 Len: 16 Enqueue: 0
-ID: 96 Len: 8 Enqueue: 7548
-ID: 97 Len: 8 Enqueue: 7566
-ID: 98 Len: 8 Enqueue: 7554
-ID: 99 Len: 8 Enqueue: 7698
-ID: 100 Len: 8 Enqueue: 7536
+ID: 96 Len: 8 Enqueue: 8091
+ID: 97 Len: 8 Enqueue: 8109
+ID: 98 Len: 8 Enqueue: 8097
+ID: 99 Len: 8 Enqueue: 8241
+ID: 100 Len: 8 Enqueue: 8079
 ID: 101 Len: 2 Enqueue: 0
-ID: 102 Len: 8 Enqueue: 7542
-ID: 103 Len: 8 Enqueue: 7680
-ID: 104 Len: 8 Enqueue: 7686
-ID: 105 Len: 24 Enqueue: 7812
+ID: 102 Len: 8 Enqueue: 8085
+ID: 103 Len: 8 Enqueue: 8223
+ID: 104 Len: 8 Enqueue: 8229
+ID: 105 Len: 24 Enqueue: 8355
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 7858
-ID: 108 Len: 48 Enqueue: 7748
-ID: 109 Len: 8 Enqueue: 8061
+ID: 107 Len: 24 Enqueue: 8401
+ID: 108 Len: 48 Enqueue: 8291
+ID: 109 Len: 8 Enqueue: 8604
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 8019
+ID: 111 Len: 48 Enqueue: 8562
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 7662
-ID: 114 Len: 8 Enqueue: 8067
+ID: 113 Len: 8 Enqueue: 8205
+ID: 114 Len: 8 Enqueue: 8610
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 8031
+ID: 116 Len: 48 Enqueue: 8574
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 7668
-ID: 119 Len: 80 Enqueue: 7950
+ID: 118 Len: 8 Enqueue: 8211
+ID: 119 Len: 80 Enqueue: 8493
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 7578
-ID: 122 Len: 72 Enqueue: 7961
-ID: 123 Len: 8 Enqueue: 7518
-ID: 124 Len: 8 Enqueue: 7584
-ID: 125 Len: 8 Enqueue: 8073
+ID: 121 Len: 8 Enqueue: 8121
+ID: 122 Len: 72 Enqueue: 8504
+ID: 123 Len: 8 Enqueue: 8061
+ID: 124 Len: 8 Enqueue: 8127
+ID: 125 Len: 8 Enqueue: 8616
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 8043
+ID: 127 Len: 48 Enqueue: 8586
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 7674
-ID: 130 Len: 8 Enqueue: 7494
-ID: 131 Len: 8 Enqueue: 7500
-ID: 132 Len: 8 Enqueue: 7512
+ID: 129 Len: 8 Enqueue: 8217
+ID: 130 Len: 8 Enqueue: 8037
+ID: 131 Len: 8 Enqueue: 8043
+ID: 132 Len: 8 Enqueue: 8055
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2557,49 +2680,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 7868
+ID: 141 Len: 16 Enqueue: 8411
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 8434
-ID: 144 Len: 16 Enqueue: 7914
+ID: 143 Len: 32 Enqueue: 8977
+ID: 144 Len: 16 Enqueue: 8457
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 8127
-ID: 147 Len: 192 Enqueue: 8095
-ID: 148 Len: 24 Enqueue: 8176
-ID: 149 Len: 8 Enqueue: 7776
-ID: 150 Len: 200 Enqueue: 7822
-ID: 151 Len: 32 Enqueue: 8445
-ID: 152 Len: 16 Enqueue: 7926
+ID: 146 Len: 200 Enqueue: 8670
+ID: 147 Len: 192 Enqueue: 8638
+ID: 148 Len: 24 Enqueue: 8719
+ID: 149 Len: 8 Enqueue: 8319
+ID: 150 Len: 200 Enqueue: 8365
+ID: 151 Len: 32 Enqueue: 8988
+ID: 152 Len: 16 Enqueue: 8469
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 8138
-ID: 155 Len: 192 Enqueue: 8079
-ID: 156 Len: 24 Enqueue: 8160
-ID: 157 Len: 8 Enqueue: 7572
+ID: 154 Len: 200 Enqueue: 8681
+ID: 155 Len: 192 Enqueue: 8622
+ID: 156 Len: 24 Enqueue: 8703
+ID: 157 Len: 8 Enqueue: 8115
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 7788
-ID: 160 Len: 200 Enqueue: 7834
-ID: 161 Len: 32 Enqueue: 8456
-ID: 162 Len: 16 Enqueue: 7938
+ID: 159 Len: 8 Enqueue: 8331
+ID: 160 Len: 200 Enqueue: 8377
+ID: 161 Len: 32 Enqueue: 8999
+ID: 162 Len: 16 Enqueue: 8481
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 8149
-ID: 165 Len: 128 Enqueue: 8111
-ID: 166 Len: 16 Enqueue: 8182
-ID: 167 Len: 8 Enqueue: 8055
+ID: 164 Len: 136 Enqueue: 8692
+ID: 165 Len: 128 Enqueue: 8654
+ID: 166 Len: 16 Enqueue: 8725
+ID: 167 Len: 8 Enqueue: 8598
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 8007
+ID: 169 Len: 48 Enqueue: 8550
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 7656
-ID: 172 Len: 8 Enqueue: 7800
-ID: 173 Len: 136 Enqueue: 7846
-ID: 174 Len: 32 Enqueue: 8423
-ID: 175 Len: 16 Enqueue: 7902
+ID: 171 Len: 8 Enqueue: 8199
+ID: 172 Len: 8 Enqueue: 8343
+ID: 173 Len: 136 Enqueue: 8389
+ID: 174 Len: 32 Enqueue: 8966
+ID: 175 Len: 16 Enqueue: 8445
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 7764
+ID: 181 Len: 8 Enqueue: 8307
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 7506
+ID: 183 Len: 8 Enqueue: 8049
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
@@ -2674,13 +2797,13 @@ ID: 254 Len: 17 Enqueue: 0
 ID: 255 Len: 0 Enqueue: 0
 ID: 256 Len: 17 Enqueue: 0
 ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 33 Enqueue: 0
+ID: 258 Len: 2 Enqueue: 0
 ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 33 Enqueue: 0
+ID: 260 Len: 2 Enqueue: 0
 ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 17 Enqueue: 0
+ID: 262 Len: 33 Enqueue: 0
 ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 17 Enqueue: 0
+ID: 264 Len: 33 Enqueue: 0
 ID: 265 Len: 0 Enqueue: 0
 ID: 266 Len: 17 Enqueue: 0
 ID: 267 Len: 0 Enqueue: 0
@@ -2688,81 +2811,81 @@ ID: 268 Len: 17 Enqueue: 0
 ID: 269 Len: 0 Enqueue: 0
 ID: 270 Len: 17 Enqueue: 0
 ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 97 Enqueue: 0
+ID: 272 Len: 17 Enqueue: 0
 ID: 273 Len: 0 Enqueue: 0
 ID: 274 Len: 17 Enqueue: 0
 ID: 275 Len: 0 Enqueue: 0
-ID: 276 Len: 17 Enqueue: 0
+ID: 276 Len: 97 Enqueue: 0
 ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 25 Enqueue: 0
+ID: 278 Len: 17 Enqueue: 0
 ID: 279 Len: 0 Enqueue: 0
 ID: 280 Len: 17 Enqueue: 0
 ID: 281 Len: 0 Enqueue: 0
 ID: 282 Len: 25 Enqueue: 0
 ID: 283 Len: 0 Enqueue: 0
-ID: 284 Len: 9 Enqueue: 0
+ID: 284 Len: 17 Enqueue: 0
 ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 17 Enqueue: 0
-ID: 287 Len: 9 Enqueue: 0
-ID: 288 Len: 25 Enqueue: 0
+ID: 286 Len: 25 Enqueue: 0
+ID: 287 Len: 0 Enqueue: 0
+ID: 288 Len: 9 Enqueue: 0
 ID: 289 Len: 0 Enqueue: 0
-ID: 290 Len: 25 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 17 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
-ID: 294 Len: 17 Enqueue: 0
+ID: 290 Len: 17 Enqueue: 0
+ID: 291 Len: 9 Enqueue: 0
+ID: 292 Len: 25 Enqueue: 0
+ID: 293 Len: 0 Enqueue: 0
+ID: 294 Len: 25 Enqueue: 0
 ID: 295 Len: 0 Enqueue: 0
-ID: 296 Len: 9 Enqueue: 0
-ID: 297 Len: 0 Enqueue: 0
-ID: 298 Len: 17 Enqueue: 0
+ID: 296 Len: 17 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 2 Enqueue: 0
 ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 9 Enqueue: 0
+ID: 300 Len: 2 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 33 Enqueue: 0
+ID: 302 Len: 2 Enqueue: 0
 ID: 303 Len: 0 Enqueue: 0
 ID: 304 Len: 17 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 9 Enqueue: 0
+ID: 306 Len: 2 Enqueue: 0
 ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 17 Enqueue: 0
+ID: 308 Len: 9 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 9 Enqueue: 0
+ID: 310 Len: 17 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 41 Enqueue: 0
+ID: 312 Len: 9 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 17 Enqueue: 0
+ID: 314 Len: 33 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 9 Enqueue: 0
+ID: 316 Len: 17 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 17 Enqueue: 0
+ID: 318 Len: 2 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
 ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 25 Enqueue: 0
+ID: 322 Len: 17 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
 ID: 324 Len: 9 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 25 Enqueue: 0
+ID: 326 Len: 41 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 89 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 9 Enqueue: 0
+ID: 330 Len: 2 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
 ID: 332 Len: 9 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
-ID: 334 Len: 9 Enqueue: 0
+ID: 334 Len: 17 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
 ID: 336 Len: 9 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 9 Enqueue: 0
+ID: 338 Len: 25 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 17 Enqueue: 0
+ID: 340 Len: 9 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 17 Enqueue: 0
+ID: 342 Len: 25 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 17 Enqueue: 0
+ID: 344 Len: 89 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 25 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
 ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
@@ -2770,17 +2893,33 @@ ID: 350 Len: 9 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
 ID: 352 Len: 9 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 25 Enqueue: 0
+ID: 354 Len: 9 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 0 Enqueue: 0
+ID: 356 Len: 17 Enqueue: 0
 ID: 357 Len: 0 Enqueue: 0
-ID: 358 Len: 97 Enqueue: 0
+ID: 358 Len: 17 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
-ID: 360 Len: 0 Enqueue: 0
+ID: 360 Len: 17 Enqueue: 0
 ID: 361 Len: 0 Enqueue: 0
-ID: 362 Len: 0 Enqueue: 0
-ID: 363 Len: 9 Enqueue: 0
+ID: 362 Len: 25 Enqueue: 0
+ID: 363 Len: 0 Enqueue: 0
 ID: 364 Len: 9 Enqueue: 0
 ID: 365 Len: 0 Enqueue: 0
-ID: 366 Len: 17 Enqueue: 0
-ID: 367 Len: 9 Enqueue: 0
+ID: 366 Len: 9 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 9 Enqueue: 0
+ID: 369 Len: 0 Enqueue: 0
+ID: 370 Len: 25 Enqueue: 0
+ID: 371 Len: 0 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 0 Enqueue: 0
+ID: 374 Len: 97 Enqueue: 0
+ID: 375 Len: 0 Enqueue: 0
+ID: 376 Len: 0 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 0 Enqueue: 0
+ID: 379 Len: 9 Enqueue: 0
+ID: 380 Len: 9 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 17 Enqueue: 0
+ID: 383 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae726]
 	PrepareEventRoot 2c 01 00 00 11 00 00 00 
@@ -24,33 +24,33 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 78 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae770]
 	PrepareEventRoot 2d 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae770.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4af1d3.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af1d3.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@4af1d3]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@4af7b3]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af1d3.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af1d3.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4af25e]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4af83e]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0x4afa6a]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0x4b004a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@4afa6a]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4afa6a]
+// 0x103: ProcessEvent[Probe[main.condBool]@4b004a]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@4afada]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@4b00ba]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0x4afa6a]
+// 0x121: ProcessCondition[Probe[main.condBool]@0x4b004a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@4afa6a]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4afa6a]
+// 0x159: ProcessEvent[Probe[main.condBool]@4b004a]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
 	PrepareEventRoot fc 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@4afada]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@4b00ba]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0x4b004a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@4afa6a]
+// 0x1af: ProcessEvent[Probe[main.condBool]@4b004a]
 	PrepareEventRoot fe 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4afa6a.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4afada]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4b00ba]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4af8ea.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4afeca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4af8ea]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4afeca]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4af8ea.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4afeca.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4af95e]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4aff3e]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4af9aa.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4aff8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@4af9aa]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@4aff8a]
 	PrepareEventRoot f8 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4af9aa.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4aff8a.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4afa1f]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4affff]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0x4af3aa]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0x4af98a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@4af3aa]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af3aa]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@4af98a]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af98a]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@4af41a]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@4af9fa]
 	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@4af3aa]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@4af98a]
 	PrepareEventRoot d8 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af3aa.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4af41a]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4af9fa]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4af46a]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@4af46a]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4af46a]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@4afa4a]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	PrepareEventRoot da 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4af4da]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4afaba]
 	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0x4af46a]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@4af46a]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4af46a]
+// 0x384: ProcessEvent[Probe[main.condInt32]@4afa4a]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	PrepareEventRoot dc 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@4af4da]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@4afaba]
 	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@4af46a]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	PrepareEventRoot de 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4af46a.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4af4da]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4afaba]
 	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4af52a]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4afb0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@4af52a]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4af52a]
+// 0x437: ProcessEvent[Probe[main.condInt64]@4afb0a]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4afb0a]
 	PrepareEventRoot e0 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4af59a]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4afb7a]
 	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@4af52a]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	PrepareEventRoot e2 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4af52a.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4af59a]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4afb7a]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4af2ea]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4af8ca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,86 +311,80 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@4af2ea]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af2ea]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@4af8ca]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af8ca]
 	PrepareEventRoot d2 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4af35a]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4af93a]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@4af2ea]
+// 0x539: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	PrepareEventRoot d4 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af2ea.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4af35a]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4af93a]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4b00c4]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
 	ConditionBegin 
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprPushOffset 08 00 00 00 
 	ExprLoadLiteral 08 00 07 00 00 00 00 00 00 00 
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x57a: ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x59c: ProcessEvent[Probe[main.condLine]Line@4b00c4]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b00c4]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@4b06a1]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
 	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 7a 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	Return 
-// 0x5b0: ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x5ee: ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@4b06a1]
+	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[1]]
 	Return 
-// 0x604: ProcessEvent[Probe[main.condLine]Line@4b00c4]
-	PrepareEventRoot 27 01 00 00 21 00 00 00 
-	Call b0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[1]]
-	Call ee 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b00c4.expr[2]]
-	Return 
-// 0x61d: ProcessCondition[Probe[main.condNilPtrStruct]@0x4afe8e]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x63f: ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x661: ProcessEvent[Probe[main.condNilPtrStruct]@4afe8e]
-	Call 1d 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4afe8e]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
 	PrepareEventRoot 1a 01 00 00 11 00 00 00 
-	Call 3f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Return 
-// 0x675: ProcessEvent[Probe[main.condNilPtrStruct]Return@4aff0e]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0x67f: ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x69a: ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessEvent[Probe[main.condNilPtrStruct]@4afe8e]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	PrepareEventRoot 1c 01 00 00 19 00 00 00 
-	Call 7f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[0]]
-	Call 9a 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4afe8e.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	Return 
-// 0x6d0: ProcessEvent[Probe[main.condNilPtrStruct]Return@4aff0e]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x6da: ProcessCondition[Probe[main.condOnly]@0x4affea]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6f7: ProcessExpression[Probe[main.condOnly]@0x4affea.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x70d: ProcessExpression[Probe[main.condOnly]@0x4affea.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x72f: ProcessEvent[Probe[main.condOnly]@4affea]
-	Call da 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4affea]
+// 0x708: ProcessEvent[Probe[main.condOnly]@4b05ca]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
-	Call f7 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4affea.expr[0]]
-	Call 0d 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4affea.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
-// 0x748: ProcessEvent[Probe[main.condOnly]Return@4b005a]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@4b063a]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x752: ProcessExpression[Probe[main.condOnly]@0x4affea.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x768: ProcessExpression[Probe[main.condOnly]@0x4affea.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x78a: ProcessEvent[Probe[main.condOnly]@4affea]
+// 0x763: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
-	Call 52 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4affea.expr[0]]
-	Call 68 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4affea.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
-// 0x79e: ProcessEvent[Probe[main.condOnly]Return@4b005a]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@4b063a]
 	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
-// 0x7a8: ProcessCondition[Probe[main.condPtrStructArg]@0x4afd2e]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7ca: ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x7ec: ProcessEvent[Probe[main.condPtrStructArg]@4afd2e]
-	Call a8 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4afd2e]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call ca 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
-// 0x800: ProcessEvent[Probe[main.condPtrStructArg]Return@4afe45]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x80a: ProcessCondition[Probe[main.condPtrStructArg]@0x4afd2e]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x82e: ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x850: ProcessEvent[Probe[main.condPtrStructArg]@4afd2e]
-	Call 0a 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4afd2e]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 2e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
-// 0x864: ProcessEvent[Probe[main.condPtrStructArg]Return@4afe45]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x889: ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x8ab: ProcessEvent[Probe[main.condPtrStructArg]@4afd2e]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	PrepareEventRoot 18 01 00 00 19 00 00 00 
-	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[0]]
-	Call 89 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4afd2e.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	Return 
-// 0x8bf: ProcessEvent[Probe[main.condPtrStructArg]Return@4afe45]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0x8c9: ProcessCondition[Probe[main.condReturnAndLocal]@0x4aff4a]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8e6: ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8fc: ProcessEvent[Probe[main.condReturnAndLocal]@4aff4a]
-	Call c9 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4aff4a]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	PrepareEventRoot 1e 01 00 00 09 00 00 00 
-	Call e6 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Return 
-// 0x910: ProcessEvent[Probe[main.condReturnAndLocal]Return@4affb5]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
 	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0x91a: ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x930: ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x946: ProcessEvent[Probe[main.condReturnAndLocal]@4aff4a]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
 	PrepareEventRoot 20 01 00 00 11 00 00 00 
-	Call 1a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[0]]
-	Call 30 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4aff4a.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	Return 
-// 0x95a: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4affb5.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x970: ProcessEvent[Probe[main.condReturnAndLocal]Return@4affb5]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
 	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call 5a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4affb5.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	Return 
-// 0x97f: ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0x958: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9a1: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x9c3: ProcessEvent[Probe[main.condString]@4afb2a]
-	Call 7f 09 00 00 // ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0x99c: ProcessEvent[Probe[main.condString]@4b010a]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call a1 09 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
-// 0x9d7: ProcessEvent[Probe[main.condString]Return@4afb9f]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0x9e1: ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9fe: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa20: ProcessEvent[Probe[main.condString]@4afb2a]
-	Call e1 09 00 00 // ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0x9f9: ProcessEvent[Probe[main.condString]@4b010a]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 02 01 00 00 11 00 00 00 
-	Call fe 09 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
-// 0xa34: ProcessEvent[Probe[main.condString]Return@4afb9f]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0xa3e: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa60: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa82: ProcessEvent[Probe[main.condString]@4afb2a]
+// 0xa5b: ProcessEvent[Probe[main.condString]@4b010a]
 	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call 3e 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
-	Call 60 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xa96: ProcessEvent[Probe[main.condString]Return@4afb9f]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0xaa0: ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0xa79: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xac2: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xae4: ProcessExpression[Probe[main.condString]@0x4afb2a.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xb06: ProcessEvent[Probe[main.condString]@4afb2a]
-	Call a0 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4afb2a]
+// 0xadf: ProcessEvent[Probe[main.condString]@4b010a]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 06 01 00 00 21 00 00 00 
-	Call c2 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[0]]
-	Call e4 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4afb2a.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xb1f: ProcessEvent[Probe[main.condString]Return@4afb9f]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xb29: ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb48: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xb6a: ProcessEvent[Probe[main.condStructArg]@4afbee]
-	Call 29 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 48 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xb7e: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xb88: ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xba4: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xbc6: ProcessEvent[Probe[main.condStructArg]@4afbee]
-	Call 88 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call a4 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xbda: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xbe4: ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc07: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xc29: ProcessEvent[Probe[main.condStructArg]@4afbee]
-	Call e4 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 07 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc3d: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xc47: ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc66: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xc88: ProcessEvent[Probe[main.condStructArg]@4afbee]
-	Call 47 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call 66 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc9c: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xca6: ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcc7: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xce9: ProcessEvent[Probe[main.condStructArg]@4afbee]
-	Call a6 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4afbee]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call c7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xcfd: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xd07: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 3e 15 00 00 // ProcessType[main.condFields]
+	Call 17 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd28: ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xd4a: ProcessEvent[Probe[main.condStructArg]@4afbee]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	PrepareEventRoot 12 01 00 00 61 00 00 00 
-	Call 07 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[0]]
-	Call 28 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4afbee.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	Return 
-// 0xd5e: ProcessEvent[Probe[main.condStructArg]Return@4afcef]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xd68: ProcessCondition[Probe[main.condUint16]@0x4af6aa]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd7f: ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xda1: ProcessEvent[Probe[main.condUint16]@4af6aa]
-	Call 68 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4af6aa]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@4afc8a]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	PrepareEventRoot ea 00 00 00 11 00 00 00 
-	Call 7f 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	Return 
-// 0xdb5: ProcessEvent[Probe[main.condUint16]Return@4af71a]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdbf: ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdd5: ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xdf7: ProcessEvent[Probe[main.condUint16]@4af6aa]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	PrepareEventRoot ec 00 00 00 13 00 00 00 
-	Call bf 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[0]]
-	Call d5 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4af6aa.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	Return 
-// 0xe0b: ProcessEvent[Probe[main.condUint16]Return@4af71a]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe15: ProcessCondition[Probe[main.condUint32]@0x4af76a]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe2e: ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xe50: ProcessEvent[Probe[main.condUint32]@4af76a]
-	Call 15 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4af76a]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@4afd4a]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call 2e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	Return 
-// 0xe64: ProcessEvent[Probe[main.condUint32]Return@4af7da]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xe6e: ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe84: ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xea6: ProcessEvent[Probe[main.condUint32]@4af76a]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	PrepareEventRoot f0 00 00 00 15 00 00 00 
-	Call 6e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[0]]
-	Call 84 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4af76a.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	Return 
-// 0xeba: ProcessEvent[Probe[main.condUint32]Return@4af7da]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xec4: ProcessCondition[Probe[main.condUint64]@0x4af82a]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xee1: ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xf03: ProcessEvent[Probe[main.condUint64]@4af82a]
-	Call c4 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4af82a]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@4afe0a]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call e1 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	Return 
-// 0xf17: ProcessEvent[Probe[main.condUint64]Return@4af89a]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf21: ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf37: ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xf59: ProcessEvent[Probe[main.condUint64]@4af82a]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	PrepareEventRoot f4 00 00 00 19 00 00 00 
-	Call 21 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[0]]
-	Call 37 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4af82a.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	Return 
-// 0xf6d: ProcessEvent[Probe[main.condUint64]Return@4af89a]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xf77: ProcessCondition[Probe[main.condUint8]@0x4af5ea]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf8d: ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xfaf: ProcessEvent[Probe[main.condUint8]@4af5ea]
-	Call 77 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4af5ea]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call 8d 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0xfc3: ProcessEvent[Probe[main.condUint8]Return@4af65a]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0xfcd: ProcessCondition[Probe[main.condUint8]@0x4af5ea]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,557 +1008,557 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfe3: ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1005: ProcessEvent[Probe[main.condUint8]@4af5ea]
-	Call cd 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4af5ea]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e6 00 00 00 11 00 00 00 
-	Call e3 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0x1019: ProcessEvent[Probe[main.condUint8]Return@4af65a]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x1023: ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1039: ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x105b: ProcessEvent[Probe[main.condUint8]@4af5ea]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@4afbca]
 	PrepareEventRoot e8 00 00 00 12 00 00 00 
-	Call 23 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[0]]
-	Call 39 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4af5ea.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	Return 
-// 0x106f: ProcessEvent[Probe[main.condUint8]Return@4af65a]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0x1079: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1089: ProcessEvent[Probe[main.inlined]@4ae4ee]
+// 0x1062: ProcessEvent[Probe[main.inlined]@4ae4ee]
 	PrepareEventRoot 2a 01 00 00 09 00 00 00 
-	Call 79 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	Return 
-// 0x1098: ProcessExpression[Probe[main.inlined]@0x4af0aa.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ae: ProcessEvent[Probe[main.inlined]@4af0aa]
+// 0x1087: ProcessEvent[Probe[main.inlined]@4af68a]
 	PrepareEventRoot 2a 01 00 00 09 00 00 00 
-	Call 98 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af0aa.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	Return 
-// 0x10bd: ProcessEvent[Probe[main.inlined]Return@4af0ea]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@4af6ca]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x10c7: ProcessExpression[Probe[main.intArg]@0x4aed8a.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10dd: ProcessEvent[Probe[main.intArg]@4aed8a]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@4af36a]
 	PrepareEventRoot bb 00 00 00 09 00 00 00 
-	Call c7 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4aed8a.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	Return 
-// 0x10ec: ProcessEvent[Probe[main.intArg]Return@4aedca]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4af3aa]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x10f6: ProcessExpression[Probe[main.intArrayArg]@0x4aef0a.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x1112: ProcessEvent[Probe[main.intArrayArg]@4aef0a]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call f6 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4aef0a.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	Return 
-// 0x1121: ProcessEvent[Probe[main.intArrayArg]Return@4aef56]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x112b: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af080.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 5e 14 00 00 // ProcessType[[3]string]
+	Call 37 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x114c: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af080]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
 	PrepareEventRoot cb 00 00 00 31 00 00 00 
-	Call 2b 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af080.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	Return 
-// 0x115b: ProcessExpression[Probe[main.intSliceArg]@0x4aee8a.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b4 14 00 00 // ProcessType[[]int]
+	Call 8d 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1184: ProcessEvent[Probe[main.intSliceArg]@4aee8a]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4af46a]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call 5b 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4aee8a.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	Return 
-// 0x1193: ProcessEvent[Probe[main.intSliceArg]Return@4aeecf]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x119d: ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x11bf: ProcessEvent[Probe[main.stringArg]@4aee0a]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 9d 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.stringArg]Return@4aee4f]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessEvent[Probe[main.stringArg]@4aee0a]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x11e2: ProcessEvent[Probe[main.stringArg]Return@4aee4f]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x11ec: ProcessExpression[Probe[main.mapArg]@0x4af16a.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7f 15 00 00 // ProcessType[map[string]int]
+	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1207: ProcessExpression[Probe[main.mapArg]@0x4af16a.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 7f 15 00 00 // ProcessType[map[string]int]
+	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1222: ProcessEvent[Probe[main.mapArg]@4af16a]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@4af74a]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
-	Call ec 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af16a.expr[0]]
-	Call 07 12 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af16a.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	Return 
-// 0x1236: ProcessEvent[Probe[main.mapArg]Return@4af19f]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4af77f]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1240: ProcessEvent[Probe[main.noArgs]@4af28a]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@4af86a]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x124a: ProcessEvent[Probe[main.noArgs]Return@4af2c6]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
 	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
-// 0x1254: ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1276: ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1298: ProcessEvent[Probe[main.stringArg]@4aee0a]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c1 00 00 00 21 00 00 00 
-	Call 54 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[0]]
-	Call 76 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4aee0a.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	Return 
-// 0x12ac: ProcessEvent[Probe[main.stringArg]Return@4aee4f]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x12b6: ProcessExpression[Probe[main.stringArrayArg]@0x4af00a.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 5e 14 00 00 // ProcessType[[3]string]
+	Call 37 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12d7: ProcessEvent[Probe[main.stringArrayArg]@4af00a]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call b6 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af00a.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	Return 
-// 0x12e6: ProcessEvent[Probe[main.stringArrayArg]Return@4af056]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x12f0: ProcessExpression[Probe[main.stringSliceArg]@0x4aef8a.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e2 14 00 00 // ProcessType[[]string]
+	Call bb 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1319: ProcessEvent[Probe[main.stringSliceArg]@4aef8a]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
 	PrepareEventRoot c7 00 00 00 19 00 00 00 
-	Call f0 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4aef8a.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	Return 
-// 0x1328: ProcessEvent[Probe[main.stringSliceArg]Return@4aefcf]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1332: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b03d6]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x133c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b05a4.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 64 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1357: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b05a4]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
 	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 3c 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b05a4.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	Return 
-// 0x1366: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 82 00 00 00 
 	Return 
-// 0x136c: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer b9 00 00 00 
 	Return 
-// 0x1372: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1378: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x137e: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1384: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x138a: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1390: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1396: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x139c: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*main.bigStruct]
+// 0x1387: ProcessType[*main.bigStruct]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*main.condFields]
+// 0x138d: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*runtime._defer]
+// 0x1393: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*runtime._panic]
+// 0x1399: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime.cgoCallers]
+// 0x139f: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime.coro]
+// 0x13a5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.g]
+// 0x13ab: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.m]
+// 0x13b1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.p]
+// 0x13b7: ProcessType[*runtime.p]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.sudog]
+// 0x13bd: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.synctestBubble]
+// 0x13c3: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.timer]
+// 0x13c9: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*runtime.traceBuf]
+// 0x13cf: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*string]
+// 0x13d5: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1402: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13db: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x1408: ProcessType[*table<string,int>]
+// 0x13e1: ProcessType[*table<string,int>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<string,main.bigStruct>]
+// 0x13e7: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1414: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13ed: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x141a: ProcessType[*uint]
+// 0x13f3: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1420: ProcessType[*uint16]
+// 0x13f9: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint32]
+// 0x13ff: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint64]
+// 0x1405: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uint8]
+// 0x140b: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1438: ProcessType[*uintptr]
+// 0x1411: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x143e: ProcessType[[2]*runtime.traceBuf]
+// 0x1417: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call f6 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call cf 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x144e: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1427: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 3e 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x145e: ProcessType[[3]string]
+// 0x1437: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x146e: ProcessType[[]*runtime.p]
+// 0x1447: ProcessType[[]*runtime.p]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1478: ProcessType[[]*runtime.p.array]
+// 0x1451: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call de 13 00 00 // ProcessType[*runtime.p]
+	Call b7 13 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1484: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x145d: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 02 14 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call db 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1490: ProcessType[[]*table<string,int>.array]
+// 0x1469: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 08 14 00 00 // ProcessType[*table<string,int>]
+	Call e1 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x149c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1475: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call e7 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14a8: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1481: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 14 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ed 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14b4: ProcessType[[]int]
+// 0x148d: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x14be: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1497: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call c1 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 9a 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ca: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x14a3: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call cc 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a5 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14d6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x14af: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call d7 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b0 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14e2: ProcessType[[]string]
+// 0x14bb: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x14ec: ProcessType[[]string.array]
+// 0x14c5: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14f8: ProcessType[[]uint8]
+// 0x14d1: ProcessType[[]uint8]
 	ProcessSlice 86 00 00 00 01 00 00 00 
 	Return 
-// 0x1502: ProcessType[[]uintptr]
+// 0x14db: ProcessType[[]uintptr]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x150c: ProcessType[error]
+// 0x14e5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x150e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14e7: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b8 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x151a: ProcessType[groupReference<string,int>]
+// 0x14f3: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 98 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1526: ProcessType[groupReference<string,main.bigStruct>]
+// 0x14ff: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a2 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1532: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x150b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x153e: ProcessType[main.condFields]
+// 0x1517: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1549: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1522: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b7 00 00 00 b3 00 00 00 10 18 
 	Return 
-// 0x1555: ProcessType[map<string,int>]
+// 0x152e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 97 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x1561: ProcessType[map<string,main.bigStruct>]
+// 0x153a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a1 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x156d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1546: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 a6 00 00 00 10 18 
 	Return 
-// 0x1579: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1552: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x157f: ProcessType[map[string]int]
+// 0x1558: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1585: ProcessType[map[string]main.bigStruct]
+// 0x155e: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x158b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1564: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1591: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x156a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call e2 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bb 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15a1: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x157a: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call f2 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cb 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x15b1: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x158a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call f8 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d1 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15c1: ProcessType[noalg.map.group[string]int]
+// 0x159a: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call a1 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 7a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15cc: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x15a5: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 6a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15d7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x15b0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15e2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call ed 16 00 00 // ProcessType[string]
+// 0x15bb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c6 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ae 13 00 00 // ProcessType[*main.bigStruct]
+	Call 87 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15f2: ProcessType[noalg.struct { key string; elem int }]
-	Call ed 16 00 00 // ProcessType[string]
+// 0x15cb: ProcessType[noalg.struct { key string; elem int }]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x15f8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15d1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 79 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 52 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1603: ProcessType[runtime.g]
+// 0x15dc: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c0 13 00 00 // ProcessType[*runtime._panic]
+	Call 99 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 13 00 00 // ProcessType[*runtime._defer]
+	Call 93 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call f8 14 00 00 // ProcessType[[]uint8]
+	Call d1 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 7e 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.sudog]
+	Call bd 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.timer]
+	Call c9 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime.coro]
+	Call a5 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call c3 13 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1668: ProcessType[runtime.m]
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+// 0x1641: ProcessType[runtime.m]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 6e 14 00 00 // ProcessType[[]*runtime.p]
+	Call 47 14 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call d2 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call ab 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call dd 16 00 00 // ProcessType[runtime.mTraceState]
+	Call b6 16 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16d2: ProcessType[runtime.mLockProfile]
+// 0x16ab: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16dd: ProcessType[runtime.mTraceState]
+// 0x16b6: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call 27 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16ed: ProcessType[string]
+// 0x16c6: ProcessType[string]
 	ProcessString 84 00 00 00 
 	Return 
-// 0x16f3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16cc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0e 15 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16fe: ProcessType[table<string,int>]
+// 0x16d7: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1a 15 00 00 // ProcessType[groupReference<string,int>]
+	Call f3 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1709: ProcessType[table<string,main.bigStruct>]
+// 0x16e2: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 26 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call ff 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1714: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x16ed: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 32 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0b 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1832,31 +1826,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5170
+ID: 5 Len: 8 Enqueue: 5131
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5869
+ID: 9 Len: 16 Enqueue: 5830
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4996
+ID: 11 Len: 8 Enqueue: 4957
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 5388
+ID: 13 Len: 16 Enqueue: 5349
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5176
-ID: 20 Len: 8 Enqueue: 5026
-ID: 21 Len: 8 Enqueue: 5158
-ID: 22 Len: 440 Enqueue: 5635
+ID: 19 Len: 8 Enqueue: 5137
+ID: 20 Len: 8 Enqueue: 4987
+ID: 21 Len: 8 Enqueue: 5119
+ID: 22 Len: 440 Enqueue: 5596
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5056
+ID: 24 Len: 8 Enqueue: 5017
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5050
+ID: 26 Len: 8 Enqueue: 5011
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5080
-ID: 29 Len: 1816 Enqueue: 5736
+ID: 28 Len: 8 Enqueue: 5041
+ID: 29 Len: 1816 Enqueue: 5697
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1865,48 +1859,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5368
-ID: 39 Len: 8 Enqueue: 4990
+ID: 38 Len: 24 Enqueue: 5329
+ID: 39 Len: 8 Enqueue: 4951
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5092
+ID: 41 Len: 8 Enqueue: 5053
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5378
-ID: 44 Len: 8 Enqueue: 5104
+ID: 43 Len: 24 Enqueue: 5339
+ID: 44 Len: 8 Enqueue: 5065
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5068
+ID: 47 Len: 8 Enqueue: 5029
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5098
+ID: 49 Len: 8 Enqueue: 5059
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5074
+ID: 55 Len: 8 Enqueue: 5035
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 5230
+ID: 62 Len: 24 Enqueue: 5191
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 5086
-ID: 65 Len: 8 Enqueue: 5062
+ID: 64 Len: 8 Enqueue: 5047
+ID: 65 Len: 8 Enqueue: 5023
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 5842
+ID: 70 Len: 56 Enqueue: 5803
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5853
+ID: 75 Len: 56 Enqueue: 5814
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 5198
-ID: 78 Len: 16 Enqueue: 5182
-ID: 79 Len: 8 Enqueue: 5110
+ID: 77 Len: 32 Enqueue: 5159
+ID: 78 Len: 16 Enqueue: 5143
+ID: 79 Len: 8 Enqueue: 5071
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -1922,43 +1916,43 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 5116
+ID: 95 Len: 8 Enqueue: 5077
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 5014
-ID: 99 Len: 8 Enqueue: 5020
-ID: 100 Len: 8 Enqueue: 5032
-ID: 101 Len: 8 Enqueue: 5164
-ID: 102 Len: 8 Enqueue: 5002
+ID: 98 Len: 8 Enqueue: 4975
+ID: 99 Len: 8 Enqueue: 4981
+ID: 100 Len: 8 Enqueue: 4993
+ID: 101 Len: 8 Enqueue: 5125
+ID: 102 Len: 8 Enqueue: 4963
 ID: 103 Len: 2 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 5008
-ID: 105 Len: 8 Enqueue: 5146
-ID: 106 Len: 8 Enqueue: 5152
-ID: 107 Len: 24 Enqueue: 5300
+ID: 104 Len: 8 Enqueue: 4969
+ID: 105 Len: 8 Enqueue: 5107
+ID: 106 Len: 8 Enqueue: 5113
+ID: 107 Len: 24 Enqueue: 5261
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 5346
-ID: 110 Len: 48 Enqueue: 5214
-ID: 111 Len: 8 Enqueue: 5503
+ID: 109 Len: 24 Enqueue: 5307
+ID: 110 Len: 48 Enqueue: 5175
+ID: 111 Len: 8 Enqueue: 5464
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5461
+ID: 113 Len: 48 Enqueue: 5422
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 5128
-ID: 116 Len: 8 Enqueue: 5509
+ID: 115 Len: 8 Enqueue: 5089
+ID: 116 Len: 8 Enqueue: 5470
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5473
+ID: 118 Len: 48 Enqueue: 5434
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5134
-ID: 121 Len: 80 Enqueue: 5438
+ID: 120 Len: 8 Enqueue: 5095
+ID: 121 Len: 80 Enqueue: 5399
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 5044
-ID: 124 Len: 8 Enqueue: 5515
+ID: 123 Len: 8 Enqueue: 5005
+ID: 124 Len: 8 Enqueue: 5476
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5485
+ID: 126 Len: 48 Enqueue: 5446
 ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5140
-ID: 129 Len: 8 Enqueue: 4966
-ID: 130 Len: 8 Enqueue: 4972
-ID: 131 Len: 8 Enqueue: 4984
+ID: 128 Len: 8 Enqueue: 5101
+ID: 129 Len: 8 Enqueue: 4927
+ID: 130 Len: 8 Enqueue: 4933
+ID: 131 Len: 8 Enqueue: 4945
 ID: 132 Len: 1 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 1 Enqueue: 0
@@ -1966,53 +1960,53 @@ ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 8 Enqueue: 5240
+ID: 139 Len: 8 Enqueue: 5201
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 5356
+ID: 143 Len: 16 Enqueue: 5317
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 32 Enqueue: 5886
-ID: 146 Len: 16 Enqueue: 5402
+ID: 145 Len: 32 Enqueue: 5847
+ID: 146 Len: 16 Enqueue: 5363
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 5569
-ID: 149 Len: 192 Enqueue: 5537
-ID: 150 Len: 24 Enqueue: 5618
-ID: 151 Len: 8 Enqueue: 5264
-ID: 152 Len: 200 Enqueue: 5310
-ID: 153 Len: 32 Enqueue: 5897
-ID: 154 Len: 16 Enqueue: 5414
+ID: 148 Len: 200 Enqueue: 5530
+ID: 149 Len: 192 Enqueue: 5498
+ID: 150 Len: 24 Enqueue: 5579
+ID: 151 Len: 8 Enqueue: 5225
+ID: 152 Len: 200 Enqueue: 5271
+ID: 153 Len: 32 Enqueue: 5858
+ID: 154 Len: 16 Enqueue: 5375
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 5580
-ID: 157 Len: 192 Enqueue: 5521
-ID: 158 Len: 24 Enqueue: 5602
-ID: 159 Len: 8 Enqueue: 5038
+ID: 156 Len: 200 Enqueue: 5541
+ID: 157 Len: 192 Enqueue: 5482
+ID: 158 Len: 24 Enqueue: 5563
+ID: 159 Len: 8 Enqueue: 4999
 ID: 160 Len: 184 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 5276
-ID: 162 Len: 200 Enqueue: 5322
-ID: 163 Len: 32 Enqueue: 5908
-ID: 164 Len: 16 Enqueue: 5426
+ID: 161 Len: 8 Enqueue: 5237
+ID: 162 Len: 200 Enqueue: 5283
+ID: 163 Len: 32 Enqueue: 5869
+ID: 164 Len: 16 Enqueue: 5387
 ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 136 Enqueue: 5591
-ID: 167 Len: 128 Enqueue: 5553
-ID: 168 Len: 16 Enqueue: 5624
-ID: 169 Len: 8 Enqueue: 5497
+ID: 166 Len: 136 Enqueue: 5552
+ID: 167 Len: 128 Enqueue: 5514
+ID: 168 Len: 16 Enqueue: 5585
+ID: 169 Len: 8 Enqueue: 5458
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 48 Enqueue: 5449
+ID: 171 Len: 48 Enqueue: 5410
 ID: 172 Len: 8 Enqueue: 0
-ID: 173 Len: 8 Enqueue: 5122
-ID: 174 Len: 8 Enqueue: 5288
-ID: 175 Len: 136 Enqueue: 5334
-ID: 176 Len: 32 Enqueue: 5875
-ID: 177 Len: 16 Enqueue: 5390
+ID: 173 Len: 8 Enqueue: 5083
+ID: 174 Len: 8 Enqueue: 5249
+ID: 175 Len: 136 Enqueue: 5295
+ID: 176 Len: 32 Enqueue: 5836
+ID: 177 Len: 16 Enqueue: 5351
 ID: 178 Len: 8 Enqueue: 0
 ID: 179 Len: 136 Enqueue: 0
 ID: 180 Len: 128 Enqueue: 0
 ID: 181 Len: 16 Enqueue: 0
 ID: 182 Len: 8 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 5252
+ID: 183 Len: 8 Enqueue: 5213
 ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 8 Enqueue: 4978
+ID: 185 Len: 8 Enqueue: 4939
 ID: 186 Len: 128 Enqueue: 0
 ID: 187 Len: 9 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
@@ -2122,7 +2116,7 @@ ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 25 Enqueue: 0
 ID: 293 Len: 0 Enqueue: 0
 ID: 294 Len: 17 Enqueue: 0
-ID: 295 Len: 33 Enqueue: 0
+ID: 295 Len: 25 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
 ID: 297 Len: 9 Enqueue: 0
 ID: 298 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae726]
-	PrepareEventRoot 73 01 00 00 11 00 00 00 
+	PrepareEventRoot 83 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae770]
-	PrepareEventRoot 74 01 00 00 09 00 00 00 
+	PrepareEventRoot 84 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae770.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call be 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call be 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4af7b3]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4b004a]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4afeca]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4aff8a]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4af98a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af98a]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4af98a]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4afb0a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af8ca]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
-	PrepareEventRoot 29 01 00 00 11 00 00 00 
+	PrepareEventRoot 2d 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4b06a1]
-	PrepareEventRoot 2a 01 00 00 19 00 00 00 
+	PrepareEventRoot 2e 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
-	PrepareEventRoot 1d 01 00 00 11 00 00 00 
+	PrepareEventRoot 21 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
-	PrepareEventRoot 1f 01 00 00 19 00 00 00 
+	PrepareEventRoot 23 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@4b063a]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4b05ca]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2b 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@4b063a]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
-	PrepareEventRoot 17 01 00 00 11 00 00 00 
+	PrepareEventRoot 1b 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	PrepareEventRoot 1d 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
-	PrepareEventRoot 1b 01 00 00 19 00 00 00 
+	PrepareEventRoot 1f 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	PrepareEventRoot 25 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
-	PrepareEventRoot 23 01 00 00 11 00 00 00 
+	PrepareEventRoot 27 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
-	PrepareEventRoot 24 01 00 00 09 00 00 00 
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4b010a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4b010a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@4b010a]
+	PrepareEventRoot 07 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@4b017f]
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@4b010a]
+	PrepareEventRoot 09 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@4b017f]
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 26 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@4b010a]
-	PrepareEventRoot 07 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@4b010a]
+	PrepareEventRoot 0b 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@4b017f]
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0xb11: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@4b010a]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
-	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@4b010a]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
+	PrepareEventRoot 0d 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@4b017f]
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[main.condFields]
+	Call 49 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	PrepareEventRoot 15 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	PrepareEventRoot 19 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@4afc8a]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@4afc8a]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@4afc8a]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@4afd4a]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@4afd4a]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4afdba]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@4afd4a]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4afdba]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@4afe0a]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@4afe0a]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@4afe0a]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@4afbca]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e7 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@4afbca]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@4afbca]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@4afbca]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@4ae4ee]
-	PrepareEventRoot 71 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@4ae4ee]
+	PrepareEventRoot 81 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@4af68a]
-	PrepareEventRoot 71 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4af6ca]
-	PrepareEventRoot 72 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@4af36a]
+// 0x111f: ProcessEvent[Probe[main.inlined]@4af68a]
+	PrepareEventRoot 81 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@4af6ca]
+	PrepareEventRoot 82 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@4af36a]
 	PrepareEventRoot be 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4af3aa]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@4af3aa]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 4a 1e 00 00 // ProcessType[[3]string]
+	Call 69 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4af46a]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@4af46a]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4b1213]
-	PrepareEventRoot 67 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+	PrepareEventRoot 77 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
-	PrepareEventRoot 68 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+	PrepareEventRoot 78 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[main.condFields]
+	Call 49 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
-	PrepareEventRoot 6b 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+	PrepareEventRoot 7b 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
-	PrepareEventRoot 6c 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+	PrepareEventRoot 7c 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4b1213]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
-	PrepareEventRoot 6a 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+	PrepareEventRoot 7a 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
-	PrepareEventRoot 6e 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+	PrepareEventRoot 7e 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
-	PrepareEventRoot 3f 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 4f 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	PrepareEventRoot 41 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
-	PrepareEventRoot 43 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	PrepareEventRoot 53 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	PrepareEventRoot 47 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
-	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 59 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*string]
+	Call 07 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
-	PrepareEventRoot 4b 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 5b 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.lenFields]
+	Call bf 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 5f 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 6f 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 60 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 70 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 63 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 73 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 75 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 66 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 76 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
-	PrepareEventRoot 35 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+	PrepareEventRoot 41 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 43 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	PrepareEventRoot 37 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
-	PrepareEventRoot 39 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+	PrepareEventRoot 47 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	PrepareEventRoot 3b 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	PrepareEventRoot 3d 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 4b 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 2f 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 31 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 33 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 35 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 37 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@4b09d3]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 39 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
-	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 3b 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@4b09d3]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@4b09d3]
-	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 3f 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 35 1f 00 00 // ProcessType[main.lenFields]
+	Call 54 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 4d 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 5d 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 4f 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 51 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 63 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 57 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 67 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
-	PrepareEventRoot 59 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 69 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
-	PrepareEventRoot 5b 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 6b 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,484 +1812,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
-	PrepareEventRoot 5d 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 6d 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@4af74a]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@4af74a]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4af77f]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@4af77f]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@4af86a]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@4af86a]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 4a 1e 00 00 // ProcessType[[3]string]
+	Call 69 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ce 1e 00 00 // ProcessType[[]string]
+	Call ed 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
-	PrepareEventRoot 6f 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
+	PrepareEventRoot 7f 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call c4 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
-	PrepareEventRoot 70 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
+	PrepareEventRoot 80 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*main.bigStruct]
+// 0x1fb3: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.condFields]
+// 0x1fb9: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.lenFields]
+// 0x1fbf: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*runtime._defer]
+// 0x1fc5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._panic]
+// 0x1fcb: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime.cgoCallers]
+// 0x1fd1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.coro]
+// 0x1fd7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.g]
+// 0x1fdd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.m]
+// 0x1fe3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.p]
+// 0x1fe9: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.sudog]
+// 0x1fef: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.synctestBubble]
+// 0x1ff5: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.timer]
+// 0x1ffb: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.traceBuf]
+// 0x2001: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*string]
+// 0x2007: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x200d: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*table<string,int>]
+// 0x2013: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<string,main.bigStruct>]
+// 0x2019: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x201f: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint]
+// 0x2025: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint16]
+// 0x202b: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint32]
+// 0x2031: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint64]
+// 0x2037: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint8]
+// 0x203d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uintptr]
+// 0x2043: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
+// 0x2049: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 01 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e3a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2059: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 49 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e4a: ProcessType[[3]string]
+// 0x2069: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e5a: ProcessType[[]*runtime.p]
+// 0x2079: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1e64: ProcessType[[]*runtime.p.array]
+// 0x2083: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call ca 1d 00 00 // ProcessType[*runtime.p]
+	Call e9 1f 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e70: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x208f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ee 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 0d 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7c: ProcessType[[]*table<string,int>.array]
+// 0x209b: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f4 1d 00 00 // ProcessType[*table<string,int>]
+	Call 13 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e88: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x20a7: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 19 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e94: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x20b3: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 00 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1f 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]int]
+// 0x20bf: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1eaa: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20c9: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call db 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call fa 21 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20d5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call e6 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 05 22 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ec2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20e1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call f1 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 10 22 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ece: ProcessType[[]string]
+// 0x20ed: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1ed8: ProcessType[[]string.array]
+// 0x20f7: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ee4: ProcessType[[]uint8]
+// 0x2103: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1eee: ProcessType[[]uintptr]
+// 0x210d: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1ef8: ProcessType[error]
+// 0x2117: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1efa: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x2119: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f06: ProcessType[groupReference<string,int>]
+// 0x2125: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f12: ProcessType[groupReference<string,main.bigStruct>]
+// 0x2131: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f1e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x213d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f2a: ProcessType[main.condFields]
+// 0x2149: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f35: ProcessType[main.lenFields]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x2154: ProcessType[main.lenFields]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*string]
+	Call 07 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f63: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x2182: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1f6f: ProcessType[map<string,int>]
+// 0x218e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1f7b: ProcessType[map<string,main.bigStruct>]
+// 0x219a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1f87: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x21a6: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1f93: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21b2: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1f99: ProcessType[map[string]int]
+// 0x21b8: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1f9f: ProcessType[map[string]main.bigStruct]
+// 0x21be: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1fa5: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21c4: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1fab: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21ca: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call fc 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 1b 22 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fbb: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21da: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 0c 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 2b 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1fcb: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21ea: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 12 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 31 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fdb: ProcessType[noalg.map.group[string]int]
+// 0x21fa: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call bb 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call da 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1fe6: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x2205: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call ab 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ca 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ff1: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x2210: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call cb 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call ea 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1ffc: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x221b: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b3 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x200c: ProcessType[noalg.struct { key string; elem int }]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x222b: ProcessType[noalg.struct { key string; elem int }]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x2012: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2231: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call b2 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x201d: ProcessType[runtime.g]
+// 0x223c: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._panic]
+	Call cb 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*runtime._defer]
+	Call c5 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call e4 1e 00 00 // ProcessType[[]uint8]
+	Call 03 21 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.sudog]
+	Call ef 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.timer]
+	Call fb 1f 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.coro]
+	Call d7 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.synctestBubble]
+	Call f5 1f 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x2082: ProcessType[runtime.m]
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+// 0x22a1: ProcessType[runtime.m]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 5a 1e 00 00 // ProcessType[[]*runtime.p]
+	Call 79 20 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d1 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call ec 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call 0b 23 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f7 20 00 00 // ProcessType[runtime.mTraceState]
+	Call 16 23 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x20ec: ProcessType[runtime.mLockProfile]
+// 0x230b: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20f7: ProcessType[runtime.mTraceState]
+// 0x2316: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call 59 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x2107: ProcessType[string]
+// 0x2326: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x210d: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x232c: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call fa 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 21 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x2118: ProcessType[table<string,int>]
+// 0x2337: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 1f 00 00 // ProcessType[groupReference<string,int>]
+	Call 25 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x2123: ProcessType[table<string,main.bigStruct>]
+// 0x2342: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 12 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 31 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x212e: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x234d: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1e 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3d 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2434,31 +2557,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7710
+ID: 5 Len: 8 Enqueue: 8253
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8455
+ID: 9 Len: 16 Enqueue: 8998
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 7530
+ID: 11 Len: 8 Enqueue: 8073
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7928
+ID: 13 Len: 16 Enqueue: 8471
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 7716
-ID: 20 Len: 8 Enqueue: 7560
-ID: 21 Len: 8 Enqueue: 7698
-ID: 22 Len: 440 Enqueue: 8221
+ID: 19 Len: 8 Enqueue: 8259
+ID: 20 Len: 8 Enqueue: 8103
+ID: 21 Len: 8 Enqueue: 8241
+ID: 22 Len: 440 Enqueue: 8764
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7596
+ID: 24 Len: 8 Enqueue: 8139
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7590
+ID: 26 Len: 8 Enqueue: 8133
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7620
-ID: 29 Len: 1816 Enqueue: 8322
+ID: 28 Len: 8 Enqueue: 8163
+ID: 29 Len: 1816 Enqueue: 8865
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2467,48 +2590,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7908
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8451
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7632
+ID: 41 Len: 8 Enqueue: 8175
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7918
-ID: 44 Len: 8 Enqueue: 7644
+ID: 43 Len: 24 Enqueue: 8461
+ID: 44 Len: 8 Enqueue: 8187
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7608
+ID: 47 Len: 8 Enqueue: 8151
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 7638
+ID: 49 Len: 8 Enqueue: 8181
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 7614
+ID: 55 Len: 8 Enqueue: 8157
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 7770
+ID: 62 Len: 24 Enqueue: 8313
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 7626
-ID: 65 Len: 8 Enqueue: 7602
+ID: 64 Len: 8 Enqueue: 8169
+ID: 65 Len: 8 Enqueue: 8145
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 8428
+ID: 70 Len: 56 Enqueue: 8971
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 8439
+ID: 75 Len: 56 Enqueue: 8982
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 7738
-ID: 78 Len: 16 Enqueue: 7722
-ID: 79 Len: 8 Enqueue: 7650
+ID: 77 Len: 32 Enqueue: 8281
+ID: 78 Len: 16 Enqueue: 8265
+ID: 79 Len: 8 Enqueue: 8193
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2524,46 +2647,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 7656
+ID: 95 Len: 8 Enqueue: 8199
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 7548
-ID: 99 Len: 8 Enqueue: 7554
-ID: 100 Len: 8 Enqueue: 7566
-ID: 101 Len: 8 Enqueue: 7704
-ID: 102 Len: 8 Enqueue: 7536
+ID: 98 Len: 8 Enqueue: 8091
+ID: 99 Len: 8 Enqueue: 8097
+ID: 100 Len: 8 Enqueue: 8109
+ID: 101 Len: 8 Enqueue: 8247
+ID: 102 Len: 8 Enqueue: 8079
 ID: 103 Len: 2 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 7542
-ID: 105 Len: 8 Enqueue: 7686
-ID: 106 Len: 8 Enqueue: 7692
-ID: 107 Len: 24 Enqueue: 7840
+ID: 104 Len: 8 Enqueue: 8085
+ID: 105 Len: 8 Enqueue: 8229
+ID: 106 Len: 8 Enqueue: 8235
+ID: 107 Len: 24 Enqueue: 8383
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 7886
-ID: 110 Len: 48 Enqueue: 7754
-ID: 111 Len: 8 Enqueue: 8089
+ID: 109 Len: 24 Enqueue: 8429
+ID: 110 Len: 48 Enqueue: 8297
+ID: 111 Len: 8 Enqueue: 8632
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 8047
+ID: 113 Len: 48 Enqueue: 8590
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 7668
-ID: 116 Len: 8 Enqueue: 8095
+ID: 115 Len: 8 Enqueue: 8211
+ID: 116 Len: 8 Enqueue: 8638
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 8059
+ID: 118 Len: 48 Enqueue: 8602
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 7674
-ID: 121 Len: 80 Enqueue: 7978
+ID: 120 Len: 8 Enqueue: 8217
+ID: 121 Len: 80 Enqueue: 8521
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 7578
-ID: 124 Len: 72 Enqueue: 7989
-ID: 125 Len: 8 Enqueue: 7518
-ID: 126 Len: 8 Enqueue: 7584
-ID: 127 Len: 8 Enqueue: 8101
+ID: 123 Len: 8 Enqueue: 8121
+ID: 124 Len: 72 Enqueue: 8532
+ID: 125 Len: 8 Enqueue: 8061
+ID: 126 Len: 8 Enqueue: 8127
+ID: 127 Len: 8 Enqueue: 8644
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 8071
+ID: 129 Len: 48 Enqueue: 8614
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 7680
-ID: 132 Len: 8 Enqueue: 7494
-ID: 133 Len: 8 Enqueue: 7500
-ID: 134 Len: 8 Enqueue: 7512
+ID: 131 Len: 8 Enqueue: 8223
+ID: 132 Len: 8 Enqueue: 8037
+ID: 133 Len: 8 Enqueue: 8043
+ID: 134 Len: 8 Enqueue: 8055
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2571,53 +2694,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 7780
+ID: 142 Len: 8 Enqueue: 8323
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7896
+ID: 146 Len: 16 Enqueue: 8439
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 8472
-ID: 149 Len: 16 Enqueue: 7942
+ID: 148 Len: 32 Enqueue: 9015
+ID: 149 Len: 16 Enqueue: 8485
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 8155
-ID: 152 Len: 192 Enqueue: 8123
-ID: 153 Len: 24 Enqueue: 8204
-ID: 154 Len: 8 Enqueue: 7804
-ID: 155 Len: 200 Enqueue: 7850
-ID: 156 Len: 32 Enqueue: 8483
-ID: 157 Len: 16 Enqueue: 7954
+ID: 151 Len: 200 Enqueue: 8698
+ID: 152 Len: 192 Enqueue: 8666
+ID: 153 Len: 24 Enqueue: 8747
+ID: 154 Len: 8 Enqueue: 8347
+ID: 155 Len: 200 Enqueue: 8393
+ID: 156 Len: 32 Enqueue: 9026
+ID: 157 Len: 16 Enqueue: 8497
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 8166
-ID: 160 Len: 192 Enqueue: 8107
-ID: 161 Len: 24 Enqueue: 8188
-ID: 162 Len: 8 Enqueue: 7572
+ID: 159 Len: 200 Enqueue: 8709
+ID: 160 Len: 192 Enqueue: 8650
+ID: 161 Len: 24 Enqueue: 8731
+ID: 162 Len: 8 Enqueue: 8115
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 7816
-ID: 165 Len: 200 Enqueue: 7862
-ID: 166 Len: 32 Enqueue: 8494
-ID: 167 Len: 16 Enqueue: 7966
+ID: 164 Len: 8 Enqueue: 8359
+ID: 165 Len: 200 Enqueue: 8405
+ID: 166 Len: 32 Enqueue: 9037
+ID: 167 Len: 16 Enqueue: 8509
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 8177
-ID: 170 Len: 128 Enqueue: 8139
-ID: 171 Len: 16 Enqueue: 8210
-ID: 172 Len: 8 Enqueue: 8083
+ID: 169 Len: 136 Enqueue: 8720
+ID: 170 Len: 128 Enqueue: 8682
+ID: 171 Len: 16 Enqueue: 8753
+ID: 172 Len: 8 Enqueue: 8626
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 8035
+ID: 174 Len: 48 Enqueue: 8578
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 7662
-ID: 177 Len: 8 Enqueue: 7828
-ID: 178 Len: 136 Enqueue: 7874
-ID: 179 Len: 32 Enqueue: 8461
-ID: 180 Len: 16 Enqueue: 7930
+ID: 176 Len: 8 Enqueue: 8205
+ID: 177 Len: 8 Enqueue: 8371
+ID: 178 Len: 136 Enqueue: 8417
+ID: 179 Len: 32 Enqueue: 9004
+ID: 180 Len: 16 Enqueue: 8473
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 7792
+ID: 186 Len: 8 Enqueue: 8335
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 7506
+ID: 188 Len: 8 Enqueue: 8049
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
@@ -2692,13 +2815,13 @@ ID: 259 Len: 17 Enqueue: 0
 ID: 260 Len: 0 Enqueue: 0
 ID: 261 Len: 17 Enqueue: 0
 ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 33 Enqueue: 0
+ID: 263 Len: 2 Enqueue: 0
 ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 33 Enqueue: 0
+ID: 265 Len: 2 Enqueue: 0
 ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 17 Enqueue: 0
+ID: 267 Len: 33 Enqueue: 0
 ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
+ID: 269 Len: 33 Enqueue: 0
 ID: 270 Len: 0 Enqueue: 0
 ID: 271 Len: 17 Enqueue: 0
 ID: 272 Len: 0 Enqueue: 0
@@ -2706,81 +2829,81 @@ ID: 273 Len: 17 Enqueue: 0
 ID: 274 Len: 0 Enqueue: 0
 ID: 275 Len: 17 Enqueue: 0
 ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 97 Enqueue: 0
+ID: 277 Len: 17 Enqueue: 0
 ID: 278 Len: 0 Enqueue: 0
 ID: 279 Len: 17 Enqueue: 0
 ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
+ID: 281 Len: 97 Enqueue: 0
 ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 25 Enqueue: 0
+ID: 283 Len: 17 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
 ID: 285 Len: 17 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 25 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 9 Enqueue: 0
+ID: 289 Len: 17 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 17 Enqueue: 0
-ID: 292 Len: 9 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
+ID: 291 Len: 25 Enqueue: 0
+ID: 292 Len: 0 Enqueue: 0
+ID: 293 Len: 9 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 25 Enqueue: 0
-ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 17 Enqueue: 0
-ID: 298 Len: 25 Enqueue: 0
-ID: 299 Len: 17 Enqueue: 0
+ID: 295 Len: 17 Enqueue: 0
+ID: 296 Len: 9 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 0 Enqueue: 0
+ID: 299 Len: 25 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 9 Enqueue: 0
-ID: 302 Len: 0 Enqueue: 0
-ID: 303 Len: 17 Enqueue: 0
+ID: 301 Len: 17 Enqueue: 0
+ID: 302 Len: 25 Enqueue: 0
+ID: 303 Len: 2 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 9 Enqueue: 0
+ID: 305 Len: 2 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
-ID: 307 Len: 33 Enqueue: 0
+ID: 307 Len: 2 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
 ID: 309 Len: 17 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 9 Enqueue: 0
+ID: 311 Len: 2 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 17 Enqueue: 0
+ID: 313 Len: 9 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 9 Enqueue: 0
+ID: 315 Len: 17 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 41 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
-ID: 319 Len: 17 Enqueue: 0
+ID: 319 Len: 33 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 9 Enqueue: 0
+ID: 321 Len: 17 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 17 Enqueue: 0
+ID: 323 Len: 2 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
 ID: 325 Len: 9 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 25 Enqueue: 0
+ID: 327 Len: 17 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
 ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
-ID: 331 Len: 25 Enqueue: 0
+ID: 331 Len: 41 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 89 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
-ID: 335 Len: 9 Enqueue: 0
+ID: 335 Len: 2 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
 ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
-ID: 339 Len: 9 Enqueue: 0
+ID: 339 Len: 17 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
 ID: 341 Len: 9 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 9 Enqueue: 0
+ID: 343 Len: 25 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 17 Enqueue: 0
+ID: 345 Len: 9 Enqueue: 0
 ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 17 Enqueue: 0
+ID: 347 Len: 25 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 17 Enqueue: 0
+ID: 349 Len: 89 Enqueue: 0
 ID: 350 Len: 0 Enqueue: 0
-ID: 351 Len: 25 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0
 ID: 352 Len: 0 Enqueue: 0
 ID: 353 Len: 9 Enqueue: 0
 ID: 354 Len: 0 Enqueue: 0
@@ -2788,17 +2911,33 @@ ID: 355 Len: 9 Enqueue: 0
 ID: 356 Len: 0 Enqueue: 0
 ID: 357 Len: 9 Enqueue: 0
 ID: 358 Len: 0 Enqueue: 0
-ID: 359 Len: 25 Enqueue: 0
+ID: 359 Len: 9 Enqueue: 0
 ID: 360 Len: 0 Enqueue: 0
-ID: 361 Len: 0 Enqueue: 0
+ID: 361 Len: 17 Enqueue: 0
 ID: 362 Len: 0 Enqueue: 0
-ID: 363 Len: 97 Enqueue: 0
+ID: 363 Len: 17 Enqueue: 0
 ID: 364 Len: 0 Enqueue: 0
-ID: 365 Len: 0 Enqueue: 0
+ID: 365 Len: 17 Enqueue: 0
 ID: 366 Len: 0 Enqueue: 0
-ID: 367 Len: 0 Enqueue: 0
-ID: 368 Len: 9 Enqueue: 0
+ID: 367 Len: 25 Enqueue: 0
+ID: 368 Len: 0 Enqueue: 0
 ID: 369 Len: 9 Enqueue: 0
 ID: 370 Len: 0 Enqueue: 0
-ID: 371 Len: 17 Enqueue: 0
-ID: 372 Len: 9 Enqueue: 0
+ID: 371 Len: 9 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 9 Enqueue: 0
+ID: 374 Len: 0 Enqueue: 0
+ID: 375 Len: 25 Enqueue: 0
+ID: 376 Len: 0 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 0 Enqueue: 0
+ID: 379 Len: 97 Enqueue: 0
+ID: 380 Len: 0 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 0 Enqueue: 0
+ID: 383 Len: 0 Enqueue: 0
+ID: 384 Len: 9 Enqueue: 0
+ID: 385 Len: 9 Enqueue: 0
+ID: 386 Len: 0 Enqueue: 0
+ID: 387 Len: 17 Enqueue: 0
+ID: 388 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae726]
-	PrepareEventRoot 63 01 00 00 11 00 00 00 
+	PrepareEventRoot 73 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae770]
-	PrepareEventRoot 64 01 00 00 09 00 00 00 
+	PrepareEventRoot 74 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae770.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4af7b3]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4b004a]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4afeca]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4aff8a]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4af98a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af98a]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4af98a]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4afb0a]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af8ca]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
@@ -377,7 +377,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
@@ -470,7 +470,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
@@ -520,7 +520,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	PrepareEventRoot 1b 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4b010a]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4b010a]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@4b010a]
 	PrepareEventRoot 07 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@4b010a]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call d3 1b 00 00 // ProcessType[main.condFields]
+	Call 2a 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	PrepareEventRoot 15 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
@@ -877,7 +877,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
@@ -921,7 +921,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
@@ -965,7 +965,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@4afbca]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@4afbca]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@4afbca]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@4ae4ee]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@4af68a]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@4af6ca]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call f3 1a 00 00 // ProcessType[[3]string]
+	Call 4a 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
+	Call a0 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@4af46a]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4b1213]
-	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	PrepareEventRoot 67 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call d3 1b 00 00 // ProcessType[main.condFields]
+	Call 2a 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
-	PrepareEventRoot 5b 01 00 00 61 00 00 00 
+	PrepareEventRoot 6b 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@4b1213]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	PrepareEventRoot 3f 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 41 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4b0c6e]
+	PrepareEventRoot 43 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@4b0c6e]
-	PrepareEventRoot 3b 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 47 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*string]
+	Call e8 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
-	PrepareEventRoot 3f 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 4b 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.lenFields]
+	Call a0 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 4f 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 5f 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 63 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
-	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 05 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4b0b13]
-	PrepareEventRoot 37 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+	PrepareEventRoot 35 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@4b09d3]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 37 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
-	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4b0b13]
+	PrepareEventRoot 39 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4b0abc]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@4b09d3]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call a0 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 3d 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 2f 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@4b09d3]
+// 0x1898: ProcessEvent[Probe[main.lenString]@4b09d3]
 	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call de 1b 00 00 // ProcessType[main.lenFields]
+	Call 35 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 41 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 4d 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 47 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 53 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 57 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 59 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 5b 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,484 +1689,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
-	PrepareEventRoot 4d 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 5d 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@4af74a]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@4af74a]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4af77f]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4af77f]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@4af86a]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@4af86a]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call f3 1a 00 00 // ProcessType[[3]string]
+	Call 4a 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]string]
+	Call ce 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a5 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
-	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
+	PrepareEventRoot 70 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*main.bigStruct]
+// 0x1d94: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.condFields]
+// 0x1d9a: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.lenFields]
+// 0x1da0: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*runtime._defer]
+// 0x1da6: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._panic]
+// 0x1dac: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime.cgoCallers]
+// 0x1db2: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.coro]
+// 0x1db8: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.g]
+// 0x1dbe: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.m]
+// 0x1dc4: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.p]
+// 0x1dca: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.sudog]
+// 0x1dd0: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.synctestBubble]
+// 0x1dd6: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.timer]
+// 0x1ddc: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.traceBuf]
+// 0x1de2: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*string]
+// 0x1de8: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dee: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*table<string,int>]
+// 0x1df4: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<string,main.bigStruct>]
+// 0x1dfa: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e00: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint]
+// 0x1e06: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint16]
+// 0x1e0c: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint32]
+// 0x1e12: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint64]
+// 0x1e18: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint8]
+// 0x1e1e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uintptr]
+// 0x1e24: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
+// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call e2 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e3a: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1af3: ProcessType[[3]string]
+// 0x1e4a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b03: ProcessType[[]*runtime.p]
+// 0x1e5a: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1b0d: ProcessType[[]*runtime.p.array]
+// 0x1e64: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 73 1a 00 00 // ProcessType[*runtime.p]
+	Call ca 1d 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e70: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 97 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ee 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b25: ProcessType[[]*table<string,int>.array]
+// 0x1e7c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9d 1a 00 00 // ProcessType[*table<string,int>]
+	Call f4 1d 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b31: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e88: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call fa 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b3d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e94: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 00 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]int]
+// 0x1ea0: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1eaa: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 84 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call db 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1eb6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 8f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call e6 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b6b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ec2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 9a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f1 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]string]
+// 0x1ece: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1b81: ProcessType[[]string.array]
+// 0x1ed8: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[[]uint8]
+// 0x1ee4: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b97: ProcessType[[]uintptr]
+// 0x1eee: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1ba1: ProcessType[error]
+// 0x1ef8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1ba3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1efa: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1baf: ProcessType[groupReference<string,int>]
+// 0x1f06: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bbb: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1f12: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bc7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f1e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bd3: ProcessType[main.condFields]
+// 0x1f2a: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1bde: ProcessType[main.lenFields]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x1f35: ProcessType[main.lenFields]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
+	Call a0 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*string]
+	Call e8 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c0c: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f63: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1c18: ProcessType[map<string,int>]
+// 0x1f6f: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1c24: ProcessType[map<string,main.bigStruct>]
+// 0x1f7b: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1c30: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f87: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1c3c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f93: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1c42: ProcessType[map[string]int]
+// 0x1f99: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c48: ProcessType[map[string]main.bigStruct]
+// 0x1f9f: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c4e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fa5: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c54: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1fab: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a5 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call fc 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c64: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1fbb: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b5 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 0c 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c74: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1fcb: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bb 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 12 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c84: ProcessType[noalg.map.group[string]int]
+// 0x1fdb: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 64 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call bb 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c8f: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1fe6: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ab 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c9a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ff1: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 74 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call cb 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1ca5: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x1ffc: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1cb5: ProcessType[noalg.struct { key string; elem int }]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x200c: ProcessType[noalg.struct { key string; elem int }]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1cbb: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2012: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 93 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cc6: ProcessType[runtime.g]
+// 0x201d: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._panic]
+	Call ac 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
+	Call a6 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 8d 1b 00 00 // ProcessType[[]uint8]
+	Call e4 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.sudog]
+	Call d0 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.timer]
+	Call dc 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.coro]
+	Call b8 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d6 1d 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1d2b: ProcessType[runtime.m]
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+// 0x2082: ProcessType[runtime.m]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 03 1b 00 00 // ProcessType[[]*runtime.p]
+	Call 5a 1e 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call ec 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call f7 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d95: ProcessType[runtime.mLockProfile]
+// 0x20ec: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1da0: ProcessType[runtime.mTraceState]
+// 0x20f7: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call 3a 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1db0: ProcessType[string]
+// 0x2107: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x1db6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x210d: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a3 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call fa 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1dc1: ProcessType[table<string,int>]
+// 0x2118: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call af 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 06 1f 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dcc: ProcessType[table<string,main.bigStruct>]
+// 0x2123: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bb 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 12 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1dd7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x212e: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2240,31 +2434,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6855
+ID: 5 Len: 8 Enqueue: 7710
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7600
+ID: 9 Len: 16 Enqueue: 8455
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6675
+ID: 11 Len: 8 Enqueue: 7530
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7073
+ID: 13 Len: 16 Enqueue: 7928
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6861
-ID: 20 Len: 8 Enqueue: 6705
-ID: 21 Len: 8 Enqueue: 6843
-ID: 22 Len: 440 Enqueue: 7366
+ID: 19 Len: 8 Enqueue: 7716
+ID: 20 Len: 8 Enqueue: 7560
+ID: 21 Len: 8 Enqueue: 7698
+ID: 22 Len: 440 Enqueue: 8221
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6741
+ID: 24 Len: 8 Enqueue: 7596
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6735
+ID: 26 Len: 8 Enqueue: 7590
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6765
-ID: 29 Len: 1816 Enqueue: 7467
+ID: 28 Len: 8 Enqueue: 7620
+ID: 29 Len: 1816 Enqueue: 8322
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2273,48 +2467,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7053
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7908
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6777
+ID: 41 Len: 8 Enqueue: 7632
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7063
-ID: 44 Len: 8 Enqueue: 6789
+ID: 43 Len: 24 Enqueue: 7918
+ID: 44 Len: 8 Enqueue: 7644
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6753
+ID: 47 Len: 8 Enqueue: 7608
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6783
+ID: 49 Len: 8 Enqueue: 7638
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6759
+ID: 55 Len: 8 Enqueue: 7614
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 6915
+ID: 62 Len: 24 Enqueue: 7770
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 6771
-ID: 65 Len: 8 Enqueue: 6747
+ID: 64 Len: 8 Enqueue: 7626
+ID: 65 Len: 8 Enqueue: 7602
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 7573
+ID: 70 Len: 56 Enqueue: 8428
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7584
+ID: 75 Len: 56 Enqueue: 8439
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 6883
-ID: 78 Len: 16 Enqueue: 6867
-ID: 79 Len: 8 Enqueue: 6795
+ID: 77 Len: 32 Enqueue: 7738
+ID: 78 Len: 16 Enqueue: 7722
+ID: 79 Len: 8 Enqueue: 7650
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2330,46 +2524,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 6801
+ID: 95 Len: 8 Enqueue: 7656
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 6693
-ID: 99 Len: 8 Enqueue: 6699
-ID: 100 Len: 8 Enqueue: 6711
-ID: 101 Len: 8 Enqueue: 6849
-ID: 102 Len: 8 Enqueue: 6681
+ID: 98 Len: 8 Enqueue: 7548
+ID: 99 Len: 8 Enqueue: 7554
+ID: 100 Len: 8 Enqueue: 7566
+ID: 101 Len: 8 Enqueue: 7704
+ID: 102 Len: 8 Enqueue: 7536
 ID: 103 Len: 2 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 6687
-ID: 105 Len: 8 Enqueue: 6831
-ID: 106 Len: 8 Enqueue: 6837
-ID: 107 Len: 24 Enqueue: 6985
+ID: 104 Len: 8 Enqueue: 7542
+ID: 105 Len: 8 Enqueue: 7686
+ID: 106 Len: 8 Enqueue: 7692
+ID: 107 Len: 24 Enqueue: 7840
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 7031
-ID: 110 Len: 48 Enqueue: 6899
-ID: 111 Len: 8 Enqueue: 7234
+ID: 109 Len: 24 Enqueue: 7886
+ID: 110 Len: 48 Enqueue: 7754
+ID: 111 Len: 8 Enqueue: 8089
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7192
+ID: 113 Len: 48 Enqueue: 8047
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 6813
-ID: 116 Len: 8 Enqueue: 7240
+ID: 115 Len: 8 Enqueue: 7668
+ID: 116 Len: 8 Enqueue: 8095
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7204
+ID: 118 Len: 48 Enqueue: 8059
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6819
-ID: 121 Len: 80 Enqueue: 7123
+ID: 120 Len: 8 Enqueue: 7674
+ID: 121 Len: 80 Enqueue: 7978
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 6723
-ID: 124 Len: 72 Enqueue: 7134
-ID: 125 Len: 8 Enqueue: 6663
-ID: 126 Len: 8 Enqueue: 6729
-ID: 127 Len: 8 Enqueue: 7246
+ID: 123 Len: 8 Enqueue: 7578
+ID: 124 Len: 72 Enqueue: 7989
+ID: 125 Len: 8 Enqueue: 7518
+ID: 126 Len: 8 Enqueue: 7584
+ID: 127 Len: 8 Enqueue: 8101
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7216
+ID: 129 Len: 48 Enqueue: 8071
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 6825
-ID: 132 Len: 8 Enqueue: 6639
-ID: 133 Len: 8 Enqueue: 6645
-ID: 134 Len: 8 Enqueue: 6657
+ID: 131 Len: 8 Enqueue: 7680
+ID: 132 Len: 8 Enqueue: 7494
+ID: 133 Len: 8 Enqueue: 7500
+ID: 134 Len: 8 Enqueue: 7512
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2377,53 +2571,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 6925
+ID: 142 Len: 8 Enqueue: 7780
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7041
+ID: 146 Len: 16 Enqueue: 7896
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 7617
-ID: 149 Len: 16 Enqueue: 7087
+ID: 148 Len: 32 Enqueue: 8472
+ID: 149 Len: 16 Enqueue: 7942
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 7300
-ID: 152 Len: 192 Enqueue: 7268
-ID: 153 Len: 24 Enqueue: 7349
-ID: 154 Len: 8 Enqueue: 6949
-ID: 155 Len: 200 Enqueue: 6995
-ID: 156 Len: 32 Enqueue: 7628
-ID: 157 Len: 16 Enqueue: 7099
+ID: 151 Len: 200 Enqueue: 8155
+ID: 152 Len: 192 Enqueue: 8123
+ID: 153 Len: 24 Enqueue: 8204
+ID: 154 Len: 8 Enqueue: 7804
+ID: 155 Len: 200 Enqueue: 7850
+ID: 156 Len: 32 Enqueue: 8483
+ID: 157 Len: 16 Enqueue: 7954
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 7311
-ID: 160 Len: 192 Enqueue: 7252
-ID: 161 Len: 24 Enqueue: 7333
-ID: 162 Len: 8 Enqueue: 6717
+ID: 159 Len: 200 Enqueue: 8166
+ID: 160 Len: 192 Enqueue: 8107
+ID: 161 Len: 24 Enqueue: 8188
+ID: 162 Len: 8 Enqueue: 7572
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 6961
-ID: 165 Len: 200 Enqueue: 7007
-ID: 166 Len: 32 Enqueue: 7639
-ID: 167 Len: 16 Enqueue: 7111
+ID: 164 Len: 8 Enqueue: 7816
+ID: 165 Len: 200 Enqueue: 7862
+ID: 166 Len: 32 Enqueue: 8494
+ID: 167 Len: 16 Enqueue: 7966
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 7322
-ID: 170 Len: 128 Enqueue: 7284
-ID: 171 Len: 16 Enqueue: 7355
-ID: 172 Len: 8 Enqueue: 7228
+ID: 169 Len: 136 Enqueue: 8177
+ID: 170 Len: 128 Enqueue: 8139
+ID: 171 Len: 16 Enqueue: 8210
+ID: 172 Len: 8 Enqueue: 8083
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 7180
+ID: 174 Len: 48 Enqueue: 8035
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 6807
-ID: 177 Len: 8 Enqueue: 6973
-ID: 178 Len: 136 Enqueue: 7019
-ID: 179 Len: 32 Enqueue: 7606
-ID: 180 Len: 16 Enqueue: 7075
+ID: 176 Len: 8 Enqueue: 7662
+ID: 177 Len: 8 Enqueue: 7828
+ID: 178 Len: 136 Enqueue: 7874
+ID: 179 Len: 32 Enqueue: 8461
+ID: 180 Len: 16 Enqueue: 7930
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 6937
+ID: 186 Len: 8 Enqueue: 7792
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 6651
+ID: 188 Len: 8 Enqueue: 7506
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
@@ -2544,51 +2738,67 @@ ID: 305 Len: 9 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 33 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 9 Enqueue: 0
+ID: 309 Len: 17 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 41 Enqueue: 0
+ID: 311 Len: 9 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 0 Enqueue: 0
+ID: 313 Len: 17 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 25 Enqueue: 0
+ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 9 Enqueue: 0
+ID: 317 Len: 41 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
-ID: 319 Len: 25 Enqueue: 0
+ID: 319 Len: 17 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 89 Enqueue: 0
+ID: 321 Len: 9 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 0 Enqueue: 0
+ID: 323 Len: 17 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
 ID: 325 Len: 9 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 9 Enqueue: 0
+ID: 327 Len: 25 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
 ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
-ID: 331 Len: 9 Enqueue: 0
+ID: 331 Len: 25 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 17 Enqueue: 0
+ID: 333 Len: 89 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
-ID: 335 Len: 25 Enqueue: 0
+ID: 335 Len: 9 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
-ID: 337 Len: 0 Enqueue: 0
+ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
 ID: 339 Len: 9 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
 ID: 341 Len: 9 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 25 Enqueue: 0
+ID: 343 Len: 9 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 0 Enqueue: 0
+ID: 345 Len: 17 Enqueue: 0
 ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 97 Enqueue: 0
+ID: 347 Len: 17 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 0 Enqueue: 0
+ID: 349 Len: 17 Enqueue: 0
 ID: 350 Len: 0 Enqueue: 0
-ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 9 Enqueue: 0
+ID: 351 Len: 25 Enqueue: 0
+ID: 352 Len: 0 Enqueue: 0
 ID: 353 Len: 9 Enqueue: 0
 ID: 354 Len: 0 Enqueue: 0
-ID: 355 Len: 17 Enqueue: 0
-ID: 356 Len: 9 Enqueue: 0
+ID: 355 Len: 9 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 9 Enqueue: 0
+ID: 358 Len: 0 Enqueue: 0
+ID: 359 Len: 25 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 0 Enqueue: 0
+ID: 363 Len: 97 Enqueue: 0
+ID: 364 Len: 0 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 0 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 9 Enqueue: 0
+ID: 369 Len: 9 Enqueue: 0
+ID: 370 Len: 0 Enqueue: 0
+ID: 371 Len: 17 Enqueue: 0
+ID: 372 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae726]
 	PrepareEventRoot 63 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae770]
 	PrepareEventRoot 64 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4af7b3]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4b004a]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4afeca]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4aff8a]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4af98a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af98a]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4af98a]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4afb0a]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af8ca]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
 	PrepareEventRoot 1d 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4b05ca]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@4b05ca]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@4b05ca]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@4b063a]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@4b063a]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@4b05ca]
+// 0x767: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@4b063a]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@4b063a]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	PrepareEventRoot 17 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	PrepareEventRoot 1b 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
 	PrepareEventRoot 23 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
 	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0x964: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@4b010a]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0x9a8: ProcessEvent[Probe[main.condString]@4b010a]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@4b017f]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@4b010a]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0xa05: ProcessEvent[Probe[main.condString]@4b010a]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@4b017f]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@4b010a]
+// 0xa67: ProcessEvent[Probe[main.condString]@4b010a]
 	PrepareEventRoot 07 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@4b017f]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0xa85: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@4b010a]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
+// 0xaeb: ProcessEvent[Probe[main.condString]@4b010a]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
 	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@4b017f]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@4b017f]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b3 1b 00 00 // ProcessType[main.condFields]
+	Call d3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@4b01ce]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	PrepareEventRoot 15 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@4afc8a]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@4afc8a]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@4afc8a]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@4afd4a]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@4afd4a]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4afdba]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@4afd4a]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4afdba]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4afdba]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@4afe0a]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@4afe0a]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@4afe0a]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@4afbca]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e7 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@4afbca]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@4afbca]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@4afbca]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@4afbca]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@4ae4ee]
+// 0x106e: ProcessEvent[Probe[main.inlined]@4ae4ee]
 	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@4af68a]
+// 0x1093: ProcessEvent[Probe[main.inlined]@4af68a]
 	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@4af6ca]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4af6ca]
 	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@4af36a]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@4af36a]
 	PrepareEventRoot be 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4af3aa]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4af3aa]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[3]string]
+	Call f3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4af46a]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4af46a]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4b1213]
 	PrepareEventRoot 57 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
 	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b3 1b 00 00 // ProcessType[main.condFields]
+	Call d3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
 	PrepareEventRoot 5b 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
 	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4b1213]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
 	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
 	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@4b0c6e]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
 	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@4b0c6e]
 	PrepareEventRoot 3b 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
 	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
 	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*string]
+	Call 91 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
 	PrepareEventRoot 3f 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
 	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Call 49 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
 	PrepareEventRoot 4f 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
 	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
 	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
 	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
 	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
 	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
 	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@4b0b13]
 	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
 	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4b0b13]
 	PrepareEventRoot 37 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
 	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x1525: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@4b09d3]
+// 0x1559: ProcessEvent[Probe[main.lenString]@4b09d3]
 	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 2e 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@4b09d3]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
 	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@4b09d3]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@4b09d3]
 	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@4b09d3]
+// 0x1642: ProcessEvent[Probe[main.lenString]@4b09d3]
 	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@4b0abc]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call be 1b 00 00 // ProcessType[main.lenFields]
+	Call de 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 41 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 47 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,484 +1495,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
 	PrepareEventRoot 4d 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
 	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@4af74a]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@4af74a]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4af77f]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4af77f]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@4af86a]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@4af86a]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@4af3ea]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@4af3ea]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4af42f]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[3]string]
+	Call f3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 57 1b 00 00 // ProcessType[[]string]
+	Call 77 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
 	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
 	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*main.bigStruct]
+// 0x1a3d: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.condFields]
+// 0x1a43: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.lenFields]
+// 0x1a49: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*runtime._defer]
+// 0x1a4f: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._panic]
+// 0x1a55: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime.cgoCallers]
+// 0x1a5b: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.coro]
+// 0x1a61: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.g]
+// 0x1a67: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.m]
+// 0x1a6d: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.p]
+// 0x1a73: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.sudog]
+// 0x1a79: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.synctestBubble]
+// 0x1a7f: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.timer]
+// 0x1a85: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.traceBuf]
+// 0x1a8b: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*string]
+// 0x1a91: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a97: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*table<string,int>]
+// 0x1a9d: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<string,main.bigStruct>]
+// 0x1aa3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1aa9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint]
+// 0x1aaf: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint16]
+// 0x1ab5: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint32]
+// 0x1abb: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint64]
+// 0x1ac1: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint8]
+// 0x1ac7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uintptr]
+// 0x1acd: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8b 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ac3: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1ae3: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[3]string]
+// 0x1af3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[]*runtime.p]
+// 0x1b03: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1aed: ProcessType[[]*runtime.p.array]
+// 0x1b0d: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 53 1a 00 00 // ProcessType[*runtime.p]
+	Call 73 1a 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af9: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1b19: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 77 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 97 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b05: ProcessType[[]*table<string,int>.array]
+// 0x1b25: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7d 1a 00 00 // ProcessType[*table<string,int>]
+	Call 9d 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b11: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b31: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a3 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b1d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b3d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 89 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a9 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]int]
+// 0x1b49: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b33: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b53: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 64 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 84 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b5f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 6f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b6b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 7a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 9a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b57: ProcessType[[]string]
+// 0x1b77: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1b61: ProcessType[[]string.array]
+// 0x1b81: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b6d: ProcessType[[]uint8]
+// 0x1b8d: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]uintptr]
+// 0x1b97: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b81: ProcessType[error]
+// 0x1ba1: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b83: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1ba3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b8f: ProcessType[groupReference<string,int>]
+// 0x1baf: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b9b: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1bbb: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ba7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bc7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bb3: ProcessType[main.condFields]
+// 0x1bd3: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1bbe: ProcessType[main.lenFields]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1bde: ProcessType[main.lenFields]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*string]
+	Call 91 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bec: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1c0c: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1bf8: ProcessType[map<string,int>]
+// 0x1c18: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1c04: ProcessType[map<string,main.bigStruct>]
+// 0x1c24: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1c10: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c30: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1c1c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c3c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1c22: ProcessType[map[string]int]
+// 0x1c42: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c28: ProcessType[map[string]main.bigStruct]
+// 0x1c48: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c2e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c4e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c34: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c54: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 85 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a5 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c44: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c64: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 95 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b5 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c54: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c74: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 9b 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call bb 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c64: ProcessType[noalg.map.group[string]int]
+// 0x1c84: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 64 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c6f: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c8f: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 34 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c7a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c9a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 74 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c85: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1ca5: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c95: ProcessType[noalg.struct { key string; elem int }]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1cb5: ProcessType[noalg.struct { key string; elem int }]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c9b: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1cbb: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1ca6: ProcessType[runtime.g]
+// 0x1cc6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._panic]
+	Call 55 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
+	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6d 1b 00 00 // ProcessType[[]uint8]
+	Call 8d 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 79 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.timer]
+	Call 85 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.coro]
+	Call 61 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 7f 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1d0b: ProcessType[runtime.m]
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d2b: ProcessType[runtime.m]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[]*runtime.p]
+	Call 03 1b 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 75 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 80 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d75: ProcessType[runtime.mLockProfile]
+// 0x1d95: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d80: ProcessType[runtime.mTraceState]
+// 0x1da0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call e3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d90: ProcessType[string]
+// 0x1db0: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x1d96: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1db6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 83 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call a3 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1da1: ProcessType[table<string,int>]
+// 0x1dc1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8f 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call af 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dac: ProcessType[table<string,main.bigStruct>]
+// 0x1dcc: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9b 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call bb 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1db7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1dd7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call c7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2240,31 +2240,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6823
+ID: 5 Len: 8 Enqueue: 6855
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7568
+ID: 9 Len: 16 Enqueue: 7600
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6643
+ID: 11 Len: 8 Enqueue: 6675
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 7041
+ID: 13 Len: 16 Enqueue: 7073
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6829
-ID: 20 Len: 8 Enqueue: 6673
-ID: 21 Len: 8 Enqueue: 6811
-ID: 22 Len: 440 Enqueue: 7334
+ID: 19 Len: 8 Enqueue: 6861
+ID: 20 Len: 8 Enqueue: 6705
+ID: 21 Len: 8 Enqueue: 6843
+ID: 22 Len: 440 Enqueue: 7366
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6709
+ID: 24 Len: 8 Enqueue: 6741
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6703
+ID: 26 Len: 8 Enqueue: 6735
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6733
-ID: 29 Len: 1816 Enqueue: 7435
+ID: 28 Len: 8 Enqueue: 6765
+ID: 29 Len: 1816 Enqueue: 7467
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2273,48 +2273,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7021
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7053
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6745
+ID: 41 Len: 8 Enqueue: 6777
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7031
-ID: 44 Len: 8 Enqueue: 6757
+ID: 43 Len: 24 Enqueue: 7063
+ID: 44 Len: 8 Enqueue: 6789
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6721
+ID: 47 Len: 8 Enqueue: 6753
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6751
+ID: 49 Len: 8 Enqueue: 6783
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6727
+ID: 55 Len: 8 Enqueue: 6759
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 6883
+ID: 62 Len: 24 Enqueue: 6915
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 6739
-ID: 65 Len: 8 Enqueue: 6715
+ID: 64 Len: 8 Enqueue: 6771
+ID: 65 Len: 8 Enqueue: 6747
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 7541
+ID: 70 Len: 56 Enqueue: 7573
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7552
+ID: 75 Len: 56 Enqueue: 7584
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 6851
-ID: 78 Len: 16 Enqueue: 6835
-ID: 79 Len: 8 Enqueue: 6763
+ID: 77 Len: 32 Enqueue: 6883
+ID: 78 Len: 16 Enqueue: 6867
+ID: 79 Len: 8 Enqueue: 6795
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2330,46 +2330,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 6769
+ID: 95 Len: 8 Enqueue: 6801
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 6661
-ID: 99 Len: 8 Enqueue: 6667
-ID: 100 Len: 8 Enqueue: 6679
-ID: 101 Len: 8 Enqueue: 6817
-ID: 102 Len: 8 Enqueue: 6649
+ID: 98 Len: 8 Enqueue: 6693
+ID: 99 Len: 8 Enqueue: 6699
+ID: 100 Len: 8 Enqueue: 6711
+ID: 101 Len: 8 Enqueue: 6849
+ID: 102 Len: 8 Enqueue: 6681
 ID: 103 Len: 2 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 6655
-ID: 105 Len: 8 Enqueue: 6799
-ID: 106 Len: 8 Enqueue: 6805
-ID: 107 Len: 24 Enqueue: 6953
+ID: 104 Len: 8 Enqueue: 6687
+ID: 105 Len: 8 Enqueue: 6831
+ID: 106 Len: 8 Enqueue: 6837
+ID: 107 Len: 24 Enqueue: 6985
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 6999
-ID: 110 Len: 48 Enqueue: 6867
-ID: 111 Len: 8 Enqueue: 7202
+ID: 109 Len: 24 Enqueue: 7031
+ID: 110 Len: 48 Enqueue: 6899
+ID: 111 Len: 8 Enqueue: 7234
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7160
+ID: 113 Len: 48 Enqueue: 7192
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 6781
-ID: 116 Len: 8 Enqueue: 7208
+ID: 115 Len: 8 Enqueue: 6813
+ID: 116 Len: 8 Enqueue: 7240
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7172
+ID: 118 Len: 48 Enqueue: 7204
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6787
-ID: 121 Len: 80 Enqueue: 7091
+ID: 120 Len: 8 Enqueue: 6819
+ID: 121 Len: 80 Enqueue: 7123
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 6691
-ID: 124 Len: 72 Enqueue: 7102
-ID: 125 Len: 8 Enqueue: 6631
-ID: 126 Len: 8 Enqueue: 6697
-ID: 127 Len: 8 Enqueue: 7214
+ID: 123 Len: 8 Enqueue: 6723
+ID: 124 Len: 72 Enqueue: 7134
+ID: 125 Len: 8 Enqueue: 6663
+ID: 126 Len: 8 Enqueue: 6729
+ID: 127 Len: 8 Enqueue: 7246
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7184
+ID: 129 Len: 48 Enqueue: 7216
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 6793
-ID: 132 Len: 8 Enqueue: 6607
-ID: 133 Len: 8 Enqueue: 6613
-ID: 134 Len: 8 Enqueue: 6625
+ID: 131 Len: 8 Enqueue: 6825
+ID: 132 Len: 8 Enqueue: 6639
+ID: 133 Len: 8 Enqueue: 6645
+ID: 134 Len: 8 Enqueue: 6657
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2377,53 +2377,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 6893
+ID: 142 Len: 8 Enqueue: 6925
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7009
+ID: 146 Len: 16 Enqueue: 7041
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 7585
-ID: 149 Len: 16 Enqueue: 7055
+ID: 148 Len: 32 Enqueue: 7617
+ID: 149 Len: 16 Enqueue: 7087
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 7268
-ID: 152 Len: 192 Enqueue: 7236
-ID: 153 Len: 24 Enqueue: 7317
-ID: 154 Len: 8 Enqueue: 6917
-ID: 155 Len: 200 Enqueue: 6963
-ID: 156 Len: 32 Enqueue: 7596
-ID: 157 Len: 16 Enqueue: 7067
+ID: 151 Len: 200 Enqueue: 7300
+ID: 152 Len: 192 Enqueue: 7268
+ID: 153 Len: 24 Enqueue: 7349
+ID: 154 Len: 8 Enqueue: 6949
+ID: 155 Len: 200 Enqueue: 6995
+ID: 156 Len: 32 Enqueue: 7628
+ID: 157 Len: 16 Enqueue: 7099
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 7279
-ID: 160 Len: 192 Enqueue: 7220
-ID: 161 Len: 24 Enqueue: 7301
-ID: 162 Len: 8 Enqueue: 6685
+ID: 159 Len: 200 Enqueue: 7311
+ID: 160 Len: 192 Enqueue: 7252
+ID: 161 Len: 24 Enqueue: 7333
+ID: 162 Len: 8 Enqueue: 6717
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 6929
-ID: 165 Len: 200 Enqueue: 6975
-ID: 166 Len: 32 Enqueue: 7607
-ID: 167 Len: 16 Enqueue: 7079
+ID: 164 Len: 8 Enqueue: 6961
+ID: 165 Len: 200 Enqueue: 7007
+ID: 166 Len: 32 Enqueue: 7639
+ID: 167 Len: 16 Enqueue: 7111
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 7290
-ID: 170 Len: 128 Enqueue: 7252
-ID: 171 Len: 16 Enqueue: 7323
-ID: 172 Len: 8 Enqueue: 7196
+ID: 169 Len: 136 Enqueue: 7322
+ID: 170 Len: 128 Enqueue: 7284
+ID: 171 Len: 16 Enqueue: 7355
+ID: 172 Len: 8 Enqueue: 7228
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 7148
+ID: 174 Len: 48 Enqueue: 7180
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 6775
-ID: 177 Len: 8 Enqueue: 6941
-ID: 178 Len: 136 Enqueue: 6987
-ID: 179 Len: 32 Enqueue: 7574
-ID: 180 Len: 16 Enqueue: 7043
+ID: 176 Len: 8 Enqueue: 6807
+ID: 177 Len: 8 Enqueue: 6973
+ID: 178 Len: 136 Enqueue: 7019
+ID: 179 Len: 32 Enqueue: 7606
+ID: 180 Len: 16 Enqueue: 7075
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 6905
+ID: 186 Len: 8 Enqueue: 6937
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 6619
+ID: 188 Len: 8 Enqueue: 6651
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4ae726]
-	PrepareEventRoot 2c 01 00 00 11 00 00 00 
+	PrepareEventRoot 63 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4ae726.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4ae770]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	PrepareEventRoot 64 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4ae770.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4af7b3]
-	PrepareEventRoot ce 00 00 00 11 00 00 00 
+	PrepareEventRoot d1 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4af7b3.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4af83e]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0x4b004a]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
-	PrepareEventRoot fa 00 00 00 11 00 00 00 
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@4b00ba]
-	PrepareEventRoot fb 00 00 00 00 00 00 00 
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0x4b004a]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4b004a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4b004a]
-	PrepareEventRoot fc 00 00 00 11 00 00 00 
+	PrepareEventRoot ff 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@4b00ba]
-	PrepareEventRoot fd 00 00 00 00 00 00 00 
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4b004a]
-	PrepareEventRoot fe 00 00 00 12 00 00 00 
+	PrepareEventRoot 01 01 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4b004a.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@4b00ba]
-	PrepareEventRoot ff 00 00 00 00 00 00 00 
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4afeca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4afeca]
-	PrepareEventRoot f6 00 00 00 11 00 00 00 
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4afeca.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4aff3e]
-	PrepareEventRoot f7 00 00 00 00 00 00 00 
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0x4aff8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4aff8a]
-	PrepareEventRoot f8 00 00 00 11 00 00 00 
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4aff8a.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@4affff]
-	PrepareEventRoot f9 00 00 00 00 00 00 00 
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0x4af98a]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4af98a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4af98a]
-	PrepareEventRoot d6 00 00 00 11 00 00 00 
+	PrepareEventRoot d9 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@4af9fa]
-	PrepareEventRoot d7 00 00 00 00 00 00 00 
+	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4af98a]
-	PrepareEventRoot d8 00 00 00 13 00 00 00 
+	PrepareEventRoot db 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4af98a.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4af9fa]
-	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
-	PrepareEventRoot da 00 00 00 11 00 00 00 
+	PrepareEventRoot dd 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@4afaba]
-	PrepareEventRoot db 00 00 00 00 00 00 00 
+	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0x4afa4a]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4afa4a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4afa4a]
-	PrepareEventRoot dc 00 00 00 11 00 00 00 
+	PrepareEventRoot df 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@4afaba]
-	PrepareEventRoot dd 00 00 00 00 00 00 00 
+	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4afa4a]
-	PrepareEventRoot de 00 00 00 15 00 00 00 
+	PrepareEventRoot e1 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4afa4a.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4afaba]
-	PrepareEventRoot df 00 00 00 00 00 00 00 
+	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4afb0a]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4afb0a]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4afb0a]
-	PrepareEventRoot e0 00 00 00 11 00 00 00 
+	PrepareEventRoot e3 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@4afb7a]
-	PrepareEventRoot e1 00 00 00 00 00 00 00 
+	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4afb0a]
-	PrepareEventRoot e2 00 00 00 19 00 00 00 
+	PrepareEventRoot e5 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4afb0a.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4afb7a]
-	PrepareEventRoot e3 00 00 00 00 00 00 00 
+	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4af8ca]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4af8ca]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4af8ca]
-	PrepareEventRoot d2 00 00 00 11 00 00 00 
+	PrepareEventRoot d5 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4af93a]
-	PrepareEventRoot d3 00 00 00 00 00 00 00 
+	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4af8ca]
-	PrepareEventRoot d4 00 00 00 12 00 00 00 
+	PrepareEventRoot d7 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4af8ca.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@4af93a]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4b06a1]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4b06a1]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	PrepareEventRoot 29 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4b06a1]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2a 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4b06a1.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4b046e]
-	PrepareEventRoot 1a 01 00 00 11 00 00 00 
+	PrepareEventRoot 1d 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4b046e]
-	PrepareEventRoot 1c 01 00 00 19 00 00 00 
+	PrepareEventRoot 1f 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4b046e.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4b04ee]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4b05ca]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@4b05ca]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4b05ca]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@4b063a]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@4b05ca]
-	PrepareEventRoot 24 01 00 00 19 00 00 00 
+	PrepareEventRoot 27 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4b05ca.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@4b063a]
-	PrepareEventRoot 25 01 00 00 00 00 00 00 
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4b030e]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4b030e]
-	PrepareEventRoot 18 01 00 00 19 00 00 00 
+	PrepareEventRoot 1b 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4b030e.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4b0425]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4b052a]
-	PrepareEventRoot 1e 01 00 00 09 00 00 00 
+	PrepareEventRoot 21 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
-	PrepareEventRoot 1f 01 00 00 00 00 00 00 
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4b052a]
-	PrepareEventRoot 20 01 00 00 11 00 00 00 
+	PrepareEventRoot 23 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4b052a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4b0595]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	PrepareEventRoot 24 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4b0595.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0x4b010a]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@4b010a]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
-	PrepareEventRoot 00 01 00 00 11 00 00 00 
+	PrepareEventRoot 03 01 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 01 01 00 00 00 00 00 00 
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@4b010a]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
-	PrepareEventRoot 02 01 00 00 11 00 00 00 
+	PrepareEventRoot 05 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@4b010a]
-	PrepareEventRoot 04 01 00 00 21 00 00 00 
+	PrepareEventRoot 07 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0x4b010a]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@4b010a]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4b010a]
-	PrepareEventRoot 06 01 00 00 21 00 00 00 
+	PrepareEventRoot 09 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4b010a.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@4b017f]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 08 01 00 00 11 00 00 00 
+	PrepareEventRoot 0b 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	PrepareEventRoot 0d 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 0b 01 00 00 00 00 00 00 
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0c 01 00 00 11 00 00 00 
+	PrepareEventRoot 0f 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 0e 01 00 00 11 00 00 00 
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@4b01ce]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4b01ce]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 17 15 00 00 // ProcessType[main.condFields]
+	Call b3 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@4b01ce]
-	PrepareEventRoot 12 01 00 00 61 00 00 00 
+	PrepareEventRoot 15 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4b01ce.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4b02cf]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0x4afc8a]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@4afc8a]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4afc8a]
-	PrepareEventRoot ea 00 00 00 11 00 00 00 
+	PrepareEventRoot ed 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
-	PrepareEventRoot eb 00 00 00 00 00 00 00 
+	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@4afc8a]
-	PrepareEventRoot ec 00 00 00 13 00 00 00 
+	PrepareEventRoot ef 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4afc8a.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@4afcfa]
-	PrepareEventRoot ed 00 00 00 00 00 00 00 
+	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0x4afd4a]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@4afd4a]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4afd4a]
-	PrepareEventRoot ee 00 00 00 11 00 00 00 
+	PrepareEventRoot f1 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4afdba]
-	PrepareEventRoot ef 00 00 00 00 00 00 00 
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@4afd4a]
-	PrepareEventRoot f0 00 00 00 15 00 00 00 
+	PrepareEventRoot f3 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4afd4a.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@4afdba]
-	PrepareEventRoot f1 00 00 00 00 00 00 00 
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4afe0a]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@4afe0a]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4afe0a]
-	PrepareEventRoot f2 00 00 00 11 00 00 00 
+	PrepareEventRoot f5 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
-	PrepareEventRoot f3 00 00 00 00 00 00 00 
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@4afe0a]
-	PrepareEventRoot f4 00 00 00 19 00 00 00 
+	PrepareEventRoot f7 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4afe0a.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@4afe7a]
-	PrepareEventRoot f5 00 00 00 00 00 00 00 
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@4afbca]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
-	PrepareEventRoot e4 00 00 00 11 00 00 00 
+	PrepareEventRoot e7 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
-	PrepareEventRoot e5 00 00 00 00 00 00 00 
+	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4afbca]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@4afbca]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4afbca]
-	PrepareEventRoot e6 00 00 00 11 00 00 00 
+	PrepareEventRoot e9 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
-	PrepareEventRoot e7 00 00 00 00 00 00 00 
+	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@4afbca]
-	PrepareEventRoot e8 00 00 00 12 00 00 00 
+	PrepareEventRoot eb 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4afbca.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@4afc3a]
-	PrepareEventRoot e9 00 00 00 00 00 00 00 
+	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@4ae4ee]
-	PrepareEventRoot 2a 01 00 00 09 00 00 00 
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4ae4ee.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@4af68a]
-	PrepareEventRoot 2a 01 00 00 09 00 00 00 
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4af68a.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@4af6ca]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@4af36a]
-	PrepareEventRoot bb 00 00 00 09 00 00 00 
+	PrepareEventRoot be 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4af36a.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@4af3aa]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4af4ea]
-	PrepareEventRoot c5 00 00 00 19 00 00 00 
+	PrepareEventRoot c8 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4af4ea.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4af536]
-	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 37 14 00 00 // ProcessType[[3]string]
+	Call d3 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4af660]
-	PrepareEventRoot cb 00 00 00 31 00 00 00 
+	PrepareEventRoot ce 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4af660.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
@@ -1104,461 +1104,875 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 8d 14 00 00 // ProcessType[[]int]
+	Call 29 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@4af46a]
-	PrepareEventRoot c3 00 00 00 19 00 00 00 
+	PrepareEventRoot c6 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4af46a.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4af4af]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@4af3ea]
-	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4af42f]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@4af3ea]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4af42f]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 58 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@4af74a]
-	PrepareEventRoot cc 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4b1213.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4af77f]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@4af86a]
-	PrepareEventRoot d0 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
-	PrepareEventRoot d1 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call b3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@4af3ea]
-	PrepareEventRoot c1 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+	PrepareEventRoot 5b 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4b1333.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4af42f]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4b1213]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4b12ec]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4b1333]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4b1436]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 37 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
-	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@4b0c6e]
+	PrepareEventRoot 3b 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4b0c6e.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4b0d4c]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 71 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4b0d8e]
+	PrepareEventRoot 3f 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4b0d8e.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4b0e58]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 4f 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 53 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4b1093]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4b1093.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4b11cb]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 35 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call bb 14 00 00 // ProcessType[[]string]
+	Call 29 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
-	PrepareEventRoot c7 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4b0b13]
+	PrepareEventRoot 37 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4b0b13.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4b0c07]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@4b09d3]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4b09d3]
+	PrepareEventRoot 2f 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@4b09d3]
+	PrepareEventRoot 33 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4b09d3.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@4b0abc]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call be 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 41 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 47 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4b0eb3]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4b0eb3]
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4b0eb3.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4b1048]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@4af3ea]
+	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@4af3ea]
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
-	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 82 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@4af74a]
+	PrepareEventRoot cf 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4af74a.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer b9 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4af77f]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 83 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@4af86a]
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4af8a6]
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@4af3ea]
+	PrepareEventRoot c4 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4af3ea.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4af42f]
+	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call d3 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4af5ea]
+	PrepareEventRoot cc 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4af5ea.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4af636]
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 57 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4af56a]
+	PrepareEventRoot ca 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4af56a.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4af5af]
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4b1476]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4b1644]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4b1644.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 85 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer bc 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 86 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 6b 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1387: ProcessType[*main.bigStruct]
-	ProcessPointer a0 00 00 00 
-	Return 
-// 0x138d: ProcessType[*main.condFields]
-	ProcessPointer 79 00 00 00 
-	Return 
-// 0x1393: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 42 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.p]
-	ProcessPointer 8a 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.synctestBubble]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.traceBuf]
-	ProcessPointer 50 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13db: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer b0 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*table<string,int>]
-	ProcessPointer 91 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 99 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a1d: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x13f3: ProcessType[*uint]
+// 0x1a23: ProcessType[*main.condFields]
+	ProcessPointer 79 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*main.lenFields]
+	ProcessPointer 7c 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 42 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.p]
+	ProcessPointer 8d 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.synctestBubble]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.traceBuf]
+	ProcessPointer 50 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer b3 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*table<string,int>]
+	ProcessPointer 94 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 9c 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a6 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*uint]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x13f9: ProcessType[*uint16]
+// 0x1a95: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint32]
+// 0x1a9b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint64]
+// 0x1aa1: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uint8]
+// 0x1aa7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1411: ProcessType[*uintptr]
+// 0x1aad: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1417: ProcessType[[2]*runtime.traceBuf]
+// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 6b 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1427: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1ac3: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1437: ProcessType[[3]string]
+// 0x1ad3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1447: ProcessType[[]*runtime.p]
+// 0x1ae3: ProcessType[[]*runtime.p]
+	ProcessSlice 8e 00 00 00 08 00 00 00 
+	Return 
+// 0x1aed: ProcessType[[]*runtime.p.array]
+	ProcessSliceDataPrep 
+	Call 53 1a 00 00 // ProcessType[*runtime.p]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1af9: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 77 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b05: ProcessType[[]*table<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 7d 1a 00 00 // ProcessType[*table<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b11: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 83 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b1d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 89 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]int]
+	ProcessSlice 90 00 00 00 08 00 00 00 
+	Return 
+// 0x1b33: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 64 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 6f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b4b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+	ProcessSliceDataPrep 
+	Call 7a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b57: ProcessType[[]string]
+	ProcessSlice 92 00 00 00 10 00 00 00 
+	Return 
+// 0x1b61: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 90 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b6d: ProcessType[[]uint8]
+	ProcessSlice 89 00 00 00 01 00 00 00 
+	Return 
+// 0x1b77: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1451: ProcessType[[]*runtime.p.array]
-	ProcessSliceDataPrep 
-	Call b7 13 00 00 // ProcessType[*runtime.p]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x145d: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call db 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1469: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call e1 13 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1475: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1481: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call ed 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]int]
-	ProcessSlice 8d 00 00 00 08 00 00 00 
-	Return 
-// 0x1497: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call 9a 15 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call a5 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14af: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
-	ProcessSliceDataPrep 
-	Call b0 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14bb: ProcessType[[]string]
-	ProcessSlice 8f 00 00 00 10 00 00 00 
-	Return 
-// 0x14c5: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call c6 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14d1: ProcessType[[]uint8]
-	ProcessSlice 86 00 00 00 01 00 00 00 
-	Return 
-// 0x14db: ProcessType[[]uintptr]
-	ProcessSlice 88 00 00 00 08 00 00 00 
-	Return 
-// 0x14e5: ProcessType[error]
+// 0x1b81: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14e7: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b8 00 00 00 88 00 00 00 00 08 
+// 0x1b83: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14f3: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 98 00 00 00 c8 00 00 00 00 08 
+// 0x1b8f: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14ff: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups a2 00 00 00 c8 00 00 00 00 08 
+// 0x1b9b: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x150b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
+// 0x1ba7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1517: ProcessType[main.condFields]
+// 0x1bb3: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1522: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b7 00 00 00 b3 00 00 00 10 18 
+// 0x1bbe: ProcessType[main.lenFields]
+	Call 90 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 29 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 71 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x152e: ProcessType[map<string,int>]
-	ProcessGoSwissMap 97 00 00 00 94 00 00 00 10 18 
+// 0x1bec: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x153a: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap a1 00 00 00 9c 00 00 00 10 18 
+// 0x1bf8: ProcessType[map<string,int>]
+	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1546: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap ae 00 00 00 a6 00 00 00 10 18 
+// 0x1c04: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1552: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer ab 00 00 00 
+// 0x1c10: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1558: ProcessType[map[string]int]
+// 0x1c1c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer ae 00 00 00 
+	Return 
+// 0x1c22: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x155e: ProcessType[map[string]main.bigStruct]
+// 0x1c28: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1564: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 7e 00 00 00 
+// 0x1c2e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 81 00 00 00 
 	Return 
-// 0x156a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c34: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call bb 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 85 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x157a: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c44: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call cb 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 95 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x158a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c54: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call d1 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9b 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x159a: ProcessType[noalg.map.group[string]int]
+// 0x1c64: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 44 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15a5: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c6f: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 34 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15b0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c7a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8a 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15bb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call c6 16 00 00 // ProcessType[string]
+// 0x1c85: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 90 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 13 00 00 // ProcessType[*main.bigStruct]
+	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15cb: ProcessType[noalg.struct { key string; elem int }]
-	Call c6 16 00 00 // ProcessType[string]
+// 0x1c95: ProcessType[noalg.struct { key string; elem int }]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15d1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c9b: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 52 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 1c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15dc: ProcessType[runtime.g]
+// 0x1ca6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._panic]
+	Call 35 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 13 00 00 // ProcessType[*runtime._defer]
+	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call d1 14 00 00 // ProcessType[[]uint8]
+	Call 6d 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.sudog]
+	Call 59 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.timer]
+	Call 65 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.coro]
+	Call 41 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 5f 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1641: ProcessType[runtime.m]
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+// 0x1d0b: ProcessType[runtime.m]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 47 14 00 00 // ProcessType[[]*runtime.p]
+	Call e3 1a 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call ab 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 75 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 80 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16ab: ProcessType[runtime.mLockProfile]
+// 0x1d75: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16b6: ProcessType[runtime.mTraceState]
+// 0x1d80: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 27 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call c3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16c6: ProcessType[string]
-	ProcessString 84 00 00 00 
+// 0x1d90: ProcessType[string]
+	ProcessString 87 00 00 00 
 	Return 
-// 0x16cc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d96: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e7 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 83 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16d7: ProcessType[table<string,int>]
+// 0x1da1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f3 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 8f 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16e2: ProcessType[table<string,main.bigStruct>]
+// 0x1dac: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ff 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9b 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16ed: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1db7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0b 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1826,31 +2240,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5131
+ID: 5 Len: 8 Enqueue: 6823
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5830
+ID: 9 Len: 16 Enqueue: 7568
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4957
+ID: 11 Len: 8 Enqueue: 6643
 ID: 12 Len: 8 Enqueue: 0
-ID: 13 Len: 16 Enqueue: 5349
+ID: 13 Len: 16 Enqueue: 7041
 ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5137
-ID: 20 Len: 8 Enqueue: 4987
-ID: 21 Len: 8 Enqueue: 5119
-ID: 22 Len: 440 Enqueue: 5596
+ID: 19 Len: 8 Enqueue: 6829
+ID: 20 Len: 8 Enqueue: 6673
+ID: 21 Len: 8 Enqueue: 6811
+ID: 22 Len: 440 Enqueue: 7334
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5017
+ID: 24 Len: 8 Enqueue: 6709
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5011
+ID: 26 Len: 8 Enqueue: 6703
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5041
-ID: 29 Len: 1816 Enqueue: 5697
+ID: 28 Len: 8 Enqueue: 6733
+ID: 29 Len: 1816 Enqueue: 7435
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1859,48 +2273,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5329
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 7021
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5053
+ID: 41 Len: 8 Enqueue: 6745
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5339
-ID: 44 Len: 8 Enqueue: 5065
+ID: 43 Len: 24 Enqueue: 7031
+ID: 44 Len: 8 Enqueue: 6757
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5029
+ID: 47 Len: 8 Enqueue: 6721
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5059
+ID: 49 Len: 8 Enqueue: 6751
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5035
+ID: 55 Len: 8 Enqueue: 6727
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 5191
+ID: 62 Len: 24 Enqueue: 6883
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 5047
-ID: 65 Len: 8 Enqueue: 5023
+ID: 64 Len: 8 Enqueue: 6739
+ID: 65 Len: 8 Enqueue: 6715
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 5803
+ID: 70 Len: 56 Enqueue: 7541
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5814
+ID: 75 Len: 56 Enqueue: 7552
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 5159
-ID: 78 Len: 16 Enqueue: 5143
-ID: 79 Len: 8 Enqueue: 5071
+ID: 77 Len: 32 Enqueue: 6851
+ID: 78 Len: 16 Enqueue: 6835
+ID: 79 Len: 8 Enqueue: 6763
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -1916,210 +2330,265 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 5077
+ID: 95 Len: 8 Enqueue: 6769
 ID: 96 Len: 8 Enqueue: 0
 ID: 97 Len: 16 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 4975
-ID: 99 Len: 8 Enqueue: 4981
-ID: 100 Len: 8 Enqueue: 4993
-ID: 101 Len: 8 Enqueue: 5125
-ID: 102 Len: 8 Enqueue: 4963
+ID: 98 Len: 8 Enqueue: 6661
+ID: 99 Len: 8 Enqueue: 6667
+ID: 100 Len: 8 Enqueue: 6679
+ID: 101 Len: 8 Enqueue: 6817
+ID: 102 Len: 8 Enqueue: 6649
 ID: 103 Len: 2 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 4969
-ID: 105 Len: 8 Enqueue: 5107
-ID: 106 Len: 8 Enqueue: 5113
-ID: 107 Len: 24 Enqueue: 5261
+ID: 104 Len: 8 Enqueue: 6655
+ID: 105 Len: 8 Enqueue: 6799
+ID: 106 Len: 8 Enqueue: 6805
+ID: 107 Len: 24 Enqueue: 6953
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 5307
-ID: 110 Len: 48 Enqueue: 5175
-ID: 111 Len: 8 Enqueue: 5464
+ID: 109 Len: 24 Enqueue: 6999
+ID: 110 Len: 48 Enqueue: 6867
+ID: 111 Len: 8 Enqueue: 7202
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5422
+ID: 113 Len: 48 Enqueue: 7160
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 5089
-ID: 116 Len: 8 Enqueue: 5470
+ID: 115 Len: 8 Enqueue: 6781
+ID: 116 Len: 8 Enqueue: 7208
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5434
+ID: 118 Len: 48 Enqueue: 7172
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5095
-ID: 121 Len: 80 Enqueue: 5399
+ID: 120 Len: 8 Enqueue: 6787
+ID: 121 Len: 80 Enqueue: 7091
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 5005
-ID: 124 Len: 8 Enqueue: 5476
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5446
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5101
-ID: 129 Len: 8 Enqueue: 4927
-ID: 130 Len: 8 Enqueue: 4933
-ID: 131 Len: 8 Enqueue: 4945
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 1 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 123 Len: 8 Enqueue: 6691
+ID: 124 Len: 72 Enqueue: 7102
+ID: 125 Len: 8 Enqueue: 6631
+ID: 126 Len: 8 Enqueue: 6697
+ID: 127 Len: 8 Enqueue: 7214
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 48 Enqueue: 7184
+ID: 130 Len: 8 Enqueue: 0
+ID: 131 Len: 8 Enqueue: 6793
+ID: 132 Len: 8 Enqueue: 6607
+ID: 133 Len: 8 Enqueue: 6613
+ID: 134 Len: 8 Enqueue: 6625
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 8 Enqueue: 0
+ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 8 Enqueue: 5201
+ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 5317
+ID: 142 Len: 8 Enqueue: 6893
+ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 32 Enqueue: 5847
-ID: 146 Len: 16 Enqueue: 5363
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 16 Enqueue: 7009
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 5530
-ID: 149 Len: 192 Enqueue: 5498
-ID: 150 Len: 24 Enqueue: 5579
-ID: 151 Len: 8 Enqueue: 5225
-ID: 152 Len: 200 Enqueue: 5271
-ID: 153 Len: 32 Enqueue: 5858
-ID: 154 Len: 16 Enqueue: 5375
-ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 5541
-ID: 157 Len: 192 Enqueue: 5482
-ID: 158 Len: 24 Enqueue: 5563
-ID: 159 Len: 8 Enqueue: 4999
-ID: 160 Len: 184 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 5237
-ID: 162 Len: 200 Enqueue: 5283
-ID: 163 Len: 32 Enqueue: 5869
-ID: 164 Len: 16 Enqueue: 5387
-ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 136 Enqueue: 5552
-ID: 167 Len: 128 Enqueue: 5514
-ID: 168 Len: 16 Enqueue: 5585
-ID: 169 Len: 8 Enqueue: 5458
-ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 48 Enqueue: 5410
-ID: 172 Len: 8 Enqueue: 0
-ID: 173 Len: 8 Enqueue: 5083
-ID: 174 Len: 8 Enqueue: 5249
-ID: 175 Len: 136 Enqueue: 5295
-ID: 176 Len: 32 Enqueue: 5836
-ID: 177 Len: 16 Enqueue: 5351
-ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 128 Enqueue: 0
-ID: 181 Len: 16 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 5213
-ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 8 Enqueue: 4939
-ID: 186 Len: 128 Enqueue: 0
-ID: 187 Len: 9 Enqueue: 0
-ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 17 Enqueue: 0
-ID: 190 Len: 0 Enqueue: 0
+ID: 148 Len: 32 Enqueue: 7585
+ID: 149 Len: 16 Enqueue: 7055
+ID: 150 Len: 8 Enqueue: 0
+ID: 151 Len: 200 Enqueue: 7268
+ID: 152 Len: 192 Enqueue: 7236
+ID: 153 Len: 24 Enqueue: 7317
+ID: 154 Len: 8 Enqueue: 6917
+ID: 155 Len: 200 Enqueue: 6963
+ID: 156 Len: 32 Enqueue: 7596
+ID: 157 Len: 16 Enqueue: 7067
+ID: 158 Len: 8 Enqueue: 0
+ID: 159 Len: 200 Enqueue: 7279
+ID: 160 Len: 192 Enqueue: 7220
+ID: 161 Len: 24 Enqueue: 7301
+ID: 162 Len: 8 Enqueue: 6685
+ID: 163 Len: 184 Enqueue: 0
+ID: 164 Len: 8 Enqueue: 6929
+ID: 165 Len: 200 Enqueue: 6975
+ID: 166 Len: 32 Enqueue: 7607
+ID: 167 Len: 16 Enqueue: 7079
+ID: 168 Len: 8 Enqueue: 0
+ID: 169 Len: 136 Enqueue: 7290
+ID: 170 Len: 128 Enqueue: 7252
+ID: 171 Len: 16 Enqueue: 7323
+ID: 172 Len: 8 Enqueue: 7196
+ID: 173 Len: 8 Enqueue: 0
+ID: 174 Len: 48 Enqueue: 7148
+ID: 175 Len: 8 Enqueue: 0
+ID: 176 Len: 8 Enqueue: 6775
+ID: 177 Len: 8 Enqueue: 6941
+ID: 178 Len: 136 Enqueue: 6987
+ID: 179 Len: 32 Enqueue: 7574
+ID: 180 Len: 16 Enqueue: 7043
+ID: 181 Len: 8 Enqueue: 0
+ID: 182 Len: 136 Enqueue: 0
+ID: 183 Len: 128 Enqueue: 0
+ID: 184 Len: 16 Enqueue: 0
+ID: 185 Len: 8 Enqueue: 0
+ID: 186 Len: 8 Enqueue: 6905
+ID: 187 Len: 136 Enqueue: 0
+ID: 188 Len: 8 Enqueue: 6619
+ID: 189 Len: 128 Enqueue: 0
+ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 33 Enqueue: 0
+ID: 192 Len: 17 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
 ID: 194 Len: 0 Enqueue: 0
-ID: 195 Len: 25 Enqueue: 0
-ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 25 Enqueue: 0
-ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 25 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 49 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
-ID: 203 Len: 49 Enqueue: 0
-ID: 204 Len: 17 Enqueue: 0
+ID: 195 Len: 0 Enqueue: 0
+ID: 196 Len: 33 Enqueue: 0
+ID: 197 Len: 0 Enqueue: 0
+ID: 198 Len: 25 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 25 Enqueue: 0
+ID: 201 Len: 0 Enqueue: 0
+ID: 202 Len: 25 Enqueue: 0
+ID: 203 Len: 0 Enqueue: 0
+ID: 204 Len: 49 Enqueue: 0
 ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 17 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
+ID: 206 Len: 49 Enqueue: 0
+ID: 207 Len: 17 Enqueue: 0
 ID: 208 Len: 0 Enqueue: 0
-ID: 209 Len: 0 Enqueue: 0
-ID: 210 Len: 17 Enqueue: 0
+ID: 209 Len: 17 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
 ID: 211 Len: 0 Enqueue: 0
-ID: 212 Len: 18 Enqueue: 0
-ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 17 Enqueue: 0
-ID: 215 Len: 0 Enqueue: 0
-ID: 216 Len: 19 Enqueue: 0
-ID: 217 Len: 0 Enqueue: 0
-ID: 218 Len: 17 Enqueue: 0
-ID: 219 Len: 0 Enqueue: 0
-ID: 220 Len: 17 Enqueue: 0
-ID: 221 Len: 0 Enqueue: 0
-ID: 222 Len: 21 Enqueue: 0
-ID: 223 Len: 0 Enqueue: 0
-ID: 224 Len: 17 Enqueue: 0
-ID: 225 Len: 0 Enqueue: 0
-ID: 226 Len: 25 Enqueue: 0
-ID: 227 Len: 0 Enqueue: 0
-ID: 228 Len: 17 Enqueue: 0
-ID: 229 Len: 0 Enqueue: 0
-ID: 230 Len: 17 Enqueue: 0
-ID: 231 Len: 0 Enqueue: 0
-ID: 232 Len: 18 Enqueue: 0
-ID: 233 Len: 0 Enqueue: 0
-ID: 234 Len: 17 Enqueue: 0
-ID: 235 Len: 0 Enqueue: 0
-ID: 236 Len: 19 Enqueue: 0
-ID: 237 Len: 0 Enqueue: 0
-ID: 238 Len: 17 Enqueue: 0
-ID: 239 Len: 0 Enqueue: 0
-ID: 240 Len: 21 Enqueue: 0
-ID: 241 Len: 0 Enqueue: 0
-ID: 242 Len: 17 Enqueue: 0
-ID: 243 Len: 0 Enqueue: 0
-ID: 244 Len: 25 Enqueue: 0
-ID: 245 Len: 0 Enqueue: 0
-ID: 246 Len: 17 Enqueue: 0
-ID: 247 Len: 0 Enqueue: 0
-ID: 248 Len: 17 Enqueue: 0
-ID: 249 Len: 0 Enqueue: 0
-ID: 250 Len: 17 Enqueue: 0
-ID: 251 Len: 0 Enqueue: 0
-ID: 252 Len: 17 Enqueue: 0
-ID: 253 Len: 0 Enqueue: 0
-ID: 254 Len: 18 Enqueue: 0
-ID: 255 Len: 0 Enqueue: 0
-ID: 256 Len: 17 Enqueue: 0
-ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 17 Enqueue: 0
-ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 33 Enqueue: 0
-ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 33 Enqueue: 0
-ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 17 Enqueue: 0
-ID: 265 Len: 0 Enqueue: 0
-ID: 266 Len: 17 Enqueue: 0
-ID: 267 Len: 0 Enqueue: 0
-ID: 268 Len: 17 Enqueue: 0
-ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 17 Enqueue: 0
-ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
-ID: 273 Len: 0 Enqueue: 0
-ID: 274 Len: 97 Enqueue: 0
-ID: 275 Len: 0 Enqueue: 0
-ID: 276 Len: 17 Enqueue: 0
-ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 17 Enqueue: 0
-ID: 279 Len: 0 Enqueue: 0
-ID: 280 Len: 25 Enqueue: 0
-ID: 281 Len: 0 Enqueue: 0
-ID: 282 Len: 17 Enqueue: 0
-ID: 283 Len: 0 Enqueue: 0
-ID: 284 Len: 25 Enqueue: 0
-ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 9 Enqueue: 0
-ID: 287 Len: 0 Enqueue: 0
-ID: 288 Len: 17 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 17 Enqueue: 0
+ID: 214 Len: 0 Enqueue: 0
+ID: 215 Len: 18 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 17 Enqueue: 0
+ID: 218 Len: 0 Enqueue: 0
+ID: 219 Len: 19 Enqueue: 0
+ID: 220 Len: 0 Enqueue: 0
+ID: 221 Len: 17 Enqueue: 0
+ID: 222 Len: 0 Enqueue: 0
+ID: 223 Len: 17 Enqueue: 0
+ID: 224 Len: 0 Enqueue: 0
+ID: 225 Len: 21 Enqueue: 0
+ID: 226 Len: 0 Enqueue: 0
+ID: 227 Len: 17 Enqueue: 0
+ID: 228 Len: 0 Enqueue: 0
+ID: 229 Len: 25 Enqueue: 0
+ID: 230 Len: 0 Enqueue: 0
+ID: 231 Len: 17 Enqueue: 0
+ID: 232 Len: 0 Enqueue: 0
+ID: 233 Len: 17 Enqueue: 0
+ID: 234 Len: 0 Enqueue: 0
+ID: 235 Len: 18 Enqueue: 0
+ID: 236 Len: 0 Enqueue: 0
+ID: 237 Len: 17 Enqueue: 0
+ID: 238 Len: 0 Enqueue: 0
+ID: 239 Len: 19 Enqueue: 0
+ID: 240 Len: 0 Enqueue: 0
+ID: 241 Len: 17 Enqueue: 0
+ID: 242 Len: 0 Enqueue: 0
+ID: 243 Len: 21 Enqueue: 0
+ID: 244 Len: 0 Enqueue: 0
+ID: 245 Len: 17 Enqueue: 0
+ID: 246 Len: 0 Enqueue: 0
+ID: 247 Len: 25 Enqueue: 0
+ID: 248 Len: 0 Enqueue: 0
+ID: 249 Len: 17 Enqueue: 0
+ID: 250 Len: 0 Enqueue: 0
+ID: 251 Len: 17 Enqueue: 0
+ID: 252 Len: 0 Enqueue: 0
+ID: 253 Len: 17 Enqueue: 0
+ID: 254 Len: 0 Enqueue: 0
+ID: 255 Len: 17 Enqueue: 0
+ID: 256 Len: 0 Enqueue: 0
+ID: 257 Len: 18 Enqueue: 0
+ID: 258 Len: 0 Enqueue: 0
+ID: 259 Len: 17 Enqueue: 0
+ID: 260 Len: 0 Enqueue: 0
+ID: 261 Len: 17 Enqueue: 0
+ID: 262 Len: 0 Enqueue: 0
+ID: 263 Len: 33 Enqueue: 0
+ID: 264 Len: 0 Enqueue: 0
+ID: 265 Len: 33 Enqueue: 0
+ID: 266 Len: 0 Enqueue: 0
+ID: 267 Len: 17 Enqueue: 0
+ID: 268 Len: 0 Enqueue: 0
+ID: 269 Len: 17 Enqueue: 0
+ID: 270 Len: 0 Enqueue: 0
+ID: 271 Len: 17 Enqueue: 0
+ID: 272 Len: 0 Enqueue: 0
+ID: 273 Len: 17 Enqueue: 0
+ID: 274 Len: 0 Enqueue: 0
+ID: 275 Len: 17 Enqueue: 0
+ID: 276 Len: 0 Enqueue: 0
+ID: 277 Len: 97 Enqueue: 0
+ID: 278 Len: 0 Enqueue: 0
+ID: 279 Len: 17 Enqueue: 0
+ID: 280 Len: 0 Enqueue: 0
+ID: 281 Len: 17 Enqueue: 0
+ID: 282 Len: 0 Enqueue: 0
+ID: 283 Len: 25 Enqueue: 0
+ID: 284 Len: 0 Enqueue: 0
+ID: 285 Len: 17 Enqueue: 0
+ID: 286 Len: 0 Enqueue: 0
+ID: 287 Len: 25 Enqueue: 0
+ID: 288 Len: 0 Enqueue: 0
 ID: 289 Len: 9 Enqueue: 0
-ID: 290 Len: 25 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 25 Enqueue: 0
-ID: 293 Len: 0 Enqueue: 0
-ID: 294 Len: 17 Enqueue: 0
+ID: 290 Len: 0 Enqueue: 0
+ID: 291 Len: 17 Enqueue: 0
+ID: 292 Len: 9 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 0 Enqueue: 0
 ID: 295 Len: 25 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 9 Enqueue: 0
-ID: 298 Len: 9 Enqueue: 0
-ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 17 Enqueue: 0
+ID: 297 Len: 17 Enqueue: 0
+ID: 298 Len: 25 Enqueue: 0
+ID: 299 Len: 17 Enqueue: 0
+ID: 300 Len: 0 Enqueue: 0
 ID: 301 Len: 9 Enqueue: 0
+ID: 302 Len: 0 Enqueue: 0
+ID: 303 Len: 17 Enqueue: 0
+ID: 304 Len: 0 Enqueue: 0
+ID: 305 Len: 9 Enqueue: 0
+ID: 306 Len: 0 Enqueue: 0
+ID: 307 Len: 33 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 9 Enqueue: 0
+ID: 310 Len: 0 Enqueue: 0
+ID: 311 Len: 41 Enqueue: 0
+ID: 312 Len: 0 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 0 Enqueue: 0
+ID: 315 Len: 25 Enqueue: 0
+ID: 316 Len: 0 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 25 Enqueue: 0
+ID: 320 Len: 0 Enqueue: 0
+ID: 321 Len: 89 Enqueue: 0
+ID: 322 Len: 0 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 0 Enqueue: 0
+ID: 325 Len: 9 Enqueue: 0
+ID: 326 Len: 0 Enqueue: 0
+ID: 327 Len: 9 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 9 Enqueue: 0
+ID: 330 Len: 0 Enqueue: 0
+ID: 331 Len: 9 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
+ID: 334 Len: 0 Enqueue: 0
+ID: 335 Len: 25 Enqueue: 0
+ID: 336 Len: 0 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 0 Enqueue: 0
+ID: 339 Len: 9 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 9 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 25 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
+ID: 347 Len: 97 Enqueue: 0
+ID: 348 Len: 0 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 9 Enqueue: 0
+ID: 353 Len: 9 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 17 Enqueue: 0
+ID: 356 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1f34]
-	PrepareEventRoot 68 01 00 00 11 00 00 00 
+	PrepareEventRoot 78 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1f79]
-	PrepareEventRoot 69 01 00 00 09 00 00 00 
+	PrepareEventRoot 79 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4c1f79.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2fca]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4c382a]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c36ae]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4c376e]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4c316a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c316a]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4c316a]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4c322a]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c32ea]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c30aa]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
@@ -377,7 +377,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	PrepareEventRoot 2f 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.condFields]
+	Call a0 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
@@ -470,7 +470,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	PrepareEventRoot 2c 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
@@ -520,7 +520,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.condFields]
+	Call a0 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@4c38ee]
 	PrepareEventRoot 0c 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call df 1b 00 00 // ProcessType[main.condFields]
+	Call 36 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	PrepareEventRoot 1a 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@4c346a]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
@@ -877,7 +877,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@4c346a]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@4c352a]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
@@ -921,7 +921,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@4c352a]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
@@ -965,7 +965,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@4c1c4a]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@4c2eaa]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@4c2eea]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ff 1a 00 00 // ProcessType[[3]string]
+	Call 56 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
+	Call ac 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
-	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	PrepareEventRoot 6c 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call df 1b 00 00 // ProcessType[main.condFields]
+	Call 36 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
-	PrepareEventRoot 60 01 00 00 61 00 00 00 
+	PrepareEventRoot 70 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@4c446e]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@4c446e]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	PrepareEventRoot 44 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 46 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@4c446e]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@4c446e]
-	PrepareEventRoot 40 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 4c 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4c458e]
-	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*string]
+	Call f4 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4c458e]
-	PrepareEventRoot 44 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 50 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*main.lenFields]
+	Call a6 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 54 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 64 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 68 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	PrepareEventRoot 3a 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 05 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	PrepareEventRoot 3c 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@4c41d3]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 3c 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 05 08 08 00 00 00 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+	PrepareEventRoot 3e 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@4c41d3]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call ac 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 42 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@4c41d3]
+// 0x1898: ProcessEvent[Probe[main.lenString]@4c41d3]
 	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call ea 1b 00 00 // ProcessType[main.lenFields]
+	Call 41 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 46 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 52 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 54 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 56 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 58 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 5e 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 60 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,500 +1689,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
-	PrepareEventRoot 52 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 62 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@4c2f6a]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@4c2f6a]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@4c304a]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@4c304a]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4c3086]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4c3086]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ff 1a 00 00 // ProcessType[[3]string]
+	Call 56 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]string]
+	Call da 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b1 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
-	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
+	PrepareEventRoot 75 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1d94: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.bigStruct]
+// 0x1d9a: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.condFields]
+// 0x1da0: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*main.lenFields]
+// 0x1da6: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._defer]
+// 0x1dac: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime._panic]
+// 0x1db2: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.cgoCallers]
+// 0x1db8: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.coro]
+// 0x1dbe: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.g]
+// 0x1dc4: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.m]
+// 0x1dca: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.p]
+// 0x1dd0: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.sudog]
+// 0x1dd6: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.synctestBubble]
+// 0x1ddc: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.timer]
+// 0x1de2: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*runtime.traceBuf]
+// 0x1de8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*runtime.xRegState]
+// 0x1dee: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*string]
+// 0x1df4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dfa: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*table<string,int>]
+// 0x1e00: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*table<string,main.bigStruct>]
+// 0x1e06: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e0c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint]
+// 0x1e12: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint16]
+// 0x1e18: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint32]
+// 0x1e1e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uint64]
+// 0x1e24: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[*uint8]
+// 0x1e2a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ad9: ProcessType[*uintptr]
+// 0x1e30: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[2]*runtime.traceBuf]
+// 0x1e36: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call e8 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aef: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e46: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call df 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 36 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1aff: ProcessType[[3]string]
+// 0x1e56: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b0f: ProcessType[[]*runtime.p]
+// 0x1e66: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]*runtime.p.array]
+// 0x1e70: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 79 1a 00 00 // ProcessType[*runtime.p]
+	Call d0 1d 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b25: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e7c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call fa 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b31: ProcessType[[]*table<string,int>.array]
+// 0x1e88: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call a9 1a 00 00 // ProcessType[*table<string,int>]
+	Call 00 1e 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b3d: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e94: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call af 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 06 1e 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1ea0: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call b5 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0c 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b55: ProcessType[[]int]
+// 0x1eac: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1eb6: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 90 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call e7 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b6b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1ec2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 9b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call f2 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ece: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a6 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call fd 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]string]
+// 0x1eda: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[[]string.array]
+// 0x1ee4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b99: ProcessType[[]uint8]
+// 0x1ef0: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1ba3: ProcessType[[]uintptr]
+// 0x1efa: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1bad: ProcessType[error]
+// 0x1f04: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1baf: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f06: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bbb: ProcessType[groupReference<string,int>]
+// 0x1f12: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bc7: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1f1e: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bd3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f2a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bdf: ProcessType[main.condFields]
+// 0x1f36: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1bea: ProcessType[main.lenFields]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x1f41: ProcessType[main.lenFields]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
+	Call ac 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*string]
+	Call f4 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c18: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f6f: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1c24: ProcessType[map<string,int>]
+// 0x1f7b: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1c30: ProcessType[map<string,main.bigStruct>]
+// 0x1f87: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c3c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f93: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1c48: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f9f: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1c4e: ProcessType[map[string]int]
+// 0x1fa5: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c54: ProcessType[map[string]main.bigStruct]
+// 0x1fab: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1c5a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fb1: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1c60: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1fb7: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b1 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 08 20 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c70: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1fc7: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 18 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c80: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1fd7: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 1e 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c90: ProcessType[noalg.map.group[string]int]
+// 0x1fe7: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 70 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call c7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c9b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1ff2: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call b7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ca6: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ffd: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 80 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d7 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1cb1: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x2008: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 9a 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1cc1: ProcessType[noalg.struct { key string; elem int }]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x2018: ProcessType[noalg.struct { key string; elem int }]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1cc7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x201e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 9f 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cd2: ProcessType[runtime.g]
+// 0x2029: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime._panic]
+	Call b2 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._defer]
+	Call ac 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 99 1b 00 00 // ProcessType[[]uint8]
+	Call f0 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.sudog]
+	Call d6 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.timer]
+	Call e2 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.coro]
+	Call be 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call dc 1d 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 1d 00 00 // ProcessType[runtime.xRegPerG]
+	Call 2d 21 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1d41: ProcessType[runtime.m]
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+// 0x2098: ProcessType[runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]*runtime.p]
+	Call 66 1e 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b8 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call b5 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 0c 21 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 17 21 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call d0 1d 00 00 // ProcessType[runtime.mWeakPointer]
+	Call 27 21 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x1db5: ProcessType[runtime.mLockProfile]
+// 0x210c: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1dc0: ProcessType[runtime.mTraceState]
+// 0x2117: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call ef 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call 46 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1dd0: ProcessType[runtime.mWeakPointer]
-	Call 3d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x2127: ProcessType[runtime.mWeakPointer]
+	Call 94 1d 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1dd6: ProcessType[runtime.xRegPerG]
-	Call 97 1a 00 00 // ProcessType[*runtime.xRegState]
+// 0x212d: ProcessType[runtime.xRegPerG]
+	Call ee 1d 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1ddc: ProcessType[string]
+// 0x2133: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x1de2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2139: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call af 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 06 1f 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1ded: ProcessType[table<string,int>]
+// 0x2144: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bb 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 12 1f 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1df8: ProcessType[table<string,main.bigStruct>]
+// 0x214f: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 1e 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1e03: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x215a: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2a 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2256,32 +2450,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6867
+ID: 5 Len: 8 Enqueue: 7722
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7644
+ID: 9 Len: 16 Enqueue: 8499
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6675
+ID: 11 Len: 8 Enqueue: 7530
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7085
+ID: 15 Len: 16 Enqueue: 7940
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6873
+ID: 19 Len: 8 Enqueue: 7728
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 6705
-ID: 22 Len: 8 Enqueue: 6855
-ID: 23 Len: 456 Enqueue: 7378
+ID: 21 Len: 8 Enqueue: 7560
+ID: 22 Len: 8 Enqueue: 7710
+ID: 23 Len: 456 Enqueue: 8233
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 6747
+ID: 25 Len: 8 Enqueue: 7602
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 6741
+ID: 27 Len: 8 Enqueue: 7596
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 6771
-ID: 30 Len: 1824 Enqueue: 7489
+ID: 29 Len: 8 Enqueue: 7626
+ID: 30 Len: 1824 Enqueue: 8344
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2290,51 +2484,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7065
-ID: 40 Len: 8 Enqueue: 6669
+ID: 39 Len: 24 Enqueue: 7920
+ID: 40 Len: 8 Enqueue: 7524
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 6783
+ID: 42 Len: 8 Enqueue: 7638
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7075
-ID: 45 Len: 8 Enqueue: 6795
+ID: 44 Len: 24 Enqueue: 7930
+ID: 45 Len: 8 Enqueue: 7650
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 6759
+ID: 48 Len: 8 Enqueue: 7614
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 6789
+ID: 50 Len: 8 Enqueue: 7644
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 7638
-ID: 53 Len: 8 Enqueue: 6807
+ID: 52 Len: 8 Enqueue: 8493
+ID: 53 Len: 8 Enqueue: 7662
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 6765
+ID: 59 Len: 8 Enqueue: 7620
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 6927
+ID: 66 Len: 24 Enqueue: 7782
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 6777
-ID: 69 Len: 8 Enqueue: 6753
+ID: 68 Len: 8 Enqueue: 7632
+ID: 69 Len: 8 Enqueue: 7608
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7605
+ID: 75 Len: 56 Enqueue: 8460
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 7616
-ID: 81 Len: 32 Enqueue: 6895
-ID: 82 Len: 16 Enqueue: 6879
-ID: 83 Len: 8 Enqueue: 6801
+ID: 80 Len: 72 Enqueue: 8471
+ID: 81 Len: 32 Enqueue: 7750
+ID: 82 Len: 16 Enqueue: 7734
+ID: 83 Len: 8 Enqueue: 7656
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2349,48 +2543,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 7632
-ID: 99 Len: 8 Enqueue: 6717
+ID: 98 Len: 8 Enqueue: 8487
+ID: 99 Len: 8 Enqueue: 7572
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 6813
+ID: 101 Len: 8 Enqueue: 7668
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 6693
-ID: 104 Len: 8 Enqueue: 6699
-ID: 105 Len: 8 Enqueue: 6711
-ID: 106 Len: 8 Enqueue: 6861
-ID: 107 Len: 8 Enqueue: 6681
+ID: 103 Len: 8 Enqueue: 7548
+ID: 104 Len: 8 Enqueue: 7554
+ID: 105 Len: 8 Enqueue: 7566
+ID: 106 Len: 8 Enqueue: 7716
+ID: 107 Len: 8 Enqueue: 7536
 ID: 108 Len: 2 Enqueue: 0
-ID: 109 Len: 8 Enqueue: 6687
-ID: 110 Len: 8 Enqueue: 6843
-ID: 111 Len: 8 Enqueue: 6849
-ID: 112 Len: 24 Enqueue: 6997
+ID: 109 Len: 8 Enqueue: 7542
+ID: 110 Len: 8 Enqueue: 7698
+ID: 111 Len: 8 Enqueue: 7704
+ID: 112 Len: 24 Enqueue: 7852
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7043
-ID: 115 Len: 48 Enqueue: 6911
-ID: 116 Len: 8 Enqueue: 7246
+ID: 114 Len: 24 Enqueue: 7898
+ID: 115 Len: 48 Enqueue: 7766
+ID: 116 Len: 8 Enqueue: 8101
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7204
+ID: 118 Len: 48 Enqueue: 8059
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6825
-ID: 121 Len: 8 Enqueue: 7252
+ID: 120 Len: 8 Enqueue: 7680
+ID: 121 Len: 8 Enqueue: 8107
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 7216
+ID: 123 Len: 48 Enqueue: 8071
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 6831
-ID: 126 Len: 80 Enqueue: 7135
+ID: 125 Len: 8 Enqueue: 7686
+ID: 126 Len: 80 Enqueue: 7990
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 6729
-ID: 129 Len: 72 Enqueue: 7146
-ID: 130 Len: 8 Enqueue: 6663
-ID: 131 Len: 8 Enqueue: 6735
-ID: 132 Len: 8 Enqueue: 7258
+ID: 128 Len: 8 Enqueue: 7584
+ID: 129 Len: 72 Enqueue: 8001
+ID: 130 Len: 8 Enqueue: 7518
+ID: 131 Len: 8 Enqueue: 7590
+ID: 132 Len: 8 Enqueue: 8113
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 7228
+ID: 134 Len: 48 Enqueue: 8083
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 6837
-ID: 137 Len: 8 Enqueue: 6639
-ID: 138 Len: 8 Enqueue: 6645
-ID: 139 Len: 8 Enqueue: 6657
+ID: 136 Len: 8 Enqueue: 7692
+ID: 137 Len: 8 Enqueue: 7494
+ID: 138 Len: 8 Enqueue: 7500
+ID: 139 Len: 8 Enqueue: 7512
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2398,53 +2592,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 6937
+ID: 147 Len: 8 Enqueue: 7792
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7053
+ID: 151 Len: 16 Enqueue: 7908
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 7661
-ID: 154 Len: 16 Enqueue: 7099
+ID: 153 Len: 32 Enqueue: 8516
+ID: 154 Len: 16 Enqueue: 7954
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 7312
-ID: 157 Len: 192 Enqueue: 7280
-ID: 158 Len: 24 Enqueue: 7361
-ID: 159 Len: 8 Enqueue: 6961
-ID: 160 Len: 200 Enqueue: 7007
-ID: 161 Len: 32 Enqueue: 7672
-ID: 162 Len: 16 Enqueue: 7111
+ID: 156 Len: 200 Enqueue: 8167
+ID: 157 Len: 192 Enqueue: 8135
+ID: 158 Len: 24 Enqueue: 8216
+ID: 159 Len: 8 Enqueue: 7816
+ID: 160 Len: 200 Enqueue: 7862
+ID: 161 Len: 32 Enqueue: 8527
+ID: 162 Len: 16 Enqueue: 7966
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 7323
-ID: 165 Len: 192 Enqueue: 7264
-ID: 166 Len: 24 Enqueue: 7345
-ID: 167 Len: 8 Enqueue: 6723
+ID: 164 Len: 200 Enqueue: 8178
+ID: 165 Len: 192 Enqueue: 8119
+ID: 166 Len: 24 Enqueue: 8200
+ID: 167 Len: 8 Enqueue: 7578
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 6973
-ID: 170 Len: 200 Enqueue: 7019
-ID: 171 Len: 32 Enqueue: 7683
-ID: 172 Len: 16 Enqueue: 7123
+ID: 169 Len: 8 Enqueue: 7828
+ID: 170 Len: 200 Enqueue: 7874
+ID: 171 Len: 32 Enqueue: 8538
+ID: 172 Len: 16 Enqueue: 7978
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 7334
-ID: 175 Len: 128 Enqueue: 7296
-ID: 176 Len: 16 Enqueue: 7367
-ID: 177 Len: 8 Enqueue: 7240
+ID: 174 Len: 136 Enqueue: 8189
+ID: 175 Len: 128 Enqueue: 8151
+ID: 176 Len: 16 Enqueue: 8222
+ID: 177 Len: 8 Enqueue: 8095
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 7192
+ID: 179 Len: 48 Enqueue: 8047
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6819
-ID: 182 Len: 8 Enqueue: 6985
-ID: 183 Len: 136 Enqueue: 7031
-ID: 184 Len: 32 Enqueue: 7650
-ID: 185 Len: 16 Enqueue: 7087
+ID: 181 Len: 8 Enqueue: 7674
+ID: 182 Len: 8 Enqueue: 7840
+ID: 183 Len: 136 Enqueue: 7886
+ID: 184 Len: 32 Enqueue: 8505
+ID: 185 Len: 16 Enqueue: 7942
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 6949
+ID: 191 Len: 8 Enqueue: 7804
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 6651
+ID: 193 Len: 8 Enqueue: 7506
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
@@ -2565,51 +2759,67 @@ ID: 310 Len: 9 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
 ID: 312 Len: 33 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 9 Enqueue: 0
+ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 41 Enqueue: 0
+ID: 316 Len: 9 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 0 Enqueue: 0
+ID: 318 Len: 17 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
-ID: 320 Len: 25 Enqueue: 0
+ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 9 Enqueue: 0
+ID: 322 Len: 41 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
-ID: 324 Len: 25 Enqueue: 0
+ID: 324 Len: 17 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 89 Enqueue: 0
+ID: 326 Len: 9 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 0 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
 ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 9 Enqueue: 0
+ID: 332 Len: 25 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
-ID: 336 Len: 9 Enqueue: 0
+ID: 336 Len: 25 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 17 Enqueue: 0
+ID: 338 Len: 89 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 25 Enqueue: 0
+ID: 340 Len: 9 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 0 Enqueue: 0
+ID: 342 Len: 9 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
 ID: 344 Len: 9 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
 ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
-ID: 348 Len: 25 Enqueue: 0
+ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 0 Enqueue: 0
+ID: 350 Len: 17 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 97 Enqueue: 0
+ID: 352 Len: 17 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 0 Enqueue: 0
+ID: 354 Len: 17 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 0 Enqueue: 0
-ID: 357 Len: 9 Enqueue: 0
+ID: 356 Len: 25 Enqueue: 0
+ID: 357 Len: 0 Enqueue: 0
 ID: 358 Len: 9 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
-ID: 360 Len: 17 Enqueue: 0
-ID: 361 Len: 9 Enqueue: 0
+ID: 360 Len: 9 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 9 Enqueue: 0
+ID: 363 Len: 0 Enqueue: 0
+ID: 364 Len: 25 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 0 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 97 Enqueue: 0
+ID: 369 Len: 0 Enqueue: 0
+ID: 370 Len: 0 Enqueue: 0
+ID: 371 Len: 0 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 9 Enqueue: 0
+ID: 374 Len: 9 Enqueue: 0
+ID: 375 Len: 0 Enqueue: 0
+ID: 376 Len: 17 Enqueue: 0
+ID: 377 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1f34]
 	PrepareEventRoot 31 01 00 00 11 00 00 00 
@@ -24,33 +24,33 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 78 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1f79]
 	PrepareEventRoot 32 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4c1f79.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4c2a0a.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2a0a.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 91 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2a0a]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2fca]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2a0a.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2a0a.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4c2a5f]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4c301f]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0x4c326a]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0x4c382a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@4c326a]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c326a]
+// 0x103: ProcessEvent[Probe[main.condBool]@4c382a]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
 	PrepareEventRoot ff 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@4c32dc]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@4c389c]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0x4c326a]
+// 0x121: ProcessCondition[Probe[main.condBool]@0x4c382a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@4c326a]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c326a]
+// 0x159: ProcessEvent[Probe[main.condBool]@4c382a]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
 	PrepareEventRoot 01 01 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@4c32dc]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@4c389c]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0x4c326a.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0x4c382a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@4c326a]
+// 0x1af: ProcessEvent[Probe[main.condBool]@4c382a]
 	PrepareEventRoot 03 01 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c326a.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c326a.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4c32dc]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@4c389c]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4c30ee.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4c36ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c30ee]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c36ae]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4c30ee.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4c36ae.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4c3165]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4c3725]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4c31ae.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0x4c376e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@4c31ae]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@4c376e]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4c31ae.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4c376e.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4c3225]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@4c37e5]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0x4c2baa]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0x4c316a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@4c2baa]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c2baa]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@4c316a]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c316a]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@4c2c1c]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@4c31dc]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@4c2baa]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@4c316a]
 	PrepareEventRoot dd 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c2baa.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4c2c1c]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4c31dc]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4c2c6a]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@4c2c6a]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c2c6a]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@4c322a]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4c2cdc]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@4c329c]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0x4c2c6a]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@4c2c6a]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c2c6a]
+// 0x384: ProcessEvent[Probe[main.condInt32]@4c322a]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	PrepareEventRoot e1 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@4c2cdc]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@4c329c]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@4c2c6a]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@4c322a]
 	PrepareEventRoot e3 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c2c6a.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4c2cdc]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4c329c]
 	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4c2d2a]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4c32ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@4c2d2a]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c2d2a]
+// 0x437: ProcessEvent[Probe[main.condInt64]@4c32ea]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c32ea]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4c2d9c]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@4c335c]
 	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@4c2d2a]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	PrepareEventRoot e7 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c2d2a.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4c2d9c]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4c335c]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4c2aea]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4c30aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,86 +311,80 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@4c2aea]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c2aea]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@4c30aa]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c30aa]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4c2b5c]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4c311c]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@4c2aea]
+// 0x539: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	PrepareEventRoot d9 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c2aea.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4c2b5c]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@4c311c]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4c38c4]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
 	ConditionBegin 
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprPushOffset 08 00 00 00 
 	ExprLoadLiteral 08 00 07 00 00 00 00 00 00 00 
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x57a: ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x59c: ProcessEvent[Probe[main.condLine]Line@4c38c4]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c38c4]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@4c3e81]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
 	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 7a 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	Return 
-// 0x5b0: ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x5ee: ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@4c3e81]
+	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[1]]
 	Return 
-// 0x604: ProcessEvent[Probe[main.condLine]Line@4c38c4]
-	PrepareEventRoot 2c 01 00 00 21 00 00 00 
-	Call b0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[1]]
-	Call ee 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c38c4.expr[2]]
-	Return 
-// 0x61d: ProcessCondition[Probe[main.condNilPtrStruct]@0x4c368e]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x63f: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x661: ProcessEvent[Probe[main.condNilPtrStruct]@4c368e]
-	Call 1d 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c368e]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
 	PrepareEventRoot 1f 01 00 00 11 00 00 00 
-	Call 3f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Return 
-// 0x675: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c370f]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x67f: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ba 13 00 00 // ProcessType[*main.condFields]
+	Call 93 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x69a: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessEvent[Probe[main.condNilPtrStruct]@4c368e]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	PrepareEventRoot 21 01 00 00 19 00 00 00 
-	Call 7f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[0]]
-	Call 9a 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c368e.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	Return 
-// 0x6d0: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c370f]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x6da: ProcessCondition[Probe[main.condOnly]@0x4c37ea]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6f7: ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x70d: ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x72f: ProcessEvent[Probe[main.condOnly]@4c37ea]
-	Call da 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c37ea]
+// 0x708: ProcessEvent[Probe[main.condOnly]@4c3daa]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
-	Call f7 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[0]]
-	Call 0d 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
-// 0x748: ProcessEvent[Probe[main.condOnly]Return@4c385c]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x752: ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x768: ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x78a: ProcessEvent[Probe[main.condOnly]@4c37ea]
+// 0x763: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call 52 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[0]]
-	Call 68 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c37ea.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
-// 0x79e: ProcessEvent[Probe[main.condOnly]Return@4c385c]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
 	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x7a8: ProcessCondition[Probe[main.condPtrStructArg]@0x4c352e]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7ca: ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x7ec: ProcessEvent[Probe[main.condPtrStructArg]@4c352e]
-	Call a8 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c352e]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call ca 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
-// 0x800: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3636]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x80a: ProcessCondition[Probe[main.condPtrStructArg]@0x4c352e]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x82e: ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x850: ProcessEvent[Probe[main.condPtrStructArg]@4c352e]
-	Call 0a 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c352e]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	PrepareEventRoot 1b 01 00 00 11 00 00 00 
-	Call 2e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
-// 0x864: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3636]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ba 13 00 00 // ProcessType[*main.condFields]
+	Call 93 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x889: ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x8ab: ProcessEvent[Probe[main.condPtrStructArg]@4c352e]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	PrepareEventRoot 1d 01 00 00 19 00 00 00 
-	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[0]]
-	Call 89 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c352e.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	Return 
-// 0x8bf: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3636]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x8c9: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c374a]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8e6: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8fc: ProcessEvent[Probe[main.condReturnAndLocal]@4c374a]
-	Call c9 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c374a]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	PrepareEventRoot 23 01 00 00 09 00 00 00 
-	Call e6 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Return 
-// 0x910: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c37bb]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
 	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x91a: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x930: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x946: ProcessEvent[Probe[main.condReturnAndLocal]@4c374a]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
 	PrepareEventRoot 25 01 00 00 11 00 00 00 
-	Call 1a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[0]]
-	Call 30 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c374a.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	Return 
-// 0x95a: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c37bb.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x970: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c37bb]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
 	PrepareEventRoot 26 01 00 00 09 00 00 00 
-	Call 5a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c37bb.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	Return 
-// 0x97f: ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0x958: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9a1: ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x9c3: ProcessEvent[Probe[main.condString]@4c332e]
-	Call 7f 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0x99c: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call a1 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
-// 0x9d7: ProcessEvent[Probe[main.condString]Return@4c33a5]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0x9e1: ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9fe: ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa20: ProcessEvent[Probe[main.condString]@4c332e]
-	Call e1 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0x9f9: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call fe 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
-// 0xa34: ProcessEvent[Probe[main.condString]Return@4c33a5]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xa3e: ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa60: ProcessExpression[Probe[main.condString]@0x4c332e.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa82: ProcessEvent[Probe[main.condString]@4c332e]
+// 0xa5b: ProcessEvent[Probe[main.condString]@4c38ee]
 	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call 3e 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
-	Call 60 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xa96: ProcessEvent[Probe[main.condString]Return@4c33a5]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xaa0: ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0xa79: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xac2: ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xae4: ProcessExpression[Probe[main.condString]@0x4c332e.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xb06: ProcessEvent[Probe[main.condString]@4c332e]
-	Call a0 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c332e]
+// 0xadf: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 0b 01 00 00 21 00 00 00 
-	Call c2 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[0]]
-	Call e4 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c332e.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xb1f: ProcessEvent[Probe[main.condString]Return@4c33a5]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xb29: ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb48: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xb6a: ProcessEvent[Probe[main.condStructArg]@4c33ee]
-	Call 29 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 48 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xb7e: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xb88: ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xba4: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xbc6: ProcessEvent[Probe[main.condStructArg]@4c33ee]
-	Call 88 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call a4 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xbda: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xbe4: ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc07: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xc29: ProcessEvent[Probe[main.condStructArg]@4c33ee]
-	Call e4 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 07 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc3d: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xc47: ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc66: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xc88: ProcessEvent[Probe[main.condStructArg]@4c33ee]
-	Call 47 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call 66 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc9c: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xca6: ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcc7: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xce9: ProcessEvent[Probe[main.condStructArg]@4c33ee]
-	Call a6 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c33ee]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call c7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xcfd: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xd07: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 4a 15 00 00 // ProcessType[main.condFields]
+	Call 23 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd28: ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xd4a: ProcessEvent[Probe[main.condStructArg]@4c33ee]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	PrepareEventRoot 17 01 00 00 61 00 00 00 
-	Call 07 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[0]]
-	Call 28 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c33ee.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	Return 
-// 0xd5e: ProcessEvent[Probe[main.condStructArg]Return@4c34f0]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0xd68: ProcessCondition[Probe[main.condUint16]@0x4c2eaa]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd7f: ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xda1: ProcessEvent[Probe[main.condUint16]@4c2eaa]
-	Call 68 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c2eaa]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@4c346a]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	PrepareEventRoot ef 00 00 00 11 00 00 00 
-	Call 7f 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	Return 
-// 0xdb5: ProcessEvent[Probe[main.condUint16]Return@4c2f1c]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdbf: ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdd5: ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xdf7: ProcessEvent[Probe[main.condUint16]@4c2eaa]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@4c346a]
 	PrepareEventRoot f1 00 00 00 13 00 00 00 
-	Call bf 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[0]]
-	Call d5 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c2eaa.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	Return 
-// 0xe0b: ProcessEvent[Probe[main.condUint16]Return@4c2f1c]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe15: ProcessCondition[Probe[main.condUint32]@0x4c2f6a]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe2e: ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xe50: ProcessEvent[Probe[main.condUint32]@4c2f6a]
-	Call 15 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c2f6a]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@4c352a]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	PrepareEventRoot f3 00 00 00 11 00 00 00 
-	Call 2e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	Return 
-// 0xe64: ProcessEvent[Probe[main.condUint32]Return@4c2fdc]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xe6e: ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe84: ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xea6: ProcessEvent[Probe[main.condUint32]@4c2f6a]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@4c352a]
 	PrepareEventRoot f5 00 00 00 15 00 00 00 
-	Call 6e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[0]]
-	Call 84 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c2f6a.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	Return 
-// 0xeba: ProcessEvent[Probe[main.condUint32]Return@4c2fdc]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xec4: ProcessCondition[Probe[main.condUint64]@0x4c302a]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xee1: ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xf03: ProcessEvent[Probe[main.condUint64]@4c302a]
-	Call c4 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c302a]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@4c35ea]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call e1 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	Return 
-// 0xf17: ProcessEvent[Probe[main.condUint64]Return@4c309c]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf21: ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf37: ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xf59: ProcessEvent[Probe[main.condUint64]@4c302a]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	PrepareEventRoot f9 00 00 00 19 00 00 00 
-	Call 21 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[0]]
-	Call 37 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c302a.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	Return 
-// 0xf6d: ProcessEvent[Probe[main.condUint64]Return@4c309c]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xf77: ProcessCondition[Probe[main.condUint8]@0x4c2dea]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf8d: ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xfaf: ProcessEvent[Probe[main.condUint8]@4c2dea]
-	Call 77 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c2dea]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call 8d 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0xfc3: ProcessEvent[Probe[main.condUint8]Return@4c2e5c]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xfcd: ProcessCondition[Probe[main.condUint8]@0x4c2dea]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,573 +1008,573 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfe3: ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1005: ProcessEvent[Probe[main.condUint8]@4c2dea]
-	Call cd 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c2dea]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot eb 00 00 00 11 00 00 00 
-	Call e3 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0x1019: ProcessEvent[Probe[main.condUint8]Return@4c2e5c]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x1023: ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1039: ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x105b: ProcessEvent[Probe[main.condUint8]@4c2dea]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	PrepareEventRoot ed 00 00 00 12 00 00 00 
-	Call 23 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[0]]
-	Call 39 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c2dea.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	Return 
-// 0x106f: ProcessEvent[Probe[main.condUint8]Return@4c2e5c]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0x1079: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1089: ProcessEvent[Probe[main.inlined]@4c1c4a]
+// 0x1062: ProcessEvent[Probe[main.inlined]@4c1c4a]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 79 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	Return 
-// 0x1098: ProcessExpression[Probe[main.inlined]@0x4c28ea.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ae: ProcessEvent[Probe[main.inlined]@4c28ea]
+// 0x1087: ProcessEvent[Probe[main.inlined]@4c2eaa]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 98 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c28ea.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	Return 
-// 0x10bd: ProcessEvent[Probe[main.inlined]Return@4c292a]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@4c2eea]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x10c7: ProcessExpression[Probe[main.intArg]@0x4c25ca.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10dd: ProcessEvent[Probe[main.intArg]@4c25ca]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@4c2b8a]
 	PrepareEventRoot c0 00 00 00 09 00 00 00 
-	Call c7 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c25ca.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	Return 
-// 0x10ec: ProcessEvent[Probe[main.intArg]Return@4c260a]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4c2bca]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x10f6: ProcessExpression[Probe[main.intArrayArg]@0x4c274a.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x1112: ProcessEvent[Probe[main.intArrayArg]@4c274a]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call f6 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c274a.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	Return 
-// 0x1121: ProcessEvent[Probe[main.intArrayArg]Return@4c2796]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x112b: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c28c0.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 6a 14 00 00 // ProcessType[[3]string]
+	Call 43 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x114c: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c28c0]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
 	PrepareEventRoot d0 00 00 00 31 00 00 00 
-	Call 2b 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c28c0.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	Return 
-// 0x115b: ProcessExpression[Probe[main.intSliceArg]@0x4c26ca.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call c0 14 00 00 // ProcessType[[]int]
+	Call 99 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1184: ProcessEvent[Probe[main.intSliceArg]@4c26ca]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call 5b 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c26ca.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	Return 
-// 0x1193: ProcessEvent[Probe[main.intSliceArg]Return@4c270f]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x119d: ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x11bf: ProcessEvent[Probe[main.stringArg]@4c264a]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call 9d 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.stringArg]Return@4c268f]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessEvent[Probe[main.stringArg]@4c264a]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x11e2: ProcessEvent[Probe[main.stringArg]Return@4c268f]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x11ec: ProcessExpression[Probe[main.mapArg]@0x4c29aa.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[string]int]
+	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1207: ProcessExpression[Probe[main.mapArg]@0x4c29aa.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[string]int]
+	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1222: ProcessEvent[Probe[main.mapArg]@4c29aa]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@4c2f6a]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call ec 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c29aa.expr[0]]
-	Call 07 12 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c29aa.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	Return 
-// 0x1236: ProcessEvent[Probe[main.mapArg]Return@4c29df]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1240: ProcessEvent[Probe[main.noArgs]@4c2a8a]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@4c304a]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x124a: ProcessEvent[Probe[main.noArgs]Return@4c2ac6]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4c3086]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x1254: ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1276: ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1298: ProcessEvent[Probe[main.stringArg]@4c264a]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c6 00 00 00 21 00 00 00 
-	Call 54 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[0]]
-	Call 76 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c264a.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	Return 
-// 0x12ac: ProcessEvent[Probe[main.stringArg]Return@4c268f]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x12b6: ProcessExpression[Probe[main.stringArrayArg]@0x4c284a.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 6a 14 00 00 // ProcessType[[3]string]
+	Call 43 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12d7: ProcessEvent[Probe[main.stringArrayArg]@4c284a]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call b6 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c284a.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	Return 
-// 0x12e6: ProcessEvent[Probe[main.stringArrayArg]Return@4c2896]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x12f0: ProcessExpression[Probe[main.stringSliceArg]@0x4c27ca.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ee 14 00 00 // ProcessType[[]string]
+	Call c7 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1319: ProcessEvent[Probe[main.stringSliceArg]@4c27ca]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
 	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call f0 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c27ca.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	Return 
-// 0x1328: ProcessEvent[Probe[main.stringSliceArg]Return@4c280f]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1332: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c3bf6]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x133c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c3dc0.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 97 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 70 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1357: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c3dc0]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
 	PrepareEventRoot 2e 01 00 00 09 00 00 00 
-	Call 3c 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c3dc0.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	Return 
-// 0x1366: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x136c: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer be 00 00 00 
 	Return 
-// 0x1372: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x1378: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x137e: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1384: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x138a: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1390: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1396: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x139c: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1387: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*main.bigStruct]
+// 0x138d: ProcessType[*main.bigStruct]
 	ProcessPointer a5 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*main.condFields]
+// 0x1393: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*runtime._defer]
+// 0x1399: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime._panic]
+// 0x139f: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime.cgoCallers]
+// 0x13a5: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.coro]
+// 0x13ab: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.g]
+// 0x13b1: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.m]
+// 0x13b7: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.p]
+// 0x13bd: ProcessType[*runtime.p]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.sudog]
+// 0x13c3: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.synctestBubble]
+// 0x13c9: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*runtime.timer]
+// 0x13cf: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*runtime.traceBuf]
+// 0x13d5: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1402: ProcessType[*runtime.xRegState]
+// 0x13db: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1408: ProcessType[*string]
+// 0x13e1: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x1414: ProcessType[*table<string,int>]
+// 0x13ed: ProcessType[*table<string,int>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x141a: ProcessType[*table<string,main.bigStruct>]
+// 0x13f3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1420: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint]
+// 0x13ff: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint16]
+// 0x1405: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uint32]
+// 0x140b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1438: ProcessType[*uint64]
+// 0x1411: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x143e: ProcessType[*uint8]
+// 0x1417: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1444: ProcessType[*uintptr]
+// 0x141d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x144a: ProcessType[[2]*runtime.traceBuf]
+// 0x1423: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call fc 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call d5 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x145a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1433: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 4a 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 23 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x146a: ProcessType[[3]string]
+// 0x1443: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x147a: ProcessType[[]*runtime.p]
+// 0x1453: ProcessType[[]*runtime.p]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1484: ProcessType[[]*runtime.p.array]
+// 0x145d: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call e4 13 00 00 // ProcessType[*runtime.p]
+	Call bd 13 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1490: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1469: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x149c: ProcessType[[]*table<string,int>.array]
+// 0x1475: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 14 14 00 00 // ProcessType[*table<string,int>]
+	Call ed 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14a8: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1481: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 1a 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f3 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14b4: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x148d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 20 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14c0: ProcessType[[]int]
+// 0x1499: ProcessType[[]int]
 	ProcessSlice 92 00 00 00 08 00 00 00 
 	Return 
-// 0x14ca: ProcessType[[]noalg.map.group[string]int.array]
+// 0x14a3: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call cd 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a6 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14d6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x14af: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call d8 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call b1 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14e2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x14bb: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call e3 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call bc 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ee: ProcessType[[]string]
+// 0x14c7: ProcessType[[]string]
 	ProcessSlice 94 00 00 00 10 00 00 00 
 	Return 
-// 0x14f8: ProcessType[[]string.array]
+// 0x14d1: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1504: ProcessType[[]uint8]
+// 0x14dd: ProcessType[[]uint8]
 	ProcessSlice 8b 00 00 00 01 00 00 00 
 	Return 
-// 0x150e: ProcessType[[]uintptr]
+// 0x14e7: ProcessType[[]uintptr]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1518: ProcessType[error]
+// 0x14f1: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x151a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14f3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bd 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1526: ProcessType[groupReference<string,int>]
+// 0x14ff: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1532: ProcessType[groupReference<string,main.bigStruct>]
+// 0x150b: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a7 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x153e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1517: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x154a: ProcessType[main.condFields]
+// 0x1523: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1555: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x152e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bc 00 00 00 b8 00 00 00 10 18 
 	Return 
-// 0x1561: ProcessType[map<string,int>]
+// 0x153a: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9c 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x156d: ProcessType[map<string,main.bigStruct>]
+// 0x1546: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a6 00 00 00 a1 00 00 00 10 18 
 	Return 
-// 0x1579: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1552: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x1585: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x155e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x158b: ProcessType[map[string]int]
+// 0x1564: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1591: ProcessType[map[string]main.bigStruct]
+// 0x156a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1597: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1570: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x159d: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1576: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call ee 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c7 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15ad: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1586: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call fe 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call d7 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x15bd: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1596: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 04 16 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call dd 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15cd: ProcessType[noalg.map.group[string]int]
+// 0x15a6: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ad 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 86 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15d8: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x15b1: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9d 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 76 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15e3: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x15bc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 96 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15ee: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 19 17 00 00 // ProcessType[string]
+// 0x15c7: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call f2 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.bigStruct]
+	Call 8d 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15fe: ProcessType[noalg.struct { key string; elem int }]
-	Call 19 17 00 00 // ProcessType[string]
+// 0x15d7: ProcessType[noalg.struct { key string; elem int }]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1604: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15dd: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 5e 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x160f: ProcessType[runtime.g]
+// 0x15e8: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime._panic]
+	Call 9f 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 13 00 00 // ProcessType[*runtime._defer]
+	Call 99 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 04 15 00 00 // ProcessType[[]uint8]
+	Call dd 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 7e 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.sudog]
+	Call c3 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f6 13 00 00 // ProcessType[*runtime.timer]
+	Call cf 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.coro]
+	Call ab 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call c9 13 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 13 17 00 00 // ProcessType[runtime.xRegPerG]
+	Call ec 16 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x167e: ProcessType[runtime.m]
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+// 0x1657: ProcessType[runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 7a 14 00 00 // ProcessType[[]*runtime.p]
+	Call 53 14 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call a5 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call f2 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call cb 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fd 16 00 00 // ProcessType[runtime.mTraceState]
+	Call d6 16 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 0d 17 00 00 // ProcessType[runtime.mWeakPointer]
+	Call e6 16 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x16f2: ProcessType[runtime.mLockProfile]
+// 0x16cb: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16fd: ProcessType[runtime.mTraceState]
+// 0x16d6: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call 33 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x170d: ProcessType[runtime.mWeakPointer]
-	Call ae 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x16e6: ProcessType[runtime.mWeakPointer]
+	Call 87 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1713: ProcessType[runtime.xRegPerG]
-	Call 02 14 00 00 // ProcessType[*runtime.xRegState]
+// 0x16ec: ProcessType[runtime.xRegPerG]
+	Call db 13 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1719: ProcessType[string]
+// 0x16f2: ProcessType[string]
 	ProcessString 89 00 00 00 
 	Return 
-// 0x171f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16f8: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1a 15 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f3 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x172a: ProcessType[table<string,int>]
+// 0x1703: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 26 15 00 00 // ProcessType[groupReference<string,int>]
+	Call ff 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1735: ProcessType[table<string,main.bigStruct>]
+// 0x170e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 32 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 0b 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1740: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1719: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3e 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 17 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1848,32 +1842,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5182
+ID: 5 Len: 8 Enqueue: 5143
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5913
+ID: 9 Len: 16 Enqueue: 5874
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4996
+ID: 11 Len: 8 Enqueue: 4957
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 5400
+ID: 15 Len: 16 Enqueue: 5361
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5188
+ID: 19 Len: 8 Enqueue: 5149
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 5026
-ID: 22 Len: 8 Enqueue: 5170
-ID: 23 Len: 456 Enqueue: 5647
+ID: 21 Len: 8 Enqueue: 4987
+ID: 22 Len: 8 Enqueue: 5131
+ID: 23 Len: 456 Enqueue: 5608
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 5062
+ID: 25 Len: 8 Enqueue: 5023
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 5056
+ID: 27 Len: 8 Enqueue: 5017
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 5086
-ID: 30 Len: 1824 Enqueue: 5758
+ID: 29 Len: 8 Enqueue: 5047
+ID: 30 Len: 1824 Enqueue: 5719
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -1882,51 +1876,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 5380
-ID: 40 Len: 8 Enqueue: 4990
+ID: 39 Len: 24 Enqueue: 5341
+ID: 40 Len: 8 Enqueue: 4951
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 5098
+ID: 42 Len: 8 Enqueue: 5059
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 5390
-ID: 45 Len: 8 Enqueue: 5110
+ID: 44 Len: 24 Enqueue: 5351
+ID: 45 Len: 8 Enqueue: 5071
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 5074
+ID: 48 Len: 8 Enqueue: 5035
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 5104
+ID: 50 Len: 8 Enqueue: 5065
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 5907
-ID: 53 Len: 8 Enqueue: 5122
+ID: 52 Len: 8 Enqueue: 5868
+ID: 53 Len: 8 Enqueue: 5083
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 5080
+ID: 59 Len: 8 Enqueue: 5041
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 5242
+ID: 66 Len: 24 Enqueue: 5203
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 5092
-ID: 69 Len: 8 Enqueue: 5068
+ID: 68 Len: 8 Enqueue: 5053
+ID: 69 Len: 8 Enqueue: 5029
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5874
+ID: 75 Len: 56 Enqueue: 5835
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 5885
-ID: 81 Len: 32 Enqueue: 5210
-ID: 82 Len: 16 Enqueue: 5194
-ID: 83 Len: 8 Enqueue: 5116
+ID: 80 Len: 72 Enqueue: 5846
+ID: 81 Len: 32 Enqueue: 5171
+ID: 82 Len: 16 Enqueue: 5155
+ID: 83 Len: 8 Enqueue: 5077
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -1941,45 +1935,45 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 5901
-ID: 99 Len: 8 Enqueue: 5038
+ID: 98 Len: 8 Enqueue: 5862
+ID: 99 Len: 8 Enqueue: 4999
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 5128
+ID: 101 Len: 8 Enqueue: 5089
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 5014
-ID: 104 Len: 8 Enqueue: 5020
-ID: 105 Len: 8 Enqueue: 5032
-ID: 106 Len: 8 Enqueue: 5176
-ID: 107 Len: 8 Enqueue: 5002
+ID: 103 Len: 8 Enqueue: 4975
+ID: 104 Len: 8 Enqueue: 4981
+ID: 105 Len: 8 Enqueue: 4993
+ID: 106 Len: 8 Enqueue: 5137
+ID: 107 Len: 8 Enqueue: 4963
 ID: 108 Len: 2 Enqueue: 0
-ID: 109 Len: 8 Enqueue: 5008
-ID: 110 Len: 8 Enqueue: 5158
-ID: 111 Len: 8 Enqueue: 5164
-ID: 112 Len: 24 Enqueue: 5312
+ID: 109 Len: 8 Enqueue: 4969
+ID: 110 Len: 8 Enqueue: 5119
+ID: 111 Len: 8 Enqueue: 5125
+ID: 112 Len: 24 Enqueue: 5273
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 5358
-ID: 115 Len: 48 Enqueue: 5226
-ID: 116 Len: 8 Enqueue: 5515
+ID: 114 Len: 24 Enqueue: 5319
+ID: 115 Len: 48 Enqueue: 5187
+ID: 116 Len: 8 Enqueue: 5476
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5473
+ID: 118 Len: 48 Enqueue: 5434
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5140
-ID: 121 Len: 8 Enqueue: 5521
+ID: 120 Len: 8 Enqueue: 5101
+ID: 121 Len: 8 Enqueue: 5482
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 5485
+ID: 123 Len: 48 Enqueue: 5446
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 5146
-ID: 126 Len: 80 Enqueue: 5450
+ID: 125 Len: 8 Enqueue: 5107
+ID: 126 Len: 80 Enqueue: 5411
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5050
-ID: 129 Len: 8 Enqueue: 5527
+ID: 128 Len: 8 Enqueue: 5011
+ID: 129 Len: 8 Enqueue: 5488
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 48 Enqueue: 5497
+ID: 131 Len: 48 Enqueue: 5458
 ID: 132 Len: 8 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 5152
-ID: 134 Len: 8 Enqueue: 4966
-ID: 135 Len: 8 Enqueue: 4972
-ID: 136 Len: 8 Enqueue: 4984
+ID: 133 Len: 8 Enqueue: 5113
+ID: 134 Len: 8 Enqueue: 4927
+ID: 135 Len: 8 Enqueue: 4933
+ID: 136 Len: 8 Enqueue: 4945
 ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 1 Enqueue: 0
@@ -1987,53 +1981,53 @@ ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 8 Enqueue: 5252
+ID: 144 Len: 8 Enqueue: 5213
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 16 Enqueue: 5368
+ID: 148 Len: 16 Enqueue: 5329
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 32 Enqueue: 5930
-ID: 151 Len: 16 Enqueue: 5414
+ID: 150 Len: 32 Enqueue: 5891
+ID: 151 Len: 16 Enqueue: 5375
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 5581
-ID: 154 Len: 192 Enqueue: 5549
-ID: 155 Len: 24 Enqueue: 5630
-ID: 156 Len: 8 Enqueue: 5276
-ID: 157 Len: 200 Enqueue: 5322
-ID: 158 Len: 32 Enqueue: 5941
-ID: 159 Len: 16 Enqueue: 5426
+ID: 153 Len: 200 Enqueue: 5542
+ID: 154 Len: 192 Enqueue: 5510
+ID: 155 Len: 24 Enqueue: 5591
+ID: 156 Len: 8 Enqueue: 5237
+ID: 157 Len: 200 Enqueue: 5283
+ID: 158 Len: 32 Enqueue: 5902
+ID: 159 Len: 16 Enqueue: 5387
 ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 200 Enqueue: 5592
-ID: 162 Len: 192 Enqueue: 5533
-ID: 163 Len: 24 Enqueue: 5614
-ID: 164 Len: 8 Enqueue: 5044
+ID: 161 Len: 200 Enqueue: 5553
+ID: 162 Len: 192 Enqueue: 5494
+ID: 163 Len: 24 Enqueue: 5575
+ID: 164 Len: 8 Enqueue: 5005
 ID: 165 Len: 184 Enqueue: 0
-ID: 166 Len: 8 Enqueue: 5288
-ID: 167 Len: 200 Enqueue: 5334
-ID: 168 Len: 32 Enqueue: 5952
-ID: 169 Len: 16 Enqueue: 5438
+ID: 166 Len: 8 Enqueue: 5249
+ID: 167 Len: 200 Enqueue: 5295
+ID: 168 Len: 32 Enqueue: 5913
+ID: 169 Len: 16 Enqueue: 5399
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 136 Enqueue: 5603
-ID: 172 Len: 128 Enqueue: 5565
-ID: 173 Len: 16 Enqueue: 5636
-ID: 174 Len: 8 Enqueue: 5509
+ID: 171 Len: 136 Enqueue: 5564
+ID: 172 Len: 128 Enqueue: 5526
+ID: 173 Len: 16 Enqueue: 5597
+ID: 174 Len: 8 Enqueue: 5470
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 48 Enqueue: 5461
+ID: 176 Len: 48 Enqueue: 5422
 ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5134
-ID: 179 Len: 8 Enqueue: 5300
-ID: 180 Len: 136 Enqueue: 5346
-ID: 181 Len: 32 Enqueue: 5919
-ID: 182 Len: 16 Enqueue: 5402
+ID: 178 Len: 8 Enqueue: 5095
+ID: 179 Len: 8 Enqueue: 5261
+ID: 180 Len: 136 Enqueue: 5307
+ID: 181 Len: 32 Enqueue: 5880
+ID: 182 Len: 16 Enqueue: 5363
 ID: 183 Len: 8 Enqueue: 0
 ID: 184 Len: 136 Enqueue: 0
 ID: 185 Len: 128 Enqueue: 0
 ID: 186 Len: 16 Enqueue: 0
 ID: 187 Len: 8 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 5264
+ID: 188 Len: 8 Enqueue: 5225
 ID: 189 Len: 136 Enqueue: 0
-ID: 190 Len: 8 Enqueue: 4978
+ID: 190 Len: 8 Enqueue: 4939
 ID: 191 Len: 128 Enqueue: 0
 ID: 192 Len: 9 Enqueue: 0
 ID: 193 Len: 0 Enqueue: 0
@@ -2143,7 +2137,7 @@ ID: 296 Len: 0 Enqueue: 0
 ID: 297 Len: 25 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
 ID: 299 Len: 17 Enqueue: 0
-ID: 300 Len: 33 Enqueue: 0
+ID: 300 Len: 25 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
 ID: 302 Len: 9 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1f34]
-	PrepareEventRoot 78 01 00 00 11 00 00 00 
+	PrepareEventRoot 88 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1f79]
-	PrepareEventRoot 79 01 00 00 09 00 00 00 
+	PrepareEventRoot 89 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4c1f79.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ca 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ca 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2fca]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -108,7 +108,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4c382a]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c36ae]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4c376e]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4c316a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c316a]
@@ -180,7 +180,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4c316a]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -248,7 +248,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4c322a]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c32ea]
@@ -292,7 +292,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c30aa]
@@ -336,7 +336,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
-	PrepareEventRoot 2e 01 00 00 11 00 00 00 
+	PrepareEventRoot 32 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4c3e81]
-	PrepareEventRoot 2f 01 00 00 19 00 00 00 
+	PrepareEventRoot 33 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
-	PrepareEventRoot 22 01 00 00 11 00 00 00 
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.condFields]
+	Call bf 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
-	PrepareEventRoot 24 01 00 00 19 00 00 00 
+	PrepareEventRoot 28 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
-	PrepareEventRoot 25 01 00 00 00 00 00 00 
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
-	PrepareEventRoot 2a 01 00 00 19 00 00 00 
+	PrepareEventRoot 2e 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@4c3daa]
-	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	PrepareEventRoot 30 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
-	PrepareEventRoot 1c 01 00 00 11 00 00 00 
+	PrepareEventRoot 20 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
-	PrepareEventRoot 1e 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 1f 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.condFields]
+	Call bf 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
-	PrepareEventRoot 20 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 21 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
-	PrepareEventRoot 26 01 00 00 09 00 00 00 
+	PrepareEventRoot 2a 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
-	PrepareEventRoot 28 01 00 00 11 00 00 00 
+	PrepareEventRoot 2c 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
-	PrepareEventRoot 29 01 00 00 09 00 00 00 
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@4c38ee]
+	PrepareEventRoot 0c 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@4c3965]
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@4c38ee]
+	PrepareEventRoot 0e 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@4c3965]
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 52 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@4c38ee]
-	PrepareEventRoot 0c 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@4c38ee]
+	PrepareEventRoot 10 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@4c3965]
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0xb11: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@4c38ee]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
-	PrepareEventRoot 0e 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
+	PrepareEventRoot 12 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@4c3965]
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+	PrepareEventRoot 1a 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 36 1f 00 00 // ProcessType[main.condFields]
+	Call 55 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	PrepareEventRoot 1a 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	PrepareEventRoot 1e 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4c346a]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@4c346a]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@4c346a]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@4c346a]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@4c346a]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4c352a]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@4c352a]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@4c352a]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4c359c]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@4c352a]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@4c352a]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4c359c]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@4c35ea]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@4c35ea]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4c365c]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@4c35ea]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4c365c]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@4c33aa]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@4c33aa]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@4c33aa]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@4c1c4a]
-	PrepareEventRoot 76 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@4c1c4a]
+	PrepareEventRoot 86 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@4c2eaa]
-	PrepareEventRoot 76 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4c2eea]
-	PrepareEventRoot 77 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@4c2b8a]
+// 0x111f: ProcessEvent[Probe[main.inlined]@4c2eaa]
+	PrepareEventRoot 86 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@4c2eea]
+	PrepareEventRoot 87 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@4c2b8a]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4c2bca]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@4c2bca]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
 	PrepareEventRoot cd 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 56 1e 00 00 // ProcessType[[3]string]
+	Call 75 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
-	PrepareEventRoot 6c 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+	PrepareEventRoot 7c 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 36 1f 00 00 // ProcessType[main.condFields]
+	Call 55 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
-	PrepareEventRoot 70 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+	PrepareEventRoot 80 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
-	PrepareEventRoot 71 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+	PrepareEventRoot 81 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
-	PrepareEventRoot 6e 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+	PrepareEventRoot 7e 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
-	PrepareEventRoot 6f 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+	PrepareEventRoot 7f 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
-	PrepareEventRoot 72 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+	PrepareEventRoot 82 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
-	PrepareEventRoot 73 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+	PrepareEventRoot 83 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0x4c446e]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0x4c446e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@4c446e]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
-	PrepareEventRoot 44 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@4c446e]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	PrepareEventRoot 52 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 54 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@4c446e]
-	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 56 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0x4c446e]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0x4c446e]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@4c446e]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
-	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@4c446e]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0x4c446e]
+	PrepareEventRoot 58 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@4c446e]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@4c446e]
-	PrepareEventRoot 4c 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@4c454e]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@4c458e]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*string]
+	Call 13 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@4c458e]
-	PrepareEventRoot 50 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 60 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*main.lenFields]
+	Call c5 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 64 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 74 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 65 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 75 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 68 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 78 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
-	PrepareEventRoot 6a 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 7a 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
-	PrepareEventRoot 6b 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 7b 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
-	PrepareEventRoot 3a 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+	PrepareEventRoot 46 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 48 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	PrepareEventRoot 3c 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0x4c4313]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
-	PrepareEventRoot 3e 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0x4c4313]
+	PrepareEventRoot 4c 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@4c4313]
-	PrepareEventRoot 42 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 50 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 34 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 36 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 38 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 3c 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@4c41d3]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 3e 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 40 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@4c41d3]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@4c41d3]
-	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 44 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@4c42bc]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 41 1f 00 00 // ProcessType[main.lenFields]
+	Call 60 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 52 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 62 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 54 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 64 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 56 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 68 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
-	PrepareEventRoot 5e 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 6e 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
-	PrepareEventRoot 60 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 70 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,500 +1812,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
-	PrepareEventRoot 62 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 72 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@4c2f6a]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@4c2f6a]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@4c304a]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@4c304a]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@4c3086]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@4c3086]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 56 1e 00 00 // ProcessType[[3]string]
+	Call 75 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call da 1e 00 00 // ProcessType[[]string]
+	Call f9 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
-	PrepareEventRoot 74 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
+	PrepareEventRoot 84 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b1 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call d0 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
-	PrepareEventRoot 75 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
+	PrepareEventRoot 85 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1fb3: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.bigStruct]
+// 0x1fb9: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.condFields]
+// 0x1fbf: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*main.lenFields]
+// 0x1fc5: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._defer]
+// 0x1fcb: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime._panic]
+// 0x1fd1: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.cgoCallers]
+// 0x1fd7: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.coro]
+// 0x1fdd: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.g]
+// 0x1fe3: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.m]
+// 0x1fe9: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.p]
+// 0x1fef: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.sudog]
+// 0x1ff5: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.synctestBubble]
+// 0x1ffb: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.timer]
+// 0x2001: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*runtime.traceBuf]
+// 0x2007: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*runtime.xRegState]
+// 0x200d: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*string]
+// 0x2013: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2019: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*table<string,int>]
+// 0x201f: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*table<string,main.bigStruct>]
+// 0x2025: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x202b: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint]
+// 0x2031: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint16]
+// 0x2037: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint32]
+// 0x203d: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uint64]
+// 0x2043: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[*uint8]
+// 0x2049: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e30: ProcessType[*uintptr]
+// 0x204f: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e36: ProcessType[[2]*runtime.traceBuf]
+// 0x2055: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 07 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e46: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2065: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 36 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 55 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e56: ProcessType[[3]string]
+// 0x2075: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e66: ProcessType[[]*runtime.p]
+// 0x2085: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1e70: ProcessType[[]*runtime.p.array]
+// 0x208f: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call d0 1d 00 00 // ProcessType[*runtime.p]
+	Call ef 1f 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x209b: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e88: ProcessType[[]*table<string,int>.array]
+// 0x20a7: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 00 1e 00 00 // ProcessType[*table<string,int>]
+	Call 1f 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e94: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x20b3: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 06 1e 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 25 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x20bf: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 0c 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2b 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eac: ProcessType[[]int]
+// 0x20cb: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20d5: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call e7 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 06 22 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ec2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20e1: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call f2 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 11 22 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ece: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20ed: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call fd 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1c 22 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eda: ProcessType[[]string]
+// 0x20f9: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1ee4: ProcessType[[]string.array]
+// 0x2103: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ef0: ProcessType[[]uint8]
+// 0x210f: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1efa: ProcessType[[]uintptr]
+// 0x2119: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1f04: ProcessType[error]
+// 0x2123: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1f06: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x2125: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f12: ProcessType[groupReference<string,int>]
+// 0x2131: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f1e: ProcessType[groupReference<string,main.bigStruct>]
+// 0x213d: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f2a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2149: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f36: ProcessType[main.condFields]
+// 0x2155: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f41: ProcessType[main.lenFields]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2160: ProcessType[main.lenFields]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*string]
+	Call 13 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f6f: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x218e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1f7b: ProcessType[map<string,int>]
+// 0x219a: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1f87: ProcessType[map<string,main.bigStruct>]
+// 0x21a6: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1f93: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x21b2: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1f9f: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21be: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1fa5: ProcessType[map[string]int]
+// 0x21c4: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1fab: ProcessType[map[string]main.bigStruct]
+// 0x21ca: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1fb1: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21d0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1fb7: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21d6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 08 20 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 27 22 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fc7: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21e6: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 18 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 37 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1fd7: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21f6: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 1e 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 3d 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fe7: ProcessType[noalg.map.group[string]int]
+// 0x2206: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call c7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e6 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1ff2: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x2211: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call b7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d6 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ffd: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x221c: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call d7 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call f6 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x2008: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2227: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b9 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x2018: ProcessType[noalg.struct { key string; elem int }]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2237: ProcessType[noalg.struct { key string; elem int }]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x201e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x223d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call be 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2029: ProcessType[runtime.g]
+// 0x2248: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime._panic]
+	Call d1 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._defer]
+	Call cb 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call f0 1e 00 00 // ProcessType[[]uint8]
+	Call 0f 21 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.sudog]
+	Call f5 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.timer]
+	Call 01 20 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.coro]
+	Call dd 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.synctestBubble]
+	Call fb 1f 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2d 21 00 00 // ProcessType[runtime.xRegPerG]
+	Call 4c 23 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x2098: ProcessType[runtime.m]
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+// 0x22b7: ProcessType[runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 66 1e 00 00 // ProcessType[[]*runtime.p]
+	Call 85 20 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d7 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 0c 21 00 00 // ProcessType[runtime.mLockProfile]
+	Call 2b 23 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 17 21 00 00 // ProcessType[runtime.mTraceState]
+	Call 36 23 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 27 21 00 00 // ProcessType[runtime.mWeakPointer]
+	Call 46 23 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x210c: ProcessType[runtime.mLockProfile]
+// 0x232b: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x2117: ProcessType[runtime.mTraceState]
+// 0x2336: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call 65 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x2127: ProcessType[runtime.mWeakPointer]
-	Call 94 1d 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x2346: ProcessType[runtime.mWeakPointer]
+	Call b3 1f 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x212d: ProcessType[runtime.xRegPerG]
-	Call ee 1d 00 00 // ProcessType[*runtime.xRegState]
+// 0x234c: ProcessType[runtime.xRegPerG]
+	Call 0d 20 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x2133: ProcessType[string]
+// 0x2352: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x2139: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2358: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 1f 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 25 21 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x2144: ProcessType[table<string,int>]
+// 0x2363: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 12 1f 00 00 // ProcessType[groupReference<string,int>]
+	Call 31 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x214f: ProcessType[table<string,main.bigStruct>]
+// 0x236e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1e 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 3d 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x215a: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2379: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 49 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2450,32 +2573,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7722
+ID: 5 Len: 8 Enqueue: 8265
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8499
+ID: 9 Len: 16 Enqueue: 9042
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 7530
+ID: 11 Len: 8 Enqueue: 8073
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7940
+ID: 15 Len: 16 Enqueue: 8483
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 7728
+ID: 19 Len: 8 Enqueue: 8271
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 7560
-ID: 22 Len: 8 Enqueue: 7710
-ID: 23 Len: 456 Enqueue: 8233
+ID: 21 Len: 8 Enqueue: 8103
+ID: 22 Len: 8 Enqueue: 8253
+ID: 23 Len: 456 Enqueue: 8776
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 7602
+ID: 25 Len: 8 Enqueue: 8145
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 7596
+ID: 27 Len: 8 Enqueue: 8139
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 7626
-ID: 30 Len: 1824 Enqueue: 8344
+ID: 29 Len: 8 Enqueue: 8169
+ID: 30 Len: 1824 Enqueue: 8887
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2484,51 +2607,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7920
-ID: 40 Len: 8 Enqueue: 7524
+ID: 39 Len: 24 Enqueue: 8463
+ID: 40 Len: 8 Enqueue: 8067
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 7638
+ID: 42 Len: 8 Enqueue: 8181
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7930
-ID: 45 Len: 8 Enqueue: 7650
+ID: 44 Len: 24 Enqueue: 8473
+ID: 45 Len: 8 Enqueue: 8193
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 7614
+ID: 48 Len: 8 Enqueue: 8157
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 7644
+ID: 50 Len: 8 Enqueue: 8187
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 8493
-ID: 53 Len: 8 Enqueue: 7662
+ID: 52 Len: 8 Enqueue: 9036
+ID: 53 Len: 8 Enqueue: 8205
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 7620
+ID: 59 Len: 8 Enqueue: 8163
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 7782
+ID: 66 Len: 24 Enqueue: 8325
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 7632
-ID: 69 Len: 8 Enqueue: 7608
+ID: 68 Len: 8 Enqueue: 8175
+ID: 69 Len: 8 Enqueue: 8151
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 8460
+ID: 75 Len: 56 Enqueue: 9003
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 8471
-ID: 81 Len: 32 Enqueue: 7750
-ID: 82 Len: 16 Enqueue: 7734
-ID: 83 Len: 8 Enqueue: 7656
+ID: 80 Len: 72 Enqueue: 9014
+ID: 81 Len: 32 Enqueue: 8293
+ID: 82 Len: 16 Enqueue: 8277
+ID: 83 Len: 8 Enqueue: 8199
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2543,48 +2666,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 8487
-ID: 99 Len: 8 Enqueue: 7572
+ID: 98 Len: 8 Enqueue: 9030
+ID: 99 Len: 8 Enqueue: 8115
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 7668
+ID: 101 Len: 8 Enqueue: 8211
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 7548
-ID: 104 Len: 8 Enqueue: 7554
-ID: 105 Len: 8 Enqueue: 7566
-ID: 106 Len: 8 Enqueue: 7716
-ID: 107 Len: 8 Enqueue: 7536
+ID: 103 Len: 8 Enqueue: 8091
+ID: 104 Len: 8 Enqueue: 8097
+ID: 105 Len: 8 Enqueue: 8109
+ID: 106 Len: 8 Enqueue: 8259
+ID: 107 Len: 8 Enqueue: 8079
 ID: 108 Len: 2 Enqueue: 0
-ID: 109 Len: 8 Enqueue: 7542
-ID: 110 Len: 8 Enqueue: 7698
-ID: 111 Len: 8 Enqueue: 7704
-ID: 112 Len: 24 Enqueue: 7852
+ID: 109 Len: 8 Enqueue: 8085
+ID: 110 Len: 8 Enqueue: 8241
+ID: 111 Len: 8 Enqueue: 8247
+ID: 112 Len: 24 Enqueue: 8395
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7898
-ID: 115 Len: 48 Enqueue: 7766
-ID: 116 Len: 8 Enqueue: 8101
+ID: 114 Len: 24 Enqueue: 8441
+ID: 115 Len: 48 Enqueue: 8309
+ID: 116 Len: 8 Enqueue: 8644
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 8059
+ID: 118 Len: 48 Enqueue: 8602
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 7680
-ID: 121 Len: 8 Enqueue: 8107
+ID: 120 Len: 8 Enqueue: 8223
+ID: 121 Len: 8 Enqueue: 8650
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 8071
+ID: 123 Len: 48 Enqueue: 8614
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 7686
-ID: 126 Len: 80 Enqueue: 7990
+ID: 125 Len: 8 Enqueue: 8229
+ID: 126 Len: 80 Enqueue: 8533
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 7584
-ID: 129 Len: 72 Enqueue: 8001
-ID: 130 Len: 8 Enqueue: 7518
-ID: 131 Len: 8 Enqueue: 7590
-ID: 132 Len: 8 Enqueue: 8113
+ID: 128 Len: 8 Enqueue: 8127
+ID: 129 Len: 72 Enqueue: 8544
+ID: 130 Len: 8 Enqueue: 8061
+ID: 131 Len: 8 Enqueue: 8133
+ID: 132 Len: 8 Enqueue: 8656
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 8083
+ID: 134 Len: 48 Enqueue: 8626
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 7692
-ID: 137 Len: 8 Enqueue: 7494
-ID: 138 Len: 8 Enqueue: 7500
-ID: 139 Len: 8 Enqueue: 7512
+ID: 136 Len: 8 Enqueue: 8235
+ID: 137 Len: 8 Enqueue: 8037
+ID: 138 Len: 8 Enqueue: 8043
+ID: 139 Len: 8 Enqueue: 8055
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2592,53 +2715,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 7792
+ID: 147 Len: 8 Enqueue: 8335
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7908
+ID: 151 Len: 16 Enqueue: 8451
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 8516
-ID: 154 Len: 16 Enqueue: 7954
+ID: 153 Len: 32 Enqueue: 9059
+ID: 154 Len: 16 Enqueue: 8497
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 8167
-ID: 157 Len: 192 Enqueue: 8135
-ID: 158 Len: 24 Enqueue: 8216
-ID: 159 Len: 8 Enqueue: 7816
-ID: 160 Len: 200 Enqueue: 7862
-ID: 161 Len: 32 Enqueue: 8527
-ID: 162 Len: 16 Enqueue: 7966
+ID: 156 Len: 200 Enqueue: 8710
+ID: 157 Len: 192 Enqueue: 8678
+ID: 158 Len: 24 Enqueue: 8759
+ID: 159 Len: 8 Enqueue: 8359
+ID: 160 Len: 200 Enqueue: 8405
+ID: 161 Len: 32 Enqueue: 9070
+ID: 162 Len: 16 Enqueue: 8509
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 8178
-ID: 165 Len: 192 Enqueue: 8119
-ID: 166 Len: 24 Enqueue: 8200
-ID: 167 Len: 8 Enqueue: 7578
+ID: 164 Len: 200 Enqueue: 8721
+ID: 165 Len: 192 Enqueue: 8662
+ID: 166 Len: 24 Enqueue: 8743
+ID: 167 Len: 8 Enqueue: 8121
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 7828
-ID: 170 Len: 200 Enqueue: 7874
-ID: 171 Len: 32 Enqueue: 8538
-ID: 172 Len: 16 Enqueue: 7978
+ID: 169 Len: 8 Enqueue: 8371
+ID: 170 Len: 200 Enqueue: 8417
+ID: 171 Len: 32 Enqueue: 9081
+ID: 172 Len: 16 Enqueue: 8521
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 8189
-ID: 175 Len: 128 Enqueue: 8151
-ID: 176 Len: 16 Enqueue: 8222
-ID: 177 Len: 8 Enqueue: 8095
+ID: 174 Len: 136 Enqueue: 8732
+ID: 175 Len: 128 Enqueue: 8694
+ID: 176 Len: 16 Enqueue: 8765
+ID: 177 Len: 8 Enqueue: 8638
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 8047
+ID: 179 Len: 48 Enqueue: 8590
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 7674
-ID: 182 Len: 8 Enqueue: 7840
-ID: 183 Len: 136 Enqueue: 7886
-ID: 184 Len: 32 Enqueue: 8505
-ID: 185 Len: 16 Enqueue: 7942
+ID: 181 Len: 8 Enqueue: 8217
+ID: 182 Len: 8 Enqueue: 8383
+ID: 183 Len: 136 Enqueue: 8429
+ID: 184 Len: 32 Enqueue: 9048
+ID: 185 Len: 16 Enqueue: 8485
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 7804
+ID: 191 Len: 8 Enqueue: 8347
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 7506
+ID: 193 Len: 8 Enqueue: 8049
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
@@ -2713,13 +2836,13 @@ ID: 264 Len: 17 Enqueue: 0
 ID: 265 Len: 0 Enqueue: 0
 ID: 266 Len: 17 Enqueue: 0
 ID: 267 Len: 0 Enqueue: 0
-ID: 268 Len: 33 Enqueue: 0
+ID: 268 Len: 2 Enqueue: 0
 ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 33 Enqueue: 0
+ID: 270 Len: 2 Enqueue: 0
 ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
+ID: 272 Len: 33 Enqueue: 0
 ID: 273 Len: 0 Enqueue: 0
-ID: 274 Len: 17 Enqueue: 0
+ID: 274 Len: 33 Enqueue: 0
 ID: 275 Len: 0 Enqueue: 0
 ID: 276 Len: 17 Enqueue: 0
 ID: 277 Len: 0 Enqueue: 0
@@ -2727,81 +2850,81 @@ ID: 278 Len: 17 Enqueue: 0
 ID: 279 Len: 0 Enqueue: 0
 ID: 280 Len: 17 Enqueue: 0
 ID: 281 Len: 0 Enqueue: 0
-ID: 282 Len: 97 Enqueue: 0
+ID: 282 Len: 17 Enqueue: 0
 ID: 283 Len: 0 Enqueue: 0
 ID: 284 Len: 17 Enqueue: 0
 ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 17 Enqueue: 0
+ID: 286 Len: 97 Enqueue: 0
 ID: 287 Len: 0 Enqueue: 0
-ID: 288 Len: 25 Enqueue: 0
+ID: 288 Len: 17 Enqueue: 0
 ID: 289 Len: 0 Enqueue: 0
 ID: 290 Len: 17 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 25 Enqueue: 0
 ID: 293 Len: 0 Enqueue: 0
-ID: 294 Len: 9 Enqueue: 0
+ID: 294 Len: 17 Enqueue: 0
 ID: 295 Len: 0 Enqueue: 0
-ID: 296 Len: 17 Enqueue: 0
-ID: 297 Len: 9 Enqueue: 0
-ID: 298 Len: 25 Enqueue: 0
+ID: 296 Len: 25 Enqueue: 0
+ID: 297 Len: 0 Enqueue: 0
+ID: 298 Len: 9 Enqueue: 0
 ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 25 Enqueue: 0
-ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 17 Enqueue: 0
-ID: 303 Len: 25 Enqueue: 0
-ID: 304 Len: 17 Enqueue: 0
+ID: 300 Len: 17 Enqueue: 0
+ID: 301 Len: 9 Enqueue: 0
+ID: 302 Len: 25 Enqueue: 0
+ID: 303 Len: 0 Enqueue: 0
+ID: 304 Len: 25 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 9 Enqueue: 0
-ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 17 Enqueue: 0
+ID: 306 Len: 17 Enqueue: 0
+ID: 307 Len: 25 Enqueue: 0
+ID: 308 Len: 2 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 9 Enqueue: 0
+ID: 310 Len: 2 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 33 Enqueue: 0
+ID: 312 Len: 2 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
 ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 9 Enqueue: 0
+ID: 316 Len: 2 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 17 Enqueue: 0
+ID: 318 Len: 9 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
-ID: 320 Len: 9 Enqueue: 0
+ID: 320 Len: 17 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 41 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
-ID: 324 Len: 17 Enqueue: 0
+ID: 324 Len: 33 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 9 Enqueue: 0
+ID: 326 Len: 17 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 17 Enqueue: 0
+ID: 328 Len: 2 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
 ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 25 Enqueue: 0
+ID: 332 Len: 17 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
-ID: 336 Len: 25 Enqueue: 0
+ID: 336 Len: 41 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 89 Enqueue: 0
+ID: 338 Len: 17 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 9 Enqueue: 0
+ID: 340 Len: 2 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
 ID: 342 Len: 9 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 9 Enqueue: 0
+ID: 344 Len: 17 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
 ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
-ID: 348 Len: 9 Enqueue: 0
+ID: 348 Len: 25 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 17 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 17 Enqueue: 0
+ID: 352 Len: 25 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 17 Enqueue: 0
+ID: 354 Len: 89 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 25 Enqueue: 0
+ID: 356 Len: 9 Enqueue: 0
 ID: 357 Len: 0 Enqueue: 0
 ID: 358 Len: 9 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
@@ -2809,17 +2932,33 @@ ID: 360 Len: 9 Enqueue: 0
 ID: 361 Len: 0 Enqueue: 0
 ID: 362 Len: 9 Enqueue: 0
 ID: 363 Len: 0 Enqueue: 0
-ID: 364 Len: 25 Enqueue: 0
+ID: 364 Len: 9 Enqueue: 0
 ID: 365 Len: 0 Enqueue: 0
-ID: 366 Len: 0 Enqueue: 0
+ID: 366 Len: 17 Enqueue: 0
 ID: 367 Len: 0 Enqueue: 0
-ID: 368 Len: 97 Enqueue: 0
+ID: 368 Len: 17 Enqueue: 0
 ID: 369 Len: 0 Enqueue: 0
-ID: 370 Len: 0 Enqueue: 0
+ID: 370 Len: 17 Enqueue: 0
 ID: 371 Len: 0 Enqueue: 0
-ID: 372 Len: 0 Enqueue: 0
-ID: 373 Len: 9 Enqueue: 0
+ID: 372 Len: 25 Enqueue: 0
+ID: 373 Len: 0 Enqueue: 0
 ID: 374 Len: 9 Enqueue: 0
 ID: 375 Len: 0 Enqueue: 0
-ID: 376 Len: 17 Enqueue: 0
-ID: 377 Len: 9 Enqueue: 0
+ID: 376 Len: 9 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 9 Enqueue: 0
+ID: 379 Len: 0 Enqueue: 0
+ID: 380 Len: 25 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 0 Enqueue: 0
+ID: 383 Len: 0 Enqueue: 0
+ID: 384 Len: 97 Enqueue: 0
+ID: 385 Len: 0 Enqueue: 0
+ID: 386 Len: 0 Enqueue: 0
+ID: 387 Len: 0 Enqueue: 0
+ID: 388 Len: 0 Enqueue: 0
+ID: 389 Len: 9 Enqueue: 0
+ID: 390 Len: 9 Enqueue: 0
+ID: 391 Len: 0 Enqueue: 0
+ID: 392 Len: 17 Enqueue: 0
+ID: 393 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1f34]
 	PrepareEventRoot 68 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1f79]
 	PrepareEventRoot 69 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2fca]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -88,7 +88,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4c382a]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c36ae]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4c376e]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4c316a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c316a]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4c316a]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -228,7 +228,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4c322a]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c32ea]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c30aa]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	PrepareEventRoot 2f 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
 	PrepareEventRoot 22 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.condFields]
+	Call 49 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
 	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4c3daa]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@4c3daa]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@4c3daa]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@4c3daa]
+// 0x767: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	PrepareEventRoot 2c 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	PrepareEventRoot 1c 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	PrepareEventRoot 1e 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.condFields]
+	Call 49 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
 	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	PrepareEventRoot 26 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
 	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
 	PrepareEventRoot 28 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
 	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0x964: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@4c38ee]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0x9a8: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@4c3965]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@4c38ee]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0xa05: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@4c3965]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@4c38ee]
+// 0xa67: ProcessEvent[Probe[main.condString]@4c38ee]
 	PrepareEventRoot 0c 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@4c3965]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0xa85: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@4c38ee]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
+// 0xaeb: ProcessEvent[Probe[main.condString]@4c38ee]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
 	PrepareEventRoot 0e 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@4c3965]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@4c3965]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 28 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 04 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call bf 1b 00 00 // ProcessType[main.condFields]
+	Call df 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@4c39ae]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	PrepareEventRoot 1a 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0x4c346a]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@4c346a]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@4c346a]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@4c346a]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@4c346a]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0x4c352a]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@4c352a]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@4c352a]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4c359c]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@4c352a]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@4c352a]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@4c359c]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@4c359c]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@4c35ea]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@4c35ea]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@4c365c]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@4c35ea]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@4c365c]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@4c365c]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@4c33aa]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@4c33aa]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@4c33aa]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@4c33aa]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@4c341c]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@4c341c]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@4c1c4a]
+// 0x106e: ProcessEvent[Probe[main.inlined]@4c1c4a]
 	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@4c2eaa]
+// 0x1093: ProcessEvent[Probe[main.inlined]@4c2eaa]
 	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@4c2eea]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@4c2eea]
 	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@4c2b8a]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@4c2b8a]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@4c2bca]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@4c2bca]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
 	PrepareEventRoot cd 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call df 1a 00 00 // ProcessType[[3]string]
+	Call ff 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
 	PrepareEventRoot 5c 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call bf 1b 00 00 // ProcessType[main.condFields]
+	Call df 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
 	PrepareEventRoot 60 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
 	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
 	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
 	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
 	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
 	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@4c446e]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@4c446e]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@4c454e]
 	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@4c446e]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@4c446e]
 	PrepareEventRoot 40 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@4c454e]
 	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@4c458e]
 	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*string]
+	Call 9d 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@4c458e]
 	PrepareEventRoot 44 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
 	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*main.lenFields]
+	Call 4f 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
 	PrepareEventRoot 54 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
 	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
 	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
 	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
 	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
 	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
 	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@4c4313]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@4c4313]
 	PrepareEventRoot 3a 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4c4313]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@4c4313]
 	PrepareEventRoot 3c 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
 	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x1525: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@4c41d3]
+// 0x1559: ProcessEvent[Probe[main.lenString]@4c41d3]
 	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@4c41d3]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
 	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@4c41d3]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@4c41d3]
 	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@4c41d3]
+// 0x1642: ProcessEvent[Probe[main.lenString]@4c41d3]
 	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@4c42bc]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call ca 1b 00 00 // ProcessType[main.lenFields]
+	Call ea 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 46 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
 	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,500 +1495,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
 	PrepareEventRoot 52 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
 	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@4c2f6a]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@4c2f6a]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@4c304a]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@4c304a]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4c3086]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@4c3086]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@4c2c0a]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call df 1a 00 00 // ProcessType[[3]string]
+	Call ff 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 63 1b 00 00 // ProcessType[[]string]
+	Call 83 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
 	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 5a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
 	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1a3d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.bigStruct]
+// 0x1a43: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.condFields]
+// 0x1a49: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*main.lenFields]
+// 0x1a4f: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._defer]
+// 0x1a55: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime._panic]
+// 0x1a5b: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.cgoCallers]
+// 0x1a61: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.coro]
+// 0x1a67: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.g]
+// 0x1a6d: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.m]
+// 0x1a73: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.p]
+// 0x1a79: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.sudog]
+// 0x1a7f: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.synctestBubble]
+// 0x1a85: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.timer]
+// 0x1a8b: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*runtime.traceBuf]
+// 0x1a91: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*runtime.xRegState]
+// 0x1a97: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*string]
+// 0x1a9d: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1aa3: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*table<string,int>]
+// 0x1aa9: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*table<string,main.bigStruct>]
+// 0x1aaf: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1ab5: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint]
+// 0x1abb: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint16]
+// 0x1ac1: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint32]
+// 0x1ac7: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uint64]
+// 0x1acd: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[*uint8]
+// 0x1ad3: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ab9: ProcessType[*uintptr]
+// 0x1ad9: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1abf: ProcessType[[2]*runtime.traceBuf]
+// 0x1adf: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 91 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1acf: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1aef: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call bf 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call df 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[3]string]
+// 0x1aff: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1aef: ProcessType[[]*runtime.p]
+// 0x1b0f: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1af9: ProcessType[[]*runtime.p.array]
+// 0x1b19: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 59 1a 00 00 // ProcessType[*runtime.p]
+	Call 79 1a 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b05: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1b25: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call a3 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b11: ProcessType[[]*table<string,int>.array]
+// 0x1b31: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 89 1a 00 00 // ProcessType[*table<string,int>]
+	Call a9 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b1d: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b3d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 8f 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call af 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b49: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 95 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b5 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b35: ProcessType[[]int]
+// 0x1b55: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b5f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 70 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 90 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b6b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 7b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 9b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b57: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b77: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 86 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a6 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b63: ProcessType[[]string]
+// 0x1b83: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1b6d: ProcessType[[]string.array]
+// 0x1b8d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b79: ProcessType[[]uint8]
+// 0x1b99: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]uintptr]
+// 0x1ba3: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[error]
+// 0x1bad: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b8f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1baf: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b9b: ProcessType[groupReference<string,int>]
+// 0x1bbb: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ba7: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1bc7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bb3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bd3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bbf: ProcessType[main.condFields]
+// 0x1bdf: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1bca: ProcessType[main.lenFields]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1bea: ProcessType[main.lenFields]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*string]
+	Call 9d 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bf8: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1c18: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1c04: ProcessType[map<string,int>]
+// 0x1c24: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1c10: ProcessType[map<string,main.bigStruct>]
+// 0x1c30: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c1c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c3c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1c28: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c48: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1c2e: ProcessType[map[string]int]
+// 0x1c4e: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c34: ProcessType[map[string]main.bigStruct]
+// 0x1c54: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1c3a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c5a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1c40: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c60: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 91 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call b1 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c50: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c70: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call c1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c60: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c80: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call a7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call c7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c70: ProcessType[noalg.map.group[string]int]
+// 0x1c90: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 50 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 70 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c7b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c9b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 40 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c86: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ca6: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 80 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c91: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1cb1: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 43 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1ca1: ProcessType[noalg.struct { key string; elem int }]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1cc1: ProcessType[noalg.struct { key string; elem int }]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1ca7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1cc7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 48 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cb2: ProcessType[runtime.g]
+// 0x1cd2: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime._panic]
+	Call 5b 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._defer]
+	Call 55 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 79 1b 00 00 // ProcessType[[]uint8]
+	Call 99 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 7f 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.timer]
+	Call 8b 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.coro]
+	Call 67 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 85 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 1d 00 00 // ProcessType[runtime.xRegPerG]
+	Call d6 1d 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1d21: ProcessType[runtime.m]
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d41: ProcessType[runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call ef 1a 00 00 // ProcessType[[]*runtime.p]
+	Call 0f 1b 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 61 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call b5 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call c0 1d 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call b0 1d 00 00 // ProcessType[runtime.mWeakPointer]
+	Call d0 1d 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x1d95: ProcessType[runtime.mLockProfile]
+// 0x1db5: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1da0: ProcessType[runtime.mTraceState]
+// 0x1dc0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call cf 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call ef 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1db0: ProcessType[runtime.mWeakPointer]
-	Call 1d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1dd0: ProcessType[runtime.mWeakPointer]
+	Call 3d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1db6: ProcessType[runtime.xRegPerG]
-	Call 77 1a 00 00 // ProcessType[*runtime.xRegState]
+// 0x1dd6: ProcessType[runtime.xRegPerG]
+	Call 97 1a 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1dbc: ProcessType[string]
+// 0x1ddc: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x1dc2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1de2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8f 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call af 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1dcd: ProcessType[table<string,int>]
+// 0x1ded: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9b 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call bb 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dd8: ProcessType[table<string,main.bigStruct>]
+// 0x1df8: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1de3: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e03: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call b3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2256,32 +2256,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6835
+ID: 5 Len: 8 Enqueue: 6867
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7612
+ID: 9 Len: 16 Enqueue: 7644
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6643
+ID: 11 Len: 8 Enqueue: 6675
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7053
+ID: 15 Len: 16 Enqueue: 7085
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6841
+ID: 19 Len: 8 Enqueue: 6873
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 6673
-ID: 22 Len: 8 Enqueue: 6823
-ID: 23 Len: 456 Enqueue: 7346
+ID: 21 Len: 8 Enqueue: 6705
+ID: 22 Len: 8 Enqueue: 6855
+ID: 23 Len: 456 Enqueue: 7378
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 6715
+ID: 25 Len: 8 Enqueue: 6747
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 6709
+ID: 27 Len: 8 Enqueue: 6741
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 6739
-ID: 30 Len: 1824 Enqueue: 7457
+ID: 29 Len: 8 Enqueue: 6771
+ID: 30 Len: 1824 Enqueue: 7489
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2290,51 +2290,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7033
-ID: 40 Len: 8 Enqueue: 6637
+ID: 39 Len: 24 Enqueue: 7065
+ID: 40 Len: 8 Enqueue: 6669
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 6751
+ID: 42 Len: 8 Enqueue: 6783
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7043
-ID: 45 Len: 8 Enqueue: 6763
+ID: 44 Len: 24 Enqueue: 7075
+ID: 45 Len: 8 Enqueue: 6795
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 6727
+ID: 48 Len: 8 Enqueue: 6759
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 6757
+ID: 50 Len: 8 Enqueue: 6789
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 7606
-ID: 53 Len: 8 Enqueue: 6775
+ID: 52 Len: 8 Enqueue: 7638
+ID: 53 Len: 8 Enqueue: 6807
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 6733
+ID: 59 Len: 8 Enqueue: 6765
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 6895
+ID: 66 Len: 24 Enqueue: 6927
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 6745
-ID: 69 Len: 8 Enqueue: 6721
+ID: 68 Len: 8 Enqueue: 6777
+ID: 69 Len: 8 Enqueue: 6753
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7573
+ID: 75 Len: 56 Enqueue: 7605
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 7584
-ID: 81 Len: 32 Enqueue: 6863
-ID: 82 Len: 16 Enqueue: 6847
-ID: 83 Len: 8 Enqueue: 6769
+ID: 80 Len: 72 Enqueue: 7616
+ID: 81 Len: 32 Enqueue: 6895
+ID: 82 Len: 16 Enqueue: 6879
+ID: 83 Len: 8 Enqueue: 6801
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2349,48 +2349,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 7600
-ID: 99 Len: 8 Enqueue: 6685
+ID: 98 Len: 8 Enqueue: 7632
+ID: 99 Len: 8 Enqueue: 6717
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 6781
+ID: 101 Len: 8 Enqueue: 6813
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 6661
-ID: 104 Len: 8 Enqueue: 6667
-ID: 105 Len: 8 Enqueue: 6679
-ID: 106 Len: 8 Enqueue: 6829
-ID: 107 Len: 8 Enqueue: 6649
+ID: 103 Len: 8 Enqueue: 6693
+ID: 104 Len: 8 Enqueue: 6699
+ID: 105 Len: 8 Enqueue: 6711
+ID: 106 Len: 8 Enqueue: 6861
+ID: 107 Len: 8 Enqueue: 6681
 ID: 108 Len: 2 Enqueue: 0
-ID: 109 Len: 8 Enqueue: 6655
-ID: 110 Len: 8 Enqueue: 6811
-ID: 111 Len: 8 Enqueue: 6817
-ID: 112 Len: 24 Enqueue: 6965
+ID: 109 Len: 8 Enqueue: 6687
+ID: 110 Len: 8 Enqueue: 6843
+ID: 111 Len: 8 Enqueue: 6849
+ID: 112 Len: 24 Enqueue: 6997
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7011
-ID: 115 Len: 48 Enqueue: 6879
-ID: 116 Len: 8 Enqueue: 7214
+ID: 114 Len: 24 Enqueue: 7043
+ID: 115 Len: 48 Enqueue: 6911
+ID: 116 Len: 8 Enqueue: 7246
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7172
+ID: 118 Len: 48 Enqueue: 7204
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6793
-ID: 121 Len: 8 Enqueue: 7220
+ID: 120 Len: 8 Enqueue: 6825
+ID: 121 Len: 8 Enqueue: 7252
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 7184
+ID: 123 Len: 48 Enqueue: 7216
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 6799
-ID: 126 Len: 80 Enqueue: 7103
+ID: 125 Len: 8 Enqueue: 6831
+ID: 126 Len: 80 Enqueue: 7135
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 6697
-ID: 129 Len: 72 Enqueue: 7114
-ID: 130 Len: 8 Enqueue: 6631
-ID: 131 Len: 8 Enqueue: 6703
-ID: 132 Len: 8 Enqueue: 7226
+ID: 128 Len: 8 Enqueue: 6729
+ID: 129 Len: 72 Enqueue: 7146
+ID: 130 Len: 8 Enqueue: 6663
+ID: 131 Len: 8 Enqueue: 6735
+ID: 132 Len: 8 Enqueue: 7258
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 7196
+ID: 134 Len: 48 Enqueue: 7228
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 6805
-ID: 137 Len: 8 Enqueue: 6607
-ID: 138 Len: 8 Enqueue: 6613
-ID: 139 Len: 8 Enqueue: 6625
+ID: 136 Len: 8 Enqueue: 6837
+ID: 137 Len: 8 Enqueue: 6639
+ID: 138 Len: 8 Enqueue: 6645
+ID: 139 Len: 8 Enqueue: 6657
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2398,53 +2398,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 6905
+ID: 147 Len: 8 Enqueue: 6937
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7021
+ID: 151 Len: 16 Enqueue: 7053
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 7629
-ID: 154 Len: 16 Enqueue: 7067
+ID: 153 Len: 32 Enqueue: 7661
+ID: 154 Len: 16 Enqueue: 7099
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 7280
-ID: 157 Len: 192 Enqueue: 7248
-ID: 158 Len: 24 Enqueue: 7329
-ID: 159 Len: 8 Enqueue: 6929
-ID: 160 Len: 200 Enqueue: 6975
-ID: 161 Len: 32 Enqueue: 7640
-ID: 162 Len: 16 Enqueue: 7079
+ID: 156 Len: 200 Enqueue: 7312
+ID: 157 Len: 192 Enqueue: 7280
+ID: 158 Len: 24 Enqueue: 7361
+ID: 159 Len: 8 Enqueue: 6961
+ID: 160 Len: 200 Enqueue: 7007
+ID: 161 Len: 32 Enqueue: 7672
+ID: 162 Len: 16 Enqueue: 7111
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 7291
-ID: 165 Len: 192 Enqueue: 7232
-ID: 166 Len: 24 Enqueue: 7313
-ID: 167 Len: 8 Enqueue: 6691
+ID: 164 Len: 200 Enqueue: 7323
+ID: 165 Len: 192 Enqueue: 7264
+ID: 166 Len: 24 Enqueue: 7345
+ID: 167 Len: 8 Enqueue: 6723
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 6941
-ID: 170 Len: 200 Enqueue: 6987
-ID: 171 Len: 32 Enqueue: 7651
-ID: 172 Len: 16 Enqueue: 7091
+ID: 169 Len: 8 Enqueue: 6973
+ID: 170 Len: 200 Enqueue: 7019
+ID: 171 Len: 32 Enqueue: 7683
+ID: 172 Len: 16 Enqueue: 7123
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 7302
-ID: 175 Len: 128 Enqueue: 7264
-ID: 176 Len: 16 Enqueue: 7335
-ID: 177 Len: 8 Enqueue: 7208
+ID: 174 Len: 136 Enqueue: 7334
+ID: 175 Len: 128 Enqueue: 7296
+ID: 176 Len: 16 Enqueue: 7367
+ID: 177 Len: 8 Enqueue: 7240
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 7160
+ID: 179 Len: 48 Enqueue: 7192
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6787
-ID: 182 Len: 8 Enqueue: 6953
-ID: 183 Len: 136 Enqueue: 6999
-ID: 184 Len: 32 Enqueue: 7618
-ID: 185 Len: 16 Enqueue: 7055
+ID: 181 Len: 8 Enqueue: 6819
+ID: 182 Len: 8 Enqueue: 6985
+ID: 183 Len: 136 Enqueue: 7031
+ID: 184 Len: 32 Enqueue: 7650
+ID: 185 Len: 16 Enqueue: 7087
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 6917
+ID: 191 Len: 8 Enqueue: 6949
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 6619
+ID: 193 Len: 8 Enqueue: 6651
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@4c1f34]
-	PrepareEventRoot 31 01 00 00 11 00 00 00 
+	PrepareEventRoot 68 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0x4c1f34.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@4c1f79]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	PrepareEventRoot 69 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0x4c1f79.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@4c2fca]
-	PrepareEventRoot d3 00 00 00 11 00 00 00 
+	PrepareEventRoot d6 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0x4c2fca.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@4c301f]
-	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0x4c382a]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
-	PrepareEventRoot ff 00 00 00 11 00 00 00 
+	PrepareEventRoot 02 01 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@4c389c]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0x4c382a]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@4c382a]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0x4c382a]
-	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	PrepareEventRoot 04 01 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@4c389c]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@4c382a]
-	PrepareEventRoot 03 01 00 00 12 00 00 00 
+	PrepareEventRoot 06 01 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0x4c382a.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@4c389c]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0x4c36ae.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@4c36ae]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	PrepareEventRoot fe 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0x4c36ae.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@4c3725]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0x4c376e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@4c376e]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	PrepareEventRoot 00 01 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0x4c376e.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@4c37e5]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0x4c316a]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@4c316a]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0x4c316a]
-	PrepareEventRoot db 00 00 00 11 00 00 00 
+	PrepareEventRoot de 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@4c31dc]
-	PrepareEventRoot dc 00 00 00 00 00 00 00 
+	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@4c316a]
-	PrepareEventRoot dd 00 00 00 13 00 00 00 
+	PrepareEventRoot e0 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0x4c316a.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@4c31dc]
-	PrepareEventRoot de 00 00 00 00 00 00 00 
+	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
-	PrepareEventRoot df 00 00 00 11 00 00 00 
+	PrepareEventRoot e2 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@4c329c]
-	PrepareEventRoot e0 00 00 00 00 00 00 00 
+	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0x4c322a]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@4c322a]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0x4c322a]
-	PrepareEventRoot e1 00 00 00 11 00 00 00 
+	PrepareEventRoot e4 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@4c329c]
-	PrepareEventRoot e2 00 00 00 00 00 00 00 
+	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@4c322a]
-	PrepareEventRoot e3 00 00 00 15 00 00 00 
+	PrepareEventRoot e6 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0x4c322a.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@4c329c]
-	PrepareEventRoot e4 00 00 00 00 00 00 00 
+	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0x4c32ea]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@4c32ea]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0x4c32ea]
-	PrepareEventRoot e5 00 00 00 11 00 00 00 
+	PrepareEventRoot e8 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@4c335c]
-	PrepareEventRoot e6 00 00 00 00 00 00 00 
+	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@4c32ea]
-	PrepareEventRoot e7 00 00 00 19 00 00 00 
+	PrepareEventRoot ea 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0x4c32ea.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@4c335c]
-	PrepareEventRoot e8 00 00 00 00 00 00 00 
+	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0x4c30aa]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@4c30aa]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0x4c30aa]
-	PrepareEventRoot d7 00 00 00 11 00 00 00 
+	PrepareEventRoot da 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@4c311c]
-	PrepareEventRoot d8 00 00 00 00 00 00 00 
+	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@4c30aa]
-	PrepareEventRoot d9 00 00 00 12 00 00 00 
+	PrepareEventRoot dc 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0x4c30aa.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@4c311c]
-	PrepareEventRoot da 00 00 00 00 00 00 00 
+	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@4c3e81]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0x4c3e81]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	PrepareEventRoot 2e 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@4c3e81]
-	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	PrepareEventRoot 2f 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0x4c3e81.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0x4c3c4e]
-	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 93 13 00 00 // ProcessType[*main.condFields]
+	Call 29 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@4c3c4e]
-	PrepareEventRoot 21 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0x4c3c4e.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@4c3ccf]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0x4c3daa]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@4c3daa]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0x4c3daa]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2a 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@4c3daa]
-	PrepareEventRoot 29 01 00 00 19 00 00 00 
+	PrepareEventRoot 2c 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0x4c3daa.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@4c3e1c]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0x4c3aee]
-	PrepareEventRoot 1b 01 00 00 11 00 00 00 
+	PrepareEventRoot 1e 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 93 13 00 00 // ProcessType[*main.condFields]
+	Call 29 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@4c3aee]
-	PrepareEventRoot 1d 01 00 00 19 00 00 00 
+	PrepareEventRoot 20 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0x4c3aee.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@4c3bf6]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0x4c3d0a]
-	PrepareEventRoot 23 01 00 00 09 00 00 00 
+	PrepareEventRoot 26 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@4c3d0a]
-	PrepareEventRoot 25 01 00 00 11 00 00 00 
+	PrepareEventRoot 28 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0x4c3d0a.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@4c3d7b]
-	PrepareEventRoot 26 01 00 00 09 00 00 00 
+	PrepareEventRoot 29 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0x4c3d7b.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0x4c38ee]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
-	PrepareEventRoot 05 01 00 00 11 00 00 00 
+	PrepareEventRoot 08 01 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@4c38ee]
-	PrepareEventRoot 09 01 00 00 21 00 00 00 
+	PrepareEventRoot 0c 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0x4c38ee]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 05 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@4c38ee]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0x4c38ee]
-	PrepareEventRoot 0b 01 00 00 21 00 00 00 
+	PrepareEventRoot 0e 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0x4c38ee.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@4c3965]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
+	PrepareEventRoot 10 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@4c39ae]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0x4c39ae]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 23 15 00 00 // ProcessType[main.condFields]
+	Call bf 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@4c39ae]
-	PrepareEventRoot 17 01 00 00 61 00 00 00 
+	PrepareEventRoot 1a 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0x4c39ae.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@4c3ab0]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0x4c346a]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@4c346a]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0x4c346a]
-	PrepareEventRoot ef 00 00 00 11 00 00 00 
+	PrepareEventRoot f2 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
-	PrepareEventRoot f0 00 00 00 00 00 00 00 
+	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@4c346a]
-	PrepareEventRoot f1 00 00 00 13 00 00 00 
+	PrepareEventRoot f4 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0x4c346a.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@4c34dc]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0x4c352a]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@4c352a]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0x4c352a]
-	PrepareEventRoot f3 00 00 00 11 00 00 00 
+	PrepareEventRoot f6 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@4c359c]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@4c352a]
-	PrepareEventRoot f5 00 00 00 15 00 00 00 
+	PrepareEventRoot f8 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0x4c352a.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@4c359c]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0x4c35ea]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@4c35ea]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0x4c35ea]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
+	PrepareEventRoot fa 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@4c365c]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@4c35ea]
-	PrepareEventRoot f9 00 00 00 19 00 00 00 
+	PrepareEventRoot fc 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0x4c35ea.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@4c365c]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
-	PrepareEventRoot e9 00 00 00 11 00 00 00 
+	PrepareEventRoot ec 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@4c341c]
-	PrepareEventRoot ea 00 00 00 00 00 00 00 
+	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0x4c33aa]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@4c33aa]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0x4c33aa]
-	PrepareEventRoot eb 00 00 00 11 00 00 00 
+	PrepareEventRoot ee 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@4c341c]
-	PrepareEventRoot ec 00 00 00 00 00 00 00 
+	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@4c33aa]
-	PrepareEventRoot ed 00 00 00 12 00 00 00 
+	PrepareEventRoot f0 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0x4c33aa.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@4c341c]
-	PrepareEventRoot ee 00 00 00 00 00 00 00 
+	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@4c1c4a]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c1c4a.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@4c2eaa]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0x4c2eaa.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@4c2eea]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@4c2b8a]
-	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0x4c2b8a.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@4c2bca]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@4c2d0a]
-	PrepareEventRoot ca 00 00 00 19 00 00 00 
+	PrepareEventRoot cd 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0x4c2d0a.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@4c2d56]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 14 00 00 // ProcessType[[3]string]
+	Call df 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@4c2e80]
-	PrepareEventRoot d0 00 00 00 31 00 00 00 
+	PrepareEventRoot d3 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0x4c2e80.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
@@ -1104,477 +1104,891 @@
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 99 14 00 00 // ProcessType[[]int]
+	Call 35 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@4c2c8a]
-	PrepareEventRoot c8 00 00 00 19 00 00 00 
+	PrepareEventRoot cb 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0x4c2c8a.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@4c2ccf]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@4c2c0a]
-	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@4c2c0a]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@4c2f6a]
-	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0x4c4a13.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
-	PrepareEventRoot d2 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@4c304a]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@4c3086]
-	PrepareEventRoot d6 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 00 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call bf 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@4c2c0a]
-	PrepareEventRoot c6 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+	PrepareEventRoot 60 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0x4c4b33.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@4c4a13]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@4c4aee]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@4c4b33]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@4c4c4f]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
-	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@4c446e]
+	PrepareEventRoot 40 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0x4c446e.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@4c454e]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@4c458e]
+	PrepareEventRoot 44 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0x4c458e.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@4c465a]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2f 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 54 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 58 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@4c4893]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0x4c4893.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@4c49cb]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 3a 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call c7 14 00 00 // ProcessType[[]string]
+	Call 35 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
-	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 05 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@4c4313]
+	PrepareEventRoot 3c 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0x4c4313.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@4c4409]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@4c41d3]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0x4c41d3]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 05 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@4c41d3]
+	PrepareEventRoot 38 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0x4c41d3.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@4c42bc]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call ca 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 46 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 18 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@4c46b3]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0x4c46b3]
+	PrepareEventRoot 52 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0x4c46b3.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@4c4839]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+	PrepareEventRoot c5 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 70 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
-	PrepareEventRoot 2e 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 87 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@4c2f6a]
+	PrepareEventRoot d4 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0x4c2f6a.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer be 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@4c2f9f]
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 88 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@4c304a]
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@4c3086]
+	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@4c2c0a]
+	PrepareEventRoot c9 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0x4c2c0a.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@4c2c4f]
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 00 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call df 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@4c2e0a]
+	PrepareEventRoot d1 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0x4c2e0a.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@4c2e56]
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 63 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@4c2d8a]
+	PrepareEventRoot cf 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0x4c2d8a.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@4c2dcf]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@4c4c96]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 3a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@4c4e60]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0x4c4e60.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 8a 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer c1 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 8b 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 68 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 70 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1387: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1a1d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x138d: ProcessType[*main.bigStruct]
-	ProcessPointer a5 00 00 00 
-	Return 
-// 0x1393: ProcessType[*main.condFields]
-	ProcessPointer 7e 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._defer]
-	ProcessPointer 1c 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime._panic]
-	ProcessPointer 1a 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 46 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.coro]
-	ProcessPointer 31 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.g]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.m]
-	ProcessPointer 1e 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.p]
-	ProcessPointer 8f 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.sudog]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.synctestBubble]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.timer]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*runtime.traceBuf]
-	ProcessPointer 54 00 00 00 
-	Return 
-// 0x13db: ProcessType[*runtime.xRegState]
-	ProcessPointer 36 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer b5 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*table<string,int>]
-	ProcessPointer 96 00 00 00 
-	Return 
-// 0x13f3: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 9e 00 00 00 
-	Return 
-// 0x13f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a23: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint]
+// 0x1a29: ProcessType[*main.condFields]
+	ProcessPointer 7e 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*main.lenFields]
+	ProcessPointer 81 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._defer]
+	ProcessPointer 1c 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime._panic]
+	ProcessPointer 1a 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 46 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.coro]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.g]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.m]
+	ProcessPointer 1e 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.p]
+	ProcessPointer 92 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.sudog]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.synctestBubble]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.timer]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*runtime.traceBuf]
+	ProcessPointer 54 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*runtime.xRegState]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer b8 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*table<string,int>]
+	ProcessPointer 99 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer a1 00 00 00 
+	Return 
+// 0x1a95: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ab 00 00 00 
+	Return 
+// 0x1a9b: ProcessType[*uint]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint16]
+// 0x1aa1: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uint32]
+// 0x1aa7: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1411: ProcessType[*uint64]
+// 0x1aad: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1417: ProcessType[*uint8]
+// 0x1ab3: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x141d: ProcessType[*uintptr]
+// 0x1ab9: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1423: ProcessType[[2]*runtime.traceBuf]
+// 0x1abf: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call d5 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 71 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1433: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1acf: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 23 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call bf 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1443: ProcessType[[3]string]
+// 0x1adf: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1453: ProcessType[[]*runtime.p]
+// 0x1aef: ProcessType[[]*runtime.p]
+	ProcessSlice 93 00 00 00 08 00 00 00 
+	Return 
+// 0x1af9: ProcessType[[]*runtime.p.array]
+	ProcessSliceDataPrep 
+	Call 59 1a 00 00 // ProcessType[*runtime.p]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b05: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 83 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b11: ProcessType[[]*table<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 89 1a 00 00 // ProcessType[*table<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b1d: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 8f 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 95 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b35: ProcessType[[]int]
+	ProcessSlice 95 00 00 00 08 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 70 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b4b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 7b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b57: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+	ProcessSliceDataPrep 
+	Call 86 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b63: ProcessType[[]string]
+	ProcessSlice 97 00 00 00 10 00 00 00 
+	Return 
+// 0x1b6d: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call bc 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b79: ProcessType[[]uint8]
+	ProcessSlice 8e 00 00 00 01 00 00 00 
+	Return 
+// 0x1b83: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x145d: ProcessType[[]*runtime.p.array]
-	ProcessSliceDataPrep 
-	Call bd 13 00 00 // ProcessType[*runtime.p]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1469: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1475: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call ed 13 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1481: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call f3 13 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call f9 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1499: ProcessType[[]int]
-	ProcessSlice 92 00 00 00 08 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call a6 15 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14af: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call b1 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14bb: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
-	ProcessSliceDataPrep 
-	Call bc 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14c7: ProcessType[[]string]
-	ProcessSlice 94 00 00 00 10 00 00 00 
-	Return 
-// 0x14d1: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call f2 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14dd: ProcessType[[]uint8]
-	ProcessSlice 8b 00 00 00 01 00 00 00 
-	Return 
-// 0x14e7: ProcessType[[]uintptr]
-	ProcessSlice 8d 00 00 00 08 00 00 00 
-	Return 
-// 0x14f1: ProcessType[error]
+// 0x1b8d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14f3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups bd 00 00 00 88 00 00 00 00 08 
+// 0x1b8f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14ff: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
+// 0x1b9b: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x150b: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups a7 00 00 00 c8 00 00 00 00 08 
+// 0x1ba7: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1517: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
+// 0x1bb3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1523: ProcessType[main.condFields]
+// 0x1bbf: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x152e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap bc 00 00 00 b8 00 00 00 10 18 
+// 0x1bca: ProcessType[main.lenFields]
+	Call bc 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 35 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x153a: ProcessType[map<string,int>]
-	ProcessGoSwissMap 9c 00 00 00 99 00 00 00 10 18 
+// 0x1bf8: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1546: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap a6 00 00 00 a1 00 00 00 10 18 
+// 0x1c04: ProcessType[map<string,int>]
+	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1552: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b3 00 00 00 ab 00 00 00 10 18 
+// 0x1c10: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x155e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer b0 00 00 00 
+// 0x1c1c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1564: ProcessType[map[string]int]
+// 0x1c28: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer b3 00 00 00 
+	Return 
+// 0x1c2e: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x156a: ProcessType[map[string]main.bigStruct]
+// 0x1c34: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1570: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 83 00 00 00 
+// 0x1c3a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1576: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c40: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c7 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 91 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1586: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c50: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d7 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call a1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1596: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c60: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call dd 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call a7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15a6: ProcessType[noalg.map.group[string]int]
+// 0x1c70: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 50 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15b1: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c7b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 76 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 40 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15bc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c86: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 96 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15c7: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call f2 16 00 00 // ProcessType[string]
+// 0x1c91: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.bigStruct]
+	Call 23 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15d7: ProcessType[noalg.struct { key string; elem int }]
-	Call f2 16 00 00 // ProcessType[string]
+// 0x1ca1: ProcessType[noalg.struct { key string; elem int }]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15dd: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1ca7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 28 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15e8: ProcessType[runtime.g]
+// 0x1cb2: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime._panic]
+	Call 3b 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._defer]
+	Call 35 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call dd 14 00 00 // ProcessType[[]uint8]
+	Call 79 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.sudog]
+	Call 5f 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.timer]
+	Call 6b 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.coro]
+	Call 47 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 65 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call ec 16 00 00 // ProcessType[runtime.xRegPerG]
+	Call b6 1d 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1657: ProcessType[runtime.m]
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+// 0x1d21: ProcessType[runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 53 14 00 00 // ProcessType[[]*runtime.p]
+	Call ef 1a 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 41 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call cb 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 16 00 00 // ProcessType[runtime.mTraceState]
+	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call e6 16 00 00 // ProcessType[runtime.mWeakPointer]
+	Call b0 1d 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x16cb: ProcessType[runtime.mLockProfile]
+// 0x1d95: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16d6: ProcessType[runtime.mTraceState]
+// 0x1da0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 33 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call cf 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16e6: ProcessType[runtime.mWeakPointer]
-	Call 87 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1db0: ProcessType[runtime.mWeakPointer]
+	Call 1d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x16ec: ProcessType[runtime.xRegPerG]
-	Call db 13 00 00 // ProcessType[*runtime.xRegState]
+// 0x1db6: ProcessType[runtime.xRegPerG]
+	Call 77 1a 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x16f2: ProcessType[string]
-	ProcessString 89 00 00 00 
+// 0x1dbc: ProcessType[string]
+	ProcessString 8c 00 00 00 
 	Return 
-// 0x16f8: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dc2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f3 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1703: ProcessType[table<string,int>]
+// 0x1dcd: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ff 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x170e: ProcessType[table<string,main.bigStruct>]
+// 0x1dd8: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0b 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1719: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1de3: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 17 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1842,32 +2256,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5143
+ID: 5 Len: 8 Enqueue: 6835
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5874
+ID: 9 Len: 16 Enqueue: 7612
 ID: 10 Len: 4 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4957
+ID: 11 Len: 8 Enqueue: 6643
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 5361
+ID: 15 Len: 16 Enqueue: 7053
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5149
+ID: 19 Len: 8 Enqueue: 6841
 ID: 20 Len: 1 Enqueue: 0
-ID: 21 Len: 8 Enqueue: 4987
-ID: 22 Len: 8 Enqueue: 5131
-ID: 23 Len: 456 Enqueue: 5608
+ID: 21 Len: 8 Enqueue: 6673
+ID: 22 Len: 8 Enqueue: 6823
+ID: 23 Len: 456 Enqueue: 7346
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 5023
+ID: 25 Len: 8 Enqueue: 6715
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 5017
+ID: 27 Len: 8 Enqueue: 6709
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 5047
-ID: 30 Len: 1824 Enqueue: 5719
+ID: 29 Len: 8 Enqueue: 6739
+ID: 30 Len: 1824 Enqueue: 7457
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -1876,51 +2290,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 5341
-ID: 40 Len: 8 Enqueue: 4951
+ID: 39 Len: 24 Enqueue: 7033
+ID: 40 Len: 8 Enqueue: 6637
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 5059
+ID: 42 Len: 8 Enqueue: 6751
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 5351
-ID: 45 Len: 8 Enqueue: 5071
+ID: 44 Len: 24 Enqueue: 7043
+ID: 45 Len: 8 Enqueue: 6763
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 5035
+ID: 48 Len: 8 Enqueue: 6727
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 5065
+ID: 50 Len: 8 Enqueue: 6757
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 5868
-ID: 53 Len: 8 Enqueue: 5083
+ID: 52 Len: 8 Enqueue: 7606
+ID: 53 Len: 8 Enqueue: 6775
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 5041
+ID: 59 Len: 8 Enqueue: 6733
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 5203
+ID: 66 Len: 24 Enqueue: 6895
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 5053
-ID: 69 Len: 8 Enqueue: 5029
+ID: 68 Len: 8 Enqueue: 6745
+ID: 69 Len: 8 Enqueue: 6721
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5835
+ID: 75 Len: 56 Enqueue: 7573
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 5846
-ID: 81 Len: 32 Enqueue: 5171
-ID: 82 Len: 16 Enqueue: 5155
-ID: 83 Len: 8 Enqueue: 5077
+ID: 80 Len: 72 Enqueue: 7584
+ID: 81 Len: 32 Enqueue: 6863
+ID: 82 Len: 16 Enqueue: 6847
+ID: 83 Len: 8 Enqueue: 6769
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -1935,212 +2349,267 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 5862
-ID: 99 Len: 8 Enqueue: 4999
+ID: 98 Len: 8 Enqueue: 7600
+ID: 99 Len: 8 Enqueue: 6685
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 5089
+ID: 101 Len: 8 Enqueue: 6781
 ID: 102 Len: 8 Enqueue: 0
-ID: 103 Len: 8 Enqueue: 4975
-ID: 104 Len: 8 Enqueue: 4981
-ID: 105 Len: 8 Enqueue: 4993
-ID: 106 Len: 8 Enqueue: 5137
-ID: 107 Len: 8 Enqueue: 4963
+ID: 103 Len: 8 Enqueue: 6661
+ID: 104 Len: 8 Enqueue: 6667
+ID: 105 Len: 8 Enqueue: 6679
+ID: 106 Len: 8 Enqueue: 6829
+ID: 107 Len: 8 Enqueue: 6649
 ID: 108 Len: 2 Enqueue: 0
-ID: 109 Len: 8 Enqueue: 4969
-ID: 110 Len: 8 Enqueue: 5119
-ID: 111 Len: 8 Enqueue: 5125
-ID: 112 Len: 24 Enqueue: 5273
+ID: 109 Len: 8 Enqueue: 6655
+ID: 110 Len: 8 Enqueue: 6811
+ID: 111 Len: 8 Enqueue: 6817
+ID: 112 Len: 24 Enqueue: 6965
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 5319
-ID: 115 Len: 48 Enqueue: 5187
-ID: 116 Len: 8 Enqueue: 5476
+ID: 114 Len: 24 Enqueue: 7011
+ID: 115 Len: 48 Enqueue: 6879
+ID: 116 Len: 8 Enqueue: 7214
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5434
+ID: 118 Len: 48 Enqueue: 7172
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5101
-ID: 121 Len: 8 Enqueue: 5482
+ID: 120 Len: 8 Enqueue: 6793
+ID: 121 Len: 8 Enqueue: 7220
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 5446
+ID: 123 Len: 48 Enqueue: 7184
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 5107
-ID: 126 Len: 80 Enqueue: 5411
+ID: 125 Len: 8 Enqueue: 6799
+ID: 126 Len: 80 Enqueue: 7103
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5011
-ID: 129 Len: 8 Enqueue: 5488
-ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 48 Enqueue: 5458
-ID: 132 Len: 8 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 5113
-ID: 134 Len: 8 Enqueue: 4927
-ID: 135 Len: 8 Enqueue: 4933
-ID: 136 Len: 8 Enqueue: 4945
-ID: 137 Len: 1 Enqueue: 0
-ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 1 Enqueue: 0
-ID: 140 Len: 8 Enqueue: 0
+ID: 128 Len: 8 Enqueue: 6697
+ID: 129 Len: 72 Enqueue: 7114
+ID: 130 Len: 8 Enqueue: 6631
+ID: 131 Len: 8 Enqueue: 6703
+ID: 132 Len: 8 Enqueue: 7226
+ID: 133 Len: 8 Enqueue: 0
+ID: 134 Len: 48 Enqueue: 7196
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 8 Enqueue: 6805
+ID: 137 Len: 8 Enqueue: 6607
+ID: 138 Len: 8 Enqueue: 6613
+ID: 139 Len: 8 Enqueue: 6625
+ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 0
+ID: 142 Len: 1 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 8 Enqueue: 5213
+ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 16 Enqueue: 5329
+ID: 147 Len: 8 Enqueue: 6905
+ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 32 Enqueue: 5891
-ID: 151 Len: 16 Enqueue: 5375
+ID: 150 Len: 8 Enqueue: 0
+ID: 151 Len: 16 Enqueue: 7021
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 5542
-ID: 154 Len: 192 Enqueue: 5510
-ID: 155 Len: 24 Enqueue: 5591
-ID: 156 Len: 8 Enqueue: 5237
-ID: 157 Len: 200 Enqueue: 5283
-ID: 158 Len: 32 Enqueue: 5902
-ID: 159 Len: 16 Enqueue: 5387
-ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 200 Enqueue: 5553
-ID: 162 Len: 192 Enqueue: 5494
-ID: 163 Len: 24 Enqueue: 5575
-ID: 164 Len: 8 Enqueue: 5005
-ID: 165 Len: 184 Enqueue: 0
-ID: 166 Len: 8 Enqueue: 5249
-ID: 167 Len: 200 Enqueue: 5295
-ID: 168 Len: 32 Enqueue: 5913
-ID: 169 Len: 16 Enqueue: 5399
-ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 136 Enqueue: 5564
-ID: 172 Len: 128 Enqueue: 5526
-ID: 173 Len: 16 Enqueue: 5597
-ID: 174 Len: 8 Enqueue: 5470
-ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 48 Enqueue: 5422
-ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5095
-ID: 179 Len: 8 Enqueue: 5261
-ID: 180 Len: 136 Enqueue: 5307
-ID: 181 Len: 32 Enqueue: 5880
-ID: 182 Len: 16 Enqueue: 5363
-ID: 183 Len: 8 Enqueue: 0
-ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 128 Enqueue: 0
-ID: 186 Len: 16 Enqueue: 0
-ID: 187 Len: 8 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 5225
-ID: 189 Len: 136 Enqueue: 0
-ID: 190 Len: 8 Enqueue: 4939
-ID: 191 Len: 128 Enqueue: 0
-ID: 192 Len: 9 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 17 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
+ID: 153 Len: 32 Enqueue: 7629
+ID: 154 Len: 16 Enqueue: 7067
+ID: 155 Len: 8 Enqueue: 0
+ID: 156 Len: 200 Enqueue: 7280
+ID: 157 Len: 192 Enqueue: 7248
+ID: 158 Len: 24 Enqueue: 7329
+ID: 159 Len: 8 Enqueue: 6929
+ID: 160 Len: 200 Enqueue: 6975
+ID: 161 Len: 32 Enqueue: 7640
+ID: 162 Len: 16 Enqueue: 7079
+ID: 163 Len: 8 Enqueue: 0
+ID: 164 Len: 200 Enqueue: 7291
+ID: 165 Len: 192 Enqueue: 7232
+ID: 166 Len: 24 Enqueue: 7313
+ID: 167 Len: 8 Enqueue: 6691
+ID: 168 Len: 184 Enqueue: 0
+ID: 169 Len: 8 Enqueue: 6941
+ID: 170 Len: 200 Enqueue: 6987
+ID: 171 Len: 32 Enqueue: 7651
+ID: 172 Len: 16 Enqueue: 7091
+ID: 173 Len: 8 Enqueue: 0
+ID: 174 Len: 136 Enqueue: 7302
+ID: 175 Len: 128 Enqueue: 7264
+ID: 176 Len: 16 Enqueue: 7335
+ID: 177 Len: 8 Enqueue: 7208
+ID: 178 Len: 8 Enqueue: 0
+ID: 179 Len: 48 Enqueue: 7160
+ID: 180 Len: 8 Enqueue: 0
+ID: 181 Len: 8 Enqueue: 6787
+ID: 182 Len: 8 Enqueue: 6953
+ID: 183 Len: 136 Enqueue: 6999
+ID: 184 Len: 32 Enqueue: 7618
+ID: 185 Len: 16 Enqueue: 7055
+ID: 186 Len: 8 Enqueue: 0
+ID: 187 Len: 136 Enqueue: 0
+ID: 188 Len: 128 Enqueue: 0
+ID: 189 Len: 16 Enqueue: 0
+ID: 190 Len: 8 Enqueue: 0
+ID: 191 Len: 8 Enqueue: 6917
+ID: 192 Len: 136 Enqueue: 0
+ID: 193 Len: 8 Enqueue: 6619
+ID: 194 Len: 128 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 33 Enqueue: 0
+ID: 197 Len: 17 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
 ID: 199 Len: 0 Enqueue: 0
-ID: 200 Len: 25 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 25 Enqueue: 0
-ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 25 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 49 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
-ID: 208 Len: 49 Enqueue: 0
-ID: 209 Len: 17 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 33 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 25 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 25 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 25 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 49 Enqueue: 0
 ID: 210 Len: 0 Enqueue: 0
-ID: 211 Len: 17 Enqueue: 0
-ID: 212 Len: 0 Enqueue: 0
+ID: 211 Len: 49 Enqueue: 0
+ID: 212 Len: 17 Enqueue: 0
 ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 0 Enqueue: 0
-ID: 215 Len: 17 Enqueue: 0
+ID: 214 Len: 17 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
 ID: 216 Len: 0 Enqueue: 0
-ID: 217 Len: 18 Enqueue: 0
-ID: 218 Len: 0 Enqueue: 0
-ID: 219 Len: 17 Enqueue: 0
-ID: 220 Len: 0 Enqueue: 0
-ID: 221 Len: 19 Enqueue: 0
-ID: 222 Len: 0 Enqueue: 0
-ID: 223 Len: 17 Enqueue: 0
-ID: 224 Len: 0 Enqueue: 0
-ID: 225 Len: 17 Enqueue: 0
-ID: 226 Len: 0 Enqueue: 0
-ID: 227 Len: 21 Enqueue: 0
-ID: 228 Len: 0 Enqueue: 0
-ID: 229 Len: 17 Enqueue: 0
-ID: 230 Len: 0 Enqueue: 0
-ID: 231 Len: 25 Enqueue: 0
-ID: 232 Len: 0 Enqueue: 0
-ID: 233 Len: 17 Enqueue: 0
-ID: 234 Len: 0 Enqueue: 0
-ID: 235 Len: 17 Enqueue: 0
-ID: 236 Len: 0 Enqueue: 0
-ID: 237 Len: 18 Enqueue: 0
-ID: 238 Len: 0 Enqueue: 0
-ID: 239 Len: 17 Enqueue: 0
-ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 19 Enqueue: 0
-ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 17 Enqueue: 0
-ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 21 Enqueue: 0
-ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
-ID: 248 Len: 0 Enqueue: 0
-ID: 249 Len: 25 Enqueue: 0
-ID: 250 Len: 0 Enqueue: 0
-ID: 251 Len: 17 Enqueue: 0
-ID: 252 Len: 0 Enqueue: 0
-ID: 253 Len: 17 Enqueue: 0
-ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 17 Enqueue: 0
-ID: 256 Len: 0 Enqueue: 0
-ID: 257 Len: 17 Enqueue: 0
-ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 18 Enqueue: 0
-ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 17 Enqueue: 0
-ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 17 Enqueue: 0
-ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 33 Enqueue: 0
-ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 33 Enqueue: 0
-ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
-ID: 270 Len: 0 Enqueue: 0
-ID: 271 Len: 17 Enqueue: 0
-ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 17 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 17 Enqueue: 0
-ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
-ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 97 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
-ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 17 Enqueue: 0
-ID: 284 Len: 0 Enqueue: 0
-ID: 285 Len: 25 Enqueue: 0
-ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 17 Enqueue: 0
-ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 25 Enqueue: 0
-ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 9 Enqueue: 0
-ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 17 Enqueue: 0
+ID: 217 Len: 0 Enqueue: 0
+ID: 218 Len: 17 Enqueue: 0
+ID: 219 Len: 0 Enqueue: 0
+ID: 220 Len: 18 Enqueue: 0
+ID: 221 Len: 0 Enqueue: 0
+ID: 222 Len: 17 Enqueue: 0
+ID: 223 Len: 0 Enqueue: 0
+ID: 224 Len: 19 Enqueue: 0
+ID: 225 Len: 0 Enqueue: 0
+ID: 226 Len: 17 Enqueue: 0
+ID: 227 Len: 0 Enqueue: 0
+ID: 228 Len: 17 Enqueue: 0
+ID: 229 Len: 0 Enqueue: 0
+ID: 230 Len: 21 Enqueue: 0
+ID: 231 Len: 0 Enqueue: 0
+ID: 232 Len: 17 Enqueue: 0
+ID: 233 Len: 0 Enqueue: 0
+ID: 234 Len: 25 Enqueue: 0
+ID: 235 Len: 0 Enqueue: 0
+ID: 236 Len: 17 Enqueue: 0
+ID: 237 Len: 0 Enqueue: 0
+ID: 238 Len: 17 Enqueue: 0
+ID: 239 Len: 0 Enqueue: 0
+ID: 240 Len: 18 Enqueue: 0
+ID: 241 Len: 0 Enqueue: 0
+ID: 242 Len: 17 Enqueue: 0
+ID: 243 Len: 0 Enqueue: 0
+ID: 244 Len: 19 Enqueue: 0
+ID: 245 Len: 0 Enqueue: 0
+ID: 246 Len: 17 Enqueue: 0
+ID: 247 Len: 0 Enqueue: 0
+ID: 248 Len: 21 Enqueue: 0
+ID: 249 Len: 0 Enqueue: 0
+ID: 250 Len: 17 Enqueue: 0
+ID: 251 Len: 0 Enqueue: 0
+ID: 252 Len: 25 Enqueue: 0
+ID: 253 Len: 0 Enqueue: 0
+ID: 254 Len: 17 Enqueue: 0
+ID: 255 Len: 0 Enqueue: 0
+ID: 256 Len: 17 Enqueue: 0
+ID: 257 Len: 0 Enqueue: 0
+ID: 258 Len: 17 Enqueue: 0
+ID: 259 Len: 0 Enqueue: 0
+ID: 260 Len: 17 Enqueue: 0
+ID: 261 Len: 0 Enqueue: 0
+ID: 262 Len: 18 Enqueue: 0
+ID: 263 Len: 0 Enqueue: 0
+ID: 264 Len: 17 Enqueue: 0
+ID: 265 Len: 0 Enqueue: 0
+ID: 266 Len: 17 Enqueue: 0
+ID: 267 Len: 0 Enqueue: 0
+ID: 268 Len: 33 Enqueue: 0
+ID: 269 Len: 0 Enqueue: 0
+ID: 270 Len: 33 Enqueue: 0
+ID: 271 Len: 0 Enqueue: 0
+ID: 272 Len: 17 Enqueue: 0
+ID: 273 Len: 0 Enqueue: 0
+ID: 274 Len: 17 Enqueue: 0
+ID: 275 Len: 0 Enqueue: 0
+ID: 276 Len: 17 Enqueue: 0
+ID: 277 Len: 0 Enqueue: 0
+ID: 278 Len: 17 Enqueue: 0
+ID: 279 Len: 0 Enqueue: 0
+ID: 280 Len: 17 Enqueue: 0
+ID: 281 Len: 0 Enqueue: 0
+ID: 282 Len: 97 Enqueue: 0
+ID: 283 Len: 0 Enqueue: 0
+ID: 284 Len: 17 Enqueue: 0
+ID: 285 Len: 0 Enqueue: 0
+ID: 286 Len: 17 Enqueue: 0
+ID: 287 Len: 0 Enqueue: 0
+ID: 288 Len: 25 Enqueue: 0
+ID: 289 Len: 0 Enqueue: 0
+ID: 290 Len: 17 Enqueue: 0
+ID: 291 Len: 0 Enqueue: 0
+ID: 292 Len: 25 Enqueue: 0
+ID: 293 Len: 0 Enqueue: 0
 ID: 294 Len: 9 Enqueue: 0
-ID: 295 Len: 25 Enqueue: 0
-ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 25 Enqueue: 0
-ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 17 Enqueue: 0
+ID: 295 Len: 0 Enqueue: 0
+ID: 296 Len: 17 Enqueue: 0
+ID: 297 Len: 9 Enqueue: 0
+ID: 298 Len: 25 Enqueue: 0
+ID: 299 Len: 0 Enqueue: 0
 ID: 300 Len: 25 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 9 Enqueue: 0
-ID: 303 Len: 9 Enqueue: 0
-ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 17 Enqueue: 0
+ID: 302 Len: 17 Enqueue: 0
+ID: 303 Len: 25 Enqueue: 0
+ID: 304 Len: 17 Enqueue: 0
+ID: 305 Len: 0 Enqueue: 0
 ID: 306 Len: 9 Enqueue: 0
+ID: 307 Len: 0 Enqueue: 0
+ID: 308 Len: 17 Enqueue: 0
+ID: 309 Len: 0 Enqueue: 0
+ID: 310 Len: 9 Enqueue: 0
+ID: 311 Len: 0 Enqueue: 0
+ID: 312 Len: 33 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 9 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 41 Enqueue: 0
+ID: 317 Len: 0 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 0 Enqueue: 0
+ID: 320 Len: 25 Enqueue: 0
+ID: 321 Len: 0 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 25 Enqueue: 0
+ID: 325 Len: 0 Enqueue: 0
+ID: 326 Len: 89 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
+ID: 331 Len: 0 Enqueue: 0
+ID: 332 Len: 9 Enqueue: 0
+ID: 333 Len: 0 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0
+ID: 335 Len: 0 Enqueue: 0
+ID: 336 Len: 9 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 17 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 25 Enqueue: 0
+ID: 341 Len: 0 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 9 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
+ID: 347 Len: 0 Enqueue: 0
+ID: 348 Len: 25 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 97 Enqueue: 0
+ID: 353 Len: 0 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 9 Enqueue: 0
+ID: 358 Len: 9 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 17 Enqueue: 0
+ID: 361 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5494]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54cc]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54cc.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6310]
-	PrepareEventRoot b8 00 00 00 11 00 00 00 
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b6384]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0xb6b18]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
-	PrepareEventRoot e4 00 00 00 11 00 00 00 
+	PrepareEventRoot e7 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@b6b80]
-	PrepareEventRoot e5 00 00 00 00 00 00 00 
+	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0xb6b18]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
-	PrepareEventRoot e6 00 00 00 11 00 00 00 
+	PrepareEventRoot e9 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@b6b80]
-	PrepareEventRoot e7 00 00 00 00 00 00 00 
+	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6b18]
-	PrepareEventRoot e8 00 00 00 12 00 00 00 
+	PrepareEventRoot eb 00 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@b6b80]
-	PrepareEventRoot e9 00 00 00 00 00 00 00 
+	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb69b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b69b8]
-	PrepareEventRoot e0 00 00 00 11 00 00 00 
+	PrepareEventRoot e3 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb69b8.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b6a20]
-	PrepareEventRoot e1 00 00 00 00 00 00 00 
+	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0xb6a68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6a68]
-	PrepareEventRoot e2 00 00 00 11 00 00 00 
+	PrepareEventRoot e5 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb6a68.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@b6ad0]
-	PrepareEventRoot e3 00 00 00 00 00 00 00 
+	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0xb64e8]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b64e8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb64e8]
-	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	PrepareEventRoot c3 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@b6548]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b64e8]
-	PrepareEventRoot c2 00 00 00 13 00 00 00 
+	PrepareEventRoot c5 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b6548]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb6598]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
-	PrepareEventRoot c4 00 00 00 11 00 00 00 
+	PrepareEventRoot c7 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@b65f8]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0xb6598]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
-	PrepareEventRoot c6 00 00 00 11 00 00 00 
+	PrepareEventRoot c9 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@b65f8]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b6598]
-	PrepareEventRoot c8 00 00 00 15 00 00 00 
+	PrepareEventRoot cb 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b65f8]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb6648]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6648]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6648]
-	PrepareEventRoot ca 00 00 00 11 00 00 00 
+	PrepareEventRoot cd 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@b66a8]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6648]
-	PrepareEventRoot cc 00 00 00 19 00 00 00 
+	PrepareEventRoot cf 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b66a8]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb6438]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6438]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6438]
-	PrepareEventRoot bc 00 00 00 11 00 00 00 
+	PrepareEventRoot bf 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b64a0]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6438]
-	PrepareEventRoot be 00 00 00 12 00 00 00 
+	PrepareEventRoot c1 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@b64a0]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0xb70f4]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb70f4]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b70f4]
-	PrepareEventRoot 11 01 00 00 19 00 00 00 
+	PrepareEventRoot 14 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
-	PrepareEventRoot 04 01 00 00 11 00 00 00 
+	PrepareEventRoot 07 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 13 00 00 // ProcessType[*main.condFields]
+	Call 41 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
-	PrepareEventRoot 06 01 00 00 19 00 00 00 
+	PrepareEventRoot 09 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb7038]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@b7038]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
-	PrepareEventRoot 0c 01 00 00 19 00 00 00 
+	PrepareEventRoot 0f 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@b7098]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@b7038]
-	PrepareEventRoot 0e 01 00 00 19 00 00 00 
+	PrepareEventRoot 11 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@b7098]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
-	PrepareEventRoot fe 00 00 00 11 00 00 00 
+	PrepareEventRoot 01 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot ff 00 00 00 00 00 00 00 
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
-	PrepareEventRoot 00 01 00 00 11 00 00 00 
+	PrepareEventRoot 03 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot 01 01 00 00 00 00 00 00 
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 13 00 00 // ProcessType[*main.condFields]
+	Call 41 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
-	PrepareEventRoot 02 01 00 00 19 00 00 00 
+	PrepareEventRoot 05 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
-	PrepareEventRoot 08 01 00 00 09 00 00 00 
+	PrepareEventRoot 0b 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	PrepareEventRoot 0d 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
-	PrepareEventRoot 0b 01 00 00 09 00 00 00 
+	PrepareEventRoot 0e 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
-	PrepareEventRoot ea 00 00 00 11 00 00 00 
+	PrepareEventRoot ed 00 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot eb 00 00 00 00 00 00 00 
+	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
-	PrepareEventRoot ec 00 00 00 11 00 00 00 
+	PrepareEventRoot ef 00 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot ed 00 00 00 00 00 00 00 
+	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@b6bc8]
-	PrepareEventRoot ee 00 00 00 21 00 00 00 
+	PrepareEventRoot f1 00 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot ef 00 00 00 00 00 00 00 
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
-	PrepareEventRoot f0 00 00 00 21 00 00 00 
+	PrepareEventRoot f3 00 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot f1 00 00 00 00 00 00 00 
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f2 00 00 00 11 00 00 00 
+	PrepareEventRoot f5 00 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f3 00 00 00 00 00 00 00 
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f4 00 00 00 11 00 00 00 
+	PrepareEventRoot f7 00 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f5 00 00 00 00 00 00 00 
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f6 00 00 00 11 00 00 00 
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f7 00 00 00 00 00 00 00 
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f8 00 00 00 11 00 00 00 
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f9 00 00 00 00 00 00 00 
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot fa 00 00 00 11 00 00 00 
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot fb 00 00 00 00 00 00 00 
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 79 15 00 00 // ProcessType[main.condFields]
+	Call 15 1c 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	PrepareEventRoot fc 00 00 00 61 00 00 00 
+	PrepareEventRoot ff 00 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot fd 00 00 00 00 00 00 00 
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@b67a8]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
-	PrepareEventRoot d4 00 00 00 11 00 00 00 
+	PrepareEventRoot d7 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6808]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@b67a8]
-	PrepareEventRoot d6 00 00 00 13 00 00 00 
+	PrepareEventRoot d9 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6808]
-	PrepareEventRoot d7 00 00 00 00 00 00 00 
+	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6858]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@b6858]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
-	PrepareEventRoot d8 00 00 00 11 00 00 00 
+	PrepareEventRoot db 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b68b8]
-	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@b6858]
-	PrepareEventRoot da 00 00 00 15 00 00 00 
+	PrepareEventRoot dd 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@b68b8]
-	PrepareEventRoot db 00 00 00 00 00 00 00 
+	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6908]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@b6908]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
-	PrepareEventRoot dc 00 00 00 11 00 00 00 
+	PrepareEventRoot df 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6968]
-	PrepareEventRoot dd 00 00 00 00 00 00 00 
+	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@b6908]
-	PrepareEventRoot de 00 00 00 19 00 00 00 
+	PrepareEventRoot e1 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6968]
-	PrepareEventRoot df 00 00 00 00 00 00 00 
+	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@b66f8]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
-	PrepareEventRoot ce 00 00 00 11 00 00 00 
+	PrepareEventRoot d1 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6760]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@b66f8]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
-	PrepareEventRoot d0 00 00 00 11 00 00 00 
+	PrepareEventRoot d3 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6760]
-	PrepareEventRoot d1 00 00 00 00 00 00 00 
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@b66f8]
-	PrepareEventRoot d2 00 00 00 12 00 00 00 
+	PrepareEventRoot d5 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6760]
-	PrepareEventRoot d3 00 00 00 00 00 00 00 
+	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@b52a4]
-	PrepareEventRoot 14 01 00 00 09 00 00 00 
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@b61d8]
-	PrepareEventRoot 14 01 00 00 09 00 00 00 
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@b6210]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@b5eb8]
-	PrepareEventRoot a5 00 00 00 09 00 00 00 
+	PrepareEventRoot a8 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5ef0]
-	PrepareEventRoot a6 00 00 00 00 00 00 00 
+	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b6038]
-	PrepareEventRoot af 00 00 00 19 00 00 00 
+	PrepareEventRoot b2 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
-	PrepareEventRoot b0 00 00 00 00 00 00 00 
+	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 27 14 00 00 // ProcessType[[3]string]
+	Call c3 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
-	PrepareEventRoot b5 00 00 00 31 00 00 00 
+	PrepareEventRoot b8 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
@@ -1104,415 +1104,829 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 73 14 00 00 // ProcessType[[]int]
+	Call 0f 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
-	PrepareEventRoot ad 00 00 00 19 00 00 00 
+	PrepareEventRoot b0 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
-	PrepareEventRoot ae 00 00 00 00 00 00 00 
+	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@b5f28]
-	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b5f64]
-	PrepareEventRoot a8 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@b5f28]
-	PrepareEventRoot a9 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b5f64]
-	PrepareEventRoot aa 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 8a 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@b6298]
-	PrepareEventRoot b6 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b62c8]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@b63c8]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b6400]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call 15 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@b5f28]
-	PrepareEventRoot ab 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+	PrepareEventRoot 45 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b5f64]
-	PrepareEventRoot ac 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 27 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b6148]
-	PrepareEventRoot b3 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
-	PrepareEventRoot b4 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 27 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 89 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 47 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 39 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 1f 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 8d 14 00 00 // ProcessType[[]string]
+	Call 0f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
-	PrepareEventRoot b1 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
-	PrepareEventRoot b2 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 21 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb73dc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0xb73dc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 1b 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 1d 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call 20 1c 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 2b 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 35 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 37 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@b5f28]
+	PrepareEventRoot aa 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+	PrepareEventRoot ab 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@b5f28]
+	PrepareEventRoot ac 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+	PrepareEventRoot ad 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9c 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
-	PrepareEventRoot 13 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 82 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@b6298]
+	PrepareEventRoot b9 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer a3 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b62c8]
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 83 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@b63c8]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b6400]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@b5f28]
+	PrepareEventRoot ae 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+	PrepareEventRoot af 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call c3 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b6148]
+	PrepareEventRoot b6 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
+	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 29 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
+	PrepareEventRoot b4 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
+	PrepareEventRoot b5 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 66 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 85 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer a6 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 86 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 64 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 9c 00 00 00 
+// 0x19f9: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1369: ProcessType[*bucket<string,int>]
+// 0x19ff: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x136f: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1a05: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1375: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 80 00 00 00 
+// 0x1a0b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer 83 00 00 00 
 	Return 
-// 0x137b: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessPointer 7b 00 00 00 
-	Return 
-// 0x1381: ProcessType[*error]
-	ProcessPointer 12 00 00 00 
-	Return 
-// 0x1387: ProcessType[*float32]
-	ProcessPointer 10 00 00 00 
-	Return 
-// 0x138d: ProcessType[*float64]
-	ProcessPointer 11 00 00 00 
-	Return 
-// 0x1393: ProcessType[*int]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x1399: ProcessType[*int32]
-	ProcessPointer 0d 00 00 00 
-	Return 
-// 0x139f: ProcessType[*int64]
-	ProcessPointer 0e 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*main.bigStruct]
-	ProcessPointer 94 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*main.condFields]
-	ProcessPointer 74 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 3d 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*runtime.mapextra]
-	ProcessPointer 6e 00 00 00 
-	Return 
-// 0x13db: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*runtime.traceBuf]
-	ProcessPointer 49 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*string]
-	ProcessPointer 0a 00 00 00 
-	Return 
-// 0x13f3: ProcessType[*uint]
-	ProcessPointer 0c 00 00 00 
-	Return 
-// 0x13f9: ProcessType[*uint16]
-	ProcessPointer 07 00 00 00 
-	Return 
-// 0x13ff: ProcessType[*uint32]
-	ProcessPointer 02 00 00 00 
-	Return 
-// 0x1405: ProcessType[*uint64]
-	ProcessPointer 0b 00 00 00 
-	Return 
-// 0x140b: ProcessType[*uint8]
-	ProcessPointer 03 00 00 00 
-	Return 
-// 0x1411: ProcessType[*uintptr]
-	ProcessPointer 01 00 00 00 
-	Return 
-// 0x1417: ProcessType[[2]*runtime.traceBuf]
-	ProcessArrayDataPrep 10 00 00 00 
-	Call e7 13 00 00 // ProcessType[*runtime.traceBuf]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1427: ProcessType[[3]string]
-	ProcessArrayDataPrep 30 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x1437: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call d7 14 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1443: ProcessType[[]bucket<string,int>.array]
-	ProcessSliceDataPrep 
-	Call e2 14 00 00 // ProcessType[bucket<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x144f: ProcessType[[]bucket<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call f7 14 00 00 // ProcessType[bucket<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x145b: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call 0c 15 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1467: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call 21 15 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1473: ProcessType[[]int]
-	ProcessSlice 8a 00 00 00 08 00 00 00 
-	Return 
-// 0x147d: ProcessType[[]key<string>]
-	ProcessArrayDataPrep 80 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]string]
-	ProcessSlice 8c 00 00 00 10 00 00 00 
-	Return 
-// 0x1497: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call 78 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]uint8]
-	ProcessSlice 86 00 00 00 01 00 00 00 
-	Return 
-// 0x14ad: ProcessType[[]uintptr]
-	ProcessSlice 88 00 00 00 08 00 00 00 
-	Return 
-// 0x14b7: ProcessType[[]val<main.bigStruct>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call a5 13 00 00 // ProcessType[*main.bigStruct]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x14c7: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessArrayDataPrep 40 00 00 00 
-	Call 84 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x14d7: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 88 00 00 00 
-	Call 63 13 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x14e2: ProcessType[bucket<string,int>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	IncrementOutputOffset 40 00 00 00 
-	Call 69 13 00 00 // ProcessType[*bucket<string,int>]
-	Return 
-// 0x14f7: ProcessType[bucket<string,main.bigStruct>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	Call b7 14 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 6f 13 00 00 // ProcessType[*bucket<string,main.bigStruct>]
-	Return 
-// 0x150c: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 08 00 00 00 
-	Call 7d 14 00 00 // ProcessType[[]key<string>]
-	Call c7 14 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 75 13 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x1521: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	IncrementOutputOffset 10 00 00 00 
-	Call c7 14 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 7b 13 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	Return 
-// 0x1531: ProcessType[error]
-	ProcessGoInterface 
-	Return 
-// 0x1533: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap a2 00 00 00 90 00 00 00 08 09 10 18 
-	Return 
-// 0x1541: ProcessType[hash<string,int>]
-	ProcessGoHmap 91 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x154f: ProcessType[hash<string,main.bigStruct>]
-	ProcessGoHmap 95 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x155d: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 9e 00 00 00 d0 00 00 00 08 09 10 18 
-	Return 
-// 0x156b: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoHmap 9d 00 00 00 58 00 00 00 08 09 10 18 
-	Return 
-// 0x1579: ProcessType[main.condFields]
-	IncrementOutputOffset 38 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
-	Return 
-// 0x1584: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 9a 00 00 00 
-	Return 
-// 0x158a: ProcessType[map[string]int]
-	ProcessPointer 6a 00 00 00 
-	Return 
-// 0x1590: ProcessType[map[string]main.bigStruct]
-	ProcessPointer 71 00 00 00 
-	Return 
-// 0x1596: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1a11: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x159c: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 79 00 00 00 
+// 0x1a17: ProcessType[*error]
+	ProcessPointer 12 00 00 00 
 	Return 
-// 0x15a2: ProcessType[runtime.g]
-	IncrementOutputOffset 20 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime._panic]
-	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime._defer]
-	IncrementOutputOffset 08 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
-	IncrementOutputOffset b8 00 00 00 
-	Call a3 14 00 00 // ProcessType[[]uint8]
-	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
-	IncrementOutputOffset 18 00 00 00 
-	Call db 13 00 00 // ProcessType[*runtime.sudog]
-	IncrementOutputOffset 08 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
-	IncrementOutputOffset 20 00 00 00 
-	Call e1 13 00 00 // ProcessType[*runtime.timer]
-	IncrementOutputOffset 18 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.coro]
+// 0x1a1d: ProcessType[*float32]
+	ProcessPointer 10 00 00 00 
 	Return 
-// 0x15fd: ProcessType[runtime.m]
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 50 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 70 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.g]
-	IncrementOutputOffset 38 00 00 00 
-	Call 78 16 00 00 // ProcessType[string]
+// 0x1a23: ProcessType[*float64]
+	ProcessPointer 11 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*int]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*int32]
+	ProcessPointer 0d 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*int64]
+	ProcessPointer 0e 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*main.bigStruct]
+	ProcessPointer 97 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*main.condFields]
+	ProcessPointer 74 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*main.lenFields]
+	ProcessPointer 77 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 3d 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*runtime.mapextra]
+	ProcessPointer 6e 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*runtime.traceBuf]
+	ProcessPointer 49 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*string]
+	ProcessPointer 0a 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*uint]
+	ProcessPointer 0c 00 00 00 
+	Return 
+// 0x1a95: ProcessType[*uint16]
+	ProcessPointer 07 00 00 00 
+	Return 
+// 0x1a9b: ProcessType[*uint32]
+	ProcessPointer 02 00 00 00 
+	Return 
+// 0x1aa1: ProcessType[*uint64]
+	ProcessPointer 0b 00 00 00 
+	Return 
+// 0x1aa7: ProcessType[*uint8]
+	ProcessPointer 03 00 00 00 
+	Return 
+// 0x1aad: ProcessType[*uintptr]
+	ProcessPointer 01 00 00 00 
+	Return 
+// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+	ProcessArrayDataPrep 10 00 00 00 
+	Call 83 1a 00 00 // ProcessType[*runtime.traceBuf]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1ac3: ProcessType[[3]string]
+	ProcessArrayDataPrep 30 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1ad3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 73 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1adf: ProcessType[[]bucket<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 7e 1b 00 00 // ProcessType[bucket<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1aeb: ProcessType[[]bucket<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 93 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1af7: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call a8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b03: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call bd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b0f: ProcessType[[]int]
+	ProcessSlice 8d 00 00 00 08 00 00 00 
+	Return 
+// 0x1b19: ProcessType[[]key<string>]
+	ProcessArrayDataPrep 80 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]string]
+	ProcessSlice 8f 00 00 00 10 00 00 00 
+	Return 
+// 0x1b33: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 42 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]uint8]
+	ProcessSlice 89 00 00 00 01 00 00 00 
+	Return 
+// 0x1b49: ProcessType[[]uintptr]
+	ProcessSlice 8b 00 00 00 08 00 00 00 
+	Return 
+// 0x1b53: ProcessType[[]val<main.bigStruct>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 3b 1a 00 00 // ProcessType[*main.bigStruct]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b63: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessArrayDataPrep 40 00 00 00 
+	Call 4e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b73: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 88 00 00 00 
+	Call f9 19 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1b7e: ProcessType[bucket<string,int>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ff 19 00 00 // ProcessType[*bucket<string,int>]
+	Return 
+// 0x1b93: ProcessType[bucket<string,main.bigStruct>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 53 1b 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 05 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Return 
+// 0x1ba8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	IncrementOutputOffset 08 00 00 00 
+	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1bbd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 11 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Return 
+// 0x1bcd: ProcessType[error]
+	ProcessGoInterface 
+	Return 
+// 0x1bcf: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
+	Return 
+// 0x1bdd: ProcessType[hash<string,int>]
+	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1beb: ProcessType[hash<string,main.bigStruct>]
+	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1bf9: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
+	Return 
+// 0x1c07: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
+	Return 
+// 0x1c15: ProcessType[main.condFields]
+	IncrementOutputOffset 38 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1c20: ProcessType[main.lenFields]
+	Call 42 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0f 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 89 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
+	Return 
+// 0x1c4e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 9d 00 00 00 
+	Return 
+// 0x1c54: ProcessType[map[string]int]
+	ProcessPointer 6a 00 00 00 
+	Return 
+// 0x1c5a: ProcessType[map[string]main.bigStruct]
+	ProcessPointer 71 00 00 00 
+	Return 
+// 0x1c60: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 81 00 00 00 
+	Return 
+// 0x1c66: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7c 00 00 00 
+	Return 
+// 0x1c6c: ProcessType[runtime.g]
+	IncrementOutputOffset 20 00 00 00 
+	Call 53 1a 00 00 // ProcessType[*runtime._panic]
+	IncrementOutputOffset 08 00 00 00 
+	Call 4d 1a 00 00 // ProcessType[*runtime._defer]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	IncrementOutputOffset b8 00 00 00 
+	Call 3f 1b 00 00 // ProcessType[[]uint8]
+	IncrementOutputOffset 40 00 00 00 
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	IncrementOutputOffset 18 00 00 00 
+	Call 77 1a 00 00 // ProcessType[*runtime.sudog]
+	IncrementOutputOffset 08 00 00 00 
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	IncrementOutputOffset 20 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*runtime.timer]
+	IncrementOutputOffset 18 00 00 00 
+	Call 5f 1a 00 00 // ProcessType[*runtime.coro]
+	Return 
+// 0x1cc7: ProcessType[runtime.m]
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 50 00 00 00 
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 70 00 00 00 
+	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	IncrementOutputOffset 38 00 00 00 
+	Call 42 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 40 00 00 00 
+	Call 59 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	IncrementOutputOffset 10 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 5d 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 27 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 68 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 32 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x165d: ProcessType[runtime.mLockProfile]
+// 0x1d27: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ad 14 00 00 // ProcessType[[]uintptr]
+	Call 49 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1668: ProcessType[runtime.mTraceState]
+// 0x1d32: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call cf 13 00 00 // ProcessType[*runtime.m]
+	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 6b 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1678: ProcessType[string]
-	ProcessString 84 00 00 00 
+// 0x1d42: ProcessType[string]
+	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1780,12 +2194,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 4957
-ID: 6 Len: 8 Enqueue: 5131
+ID: 5 Len: 8 Enqueue: 6643
+ID: 6 Len: 8 Enqueue: 6823
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 5137
+ID: 8 Len: 8 Enqueue: 6829
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 5752
+ID: 10 Len: 16 Enqueue: 7490
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -1793,18 +2207,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 5425
+ID: 18 Len: 16 Enqueue: 7117
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 5017
-ID: 21 Len: 8 Enqueue: 5119
-ID: 22 Len: 432 Enqueue: 5538
+ID: 20 Len: 8 Enqueue: 6703
+ID: 21 Len: 8 Enqueue: 6811
+ID: 22 Len: 432 Enqueue: 7276
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5047
+ID: 24 Len: 8 Enqueue: 6739
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5041
+ID: 26 Len: 8 Enqueue: 6733
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5071
-ID: 29 Len: 1760 Enqueue: 5629
+ID: 28 Len: 8 Enqueue: 6763
+ID: 29 Len: 1760 Enqueue: 7367
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1813,41 +2227,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5283
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 6975
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5083
+ID: 41 Len: 8 Enqueue: 6775
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5293
-ID: 44 Len: 8 Enqueue: 5089
+ID: 43 Len: 24 Enqueue: 6985
+ID: 44 Len: 8 Enqueue: 6781
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5059
+ID: 47 Len: 8 Enqueue: 6751
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 5065
+ID: 53 Len: 8 Enqueue: 6757
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 5053
+ID: 60 Len: 8 Enqueue: 6745
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 5725
+ID: 64 Len: 64 Enqueue: 7463
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 5736
+ID: 69 Len: 32 Enqueue: 7474
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 5143
-ID: 72 Len: 8 Enqueue: 5095
+ID: 71 Len: 16 Enqueue: 6835
+ID: 72 Len: 8 Enqueue: 6787
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -1863,195 +2277,250 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 5101
+ID: 88 Len: 8 Enqueue: 6793
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 5005
-ID: 93 Len: 8 Enqueue: 5023
-ID: 94 Len: 8 Enqueue: 5011
-ID: 95 Len: 8 Enqueue: 5125
-ID: 96 Len: 8 Enqueue: 4993
-ID: 97 Len: 8 Enqueue: 4999
-ID: 98 Len: 8 Enqueue: 5107
-ID: 99 Len: 8 Enqueue: 5113
-ID: 100 Len: 24 Enqueue: 5235
+ID: 92 Len: 8 Enqueue: 6691
+ID: 93 Len: 8 Enqueue: 6709
+ID: 94 Len: 8 Enqueue: 6697
+ID: 95 Len: 8 Enqueue: 6817
+ID: 96 Len: 8 Enqueue: 6679
+ID: 97 Len: 8 Enqueue: 6685
+ID: 98 Len: 8 Enqueue: 6799
+ID: 99 Len: 8 Enqueue: 6805
+ID: 100 Len: 24 Enqueue: 6927
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 5261
-ID: 103 Len: 48 Enqueue: 5159
-ID: 104 Len: 8 Enqueue: 5514
+ID: 102 Len: 24 Enqueue: 6953
+ID: 103 Len: 48 Enqueue: 6851
+ID: 104 Len: 8 Enqueue: 7252
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 5441
-ID: 107 Len: 8 Enqueue: 4969
-ID: 108 Len: 208 Enqueue: 5346
-ID: 109 Len: 8 Enqueue: 5077
+ID: 106 Len: 48 Enqueue: 7133
+ID: 107 Len: 8 Enqueue: 6655
+ID: 108 Len: 208 Enqueue: 7038
+ID: 109 Len: 8 Enqueue: 6769
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 5520
+ID: 111 Len: 8 Enqueue: 7258
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5455
-ID: 114 Len: 8 Enqueue: 4975
-ID: 115 Len: 208 Enqueue: 5367
-ID: 116 Len: 80 Enqueue: 5497
+ID: 113 Len: 48 Enqueue: 7147
+ID: 114 Len: 8 Enqueue: 6661
+ID: 115 Len: 208 Enqueue: 7059
+ID: 116 Len: 80 Enqueue: 7189
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5035
-ID: 119 Len: 8 Enqueue: 5532
-ID: 120 Len: 8 Enqueue: 0
-ID: 121 Len: 48 Enqueue: 5483
-ID: 122 Len: 8 Enqueue: 4987
-ID: 123 Len: 88 Enqueue: 5409
-ID: 124 Len: 8 Enqueue: 5526
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5469
-ID: 127 Len: 8 Enqueue: 4981
-ID: 128 Len: 208 Enqueue: 5388
-ID: 129 Len: 8 Enqueue: 4927
-ID: 130 Len: 8 Enqueue: 4933
-ID: 131 Len: 8 Enqueue: 4945
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 1 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 118 Len: 8 Enqueue: 6721
+ID: 119 Len: 72 Enqueue: 7200
+ID: 120 Len: 8 Enqueue: 6631
+ID: 121 Len: 8 Enqueue: 6727
+ID: 122 Len: 8 Enqueue: 7270
+ID: 123 Len: 8 Enqueue: 0
+ID: 124 Len: 48 Enqueue: 7175
+ID: 125 Len: 8 Enqueue: 6673
+ID: 126 Len: 88 Enqueue: 7101
+ID: 127 Len: 8 Enqueue: 7264
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 48 Enqueue: 7161
+ID: 130 Len: 8 Enqueue: 6667
+ID: 131 Len: 208 Enqueue: 7080
+ID: 132 Len: 8 Enqueue: 6607
+ID: 133 Len: 8 Enqueue: 6613
+ID: 134 Len: 8 Enqueue: 6625
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 8 Enqueue: 0
+ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 16 Enqueue: 5271
+ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 128 Enqueue: 5245
-ID: 144 Len: 64 Enqueue: 0
-ID: 145 Len: 208 Enqueue: 5187
-ID: 146 Len: 64 Enqueue: 5303
-ID: 147 Len: 8 Enqueue: 5029
-ID: 148 Len: 184 Enqueue: 0
-ID: 149 Len: 208 Enqueue: 5199
-ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 64 Enqueue: 5319
-ID: 152 Len: 8 Enqueue: 5508
+ID: 143 Len: 16 Enqueue: 6963
+ID: 144 Len: 8 Enqueue: 0
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 128 Enqueue: 6937
+ID: 147 Len: 64 Enqueue: 0
+ID: 148 Len: 208 Enqueue: 6879
+ID: 149 Len: 64 Enqueue: 6995
+ID: 150 Len: 8 Enqueue: 6715
+ID: 151 Len: 184 Enqueue: 0
+ID: 152 Len: 208 Enqueue: 6891
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 48 Enqueue: 5427
-ID: 155 Len: 8 Enqueue: 4963
-ID: 156 Len: 144 Enqueue: 5335
-ID: 157 Len: 88 Enqueue: 5223
-ID: 158 Len: 208 Enqueue: 5211
-ID: 159 Len: 64 Enqueue: 0
-ID: 160 Len: 64 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 0
-ID: 162 Len: 144 Enqueue: 5175
-ID: 163 Len: 8 Enqueue: 4939
-ID: 164 Len: 128 Enqueue: 0
-ID: 165 Len: 9 Enqueue: 0
-ID: 166 Len: 0 Enqueue: 0
-ID: 167 Len: 17 Enqueue: 0
-ID: 168 Len: 0 Enqueue: 0
+ID: 154 Len: 64 Enqueue: 7011
+ID: 155 Len: 8 Enqueue: 7246
+ID: 156 Len: 8 Enqueue: 0
+ID: 157 Len: 48 Enqueue: 7119
+ID: 158 Len: 8 Enqueue: 6649
+ID: 159 Len: 144 Enqueue: 7027
+ID: 160 Len: 88 Enqueue: 6915
+ID: 161 Len: 208 Enqueue: 6903
+ID: 162 Len: 64 Enqueue: 0
+ID: 163 Len: 64 Enqueue: 0
+ID: 164 Len: 8 Enqueue: 0
+ID: 165 Len: 144 Enqueue: 6867
+ID: 166 Len: 8 Enqueue: 6619
+ID: 167 Len: 128 Enqueue: 0
+ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
-ID: 170 Len: 0 Enqueue: 0
-ID: 171 Len: 33 Enqueue: 0
+ID: 170 Len: 17 Enqueue: 0
+ID: 171 Len: 0 Enqueue: 0
 ID: 172 Len: 0 Enqueue: 0
-ID: 173 Len: 25 Enqueue: 0
-ID: 174 Len: 0 Enqueue: 0
-ID: 175 Len: 25 Enqueue: 0
-ID: 176 Len: 0 Enqueue: 0
-ID: 177 Len: 25 Enqueue: 0
-ID: 178 Len: 0 Enqueue: 0
-ID: 179 Len: 49 Enqueue: 0
-ID: 180 Len: 0 Enqueue: 0
-ID: 181 Len: 49 Enqueue: 0
-ID: 182 Len: 17 Enqueue: 0
+ID: 173 Len: 0 Enqueue: 0
+ID: 174 Len: 33 Enqueue: 0
+ID: 175 Len: 0 Enqueue: 0
+ID: 176 Len: 25 Enqueue: 0
+ID: 177 Len: 0 Enqueue: 0
+ID: 178 Len: 25 Enqueue: 0
+ID: 179 Len: 0 Enqueue: 0
+ID: 180 Len: 25 Enqueue: 0
+ID: 181 Len: 0 Enqueue: 0
+ID: 182 Len: 49 Enqueue: 0
 ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 17 Enqueue: 0
-ID: 185 Len: 0 Enqueue: 0
+ID: 184 Len: 49 Enqueue: 0
+ID: 185 Len: 17 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 17 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 18 Enqueue: 0
-ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 17 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 19 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 17 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 17 Enqueue: 0
-ID: 199 Len: 0 Enqueue: 0
-ID: 200 Len: 21 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 17 Enqueue: 0
-ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 25 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 17 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
-ID: 208 Len: 17 Enqueue: 0
-ID: 209 Len: 0 Enqueue: 0
-ID: 210 Len: 18 Enqueue: 0
-ID: 211 Len: 0 Enqueue: 0
-ID: 212 Len: 17 Enqueue: 0
-ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 19 Enqueue: 0
-ID: 215 Len: 0 Enqueue: 0
-ID: 216 Len: 17 Enqueue: 0
-ID: 217 Len: 0 Enqueue: 0
-ID: 218 Len: 21 Enqueue: 0
-ID: 219 Len: 0 Enqueue: 0
-ID: 220 Len: 17 Enqueue: 0
-ID: 221 Len: 0 Enqueue: 0
-ID: 222 Len: 25 Enqueue: 0
-ID: 223 Len: 0 Enqueue: 0
-ID: 224 Len: 17 Enqueue: 0
-ID: 225 Len: 0 Enqueue: 0
-ID: 226 Len: 17 Enqueue: 0
-ID: 227 Len: 0 Enqueue: 0
-ID: 228 Len: 17 Enqueue: 0
-ID: 229 Len: 0 Enqueue: 0
-ID: 230 Len: 17 Enqueue: 0
-ID: 231 Len: 0 Enqueue: 0
-ID: 232 Len: 18 Enqueue: 0
-ID: 233 Len: 0 Enqueue: 0
-ID: 234 Len: 17 Enqueue: 0
-ID: 235 Len: 0 Enqueue: 0
-ID: 236 Len: 17 Enqueue: 0
-ID: 237 Len: 0 Enqueue: 0
-ID: 238 Len: 33 Enqueue: 0
-ID: 239 Len: 0 Enqueue: 0
-ID: 240 Len: 33 Enqueue: 0
-ID: 241 Len: 0 Enqueue: 0
-ID: 242 Len: 17 Enqueue: 0
-ID: 243 Len: 0 Enqueue: 0
-ID: 244 Len: 17 Enqueue: 0
-ID: 245 Len: 0 Enqueue: 0
-ID: 246 Len: 17 Enqueue: 0
-ID: 247 Len: 0 Enqueue: 0
-ID: 248 Len: 17 Enqueue: 0
-ID: 249 Len: 0 Enqueue: 0
-ID: 250 Len: 17 Enqueue: 0
-ID: 251 Len: 0 Enqueue: 0
-ID: 252 Len: 97 Enqueue: 0
-ID: 253 Len: 0 Enqueue: 0
-ID: 254 Len: 17 Enqueue: 0
-ID: 255 Len: 0 Enqueue: 0
-ID: 256 Len: 17 Enqueue: 0
-ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 25 Enqueue: 0
-ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 17 Enqueue: 0
-ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 25 Enqueue: 0
-ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 9 Enqueue: 0
-ID: 265 Len: 0 Enqueue: 0
-ID: 266 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 17 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 18 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 17 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 19 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 17 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 17 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 21 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 17 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 25 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 17 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
+ID: 211 Len: 17 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 18 Enqueue: 0
+ID: 214 Len: 0 Enqueue: 0
+ID: 215 Len: 17 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 19 Enqueue: 0
+ID: 218 Len: 0 Enqueue: 0
+ID: 219 Len: 17 Enqueue: 0
+ID: 220 Len: 0 Enqueue: 0
+ID: 221 Len: 21 Enqueue: 0
+ID: 222 Len: 0 Enqueue: 0
+ID: 223 Len: 17 Enqueue: 0
+ID: 224 Len: 0 Enqueue: 0
+ID: 225 Len: 25 Enqueue: 0
+ID: 226 Len: 0 Enqueue: 0
+ID: 227 Len: 17 Enqueue: 0
+ID: 228 Len: 0 Enqueue: 0
+ID: 229 Len: 17 Enqueue: 0
+ID: 230 Len: 0 Enqueue: 0
+ID: 231 Len: 17 Enqueue: 0
+ID: 232 Len: 0 Enqueue: 0
+ID: 233 Len: 17 Enqueue: 0
+ID: 234 Len: 0 Enqueue: 0
+ID: 235 Len: 18 Enqueue: 0
+ID: 236 Len: 0 Enqueue: 0
+ID: 237 Len: 17 Enqueue: 0
+ID: 238 Len: 0 Enqueue: 0
+ID: 239 Len: 17 Enqueue: 0
+ID: 240 Len: 0 Enqueue: 0
+ID: 241 Len: 33 Enqueue: 0
+ID: 242 Len: 0 Enqueue: 0
+ID: 243 Len: 33 Enqueue: 0
+ID: 244 Len: 0 Enqueue: 0
+ID: 245 Len: 17 Enqueue: 0
+ID: 246 Len: 0 Enqueue: 0
+ID: 247 Len: 17 Enqueue: 0
+ID: 248 Len: 0 Enqueue: 0
+ID: 249 Len: 17 Enqueue: 0
+ID: 250 Len: 0 Enqueue: 0
+ID: 251 Len: 17 Enqueue: 0
+ID: 252 Len: 0 Enqueue: 0
+ID: 253 Len: 17 Enqueue: 0
+ID: 254 Len: 0 Enqueue: 0
+ID: 255 Len: 97 Enqueue: 0
+ID: 256 Len: 0 Enqueue: 0
+ID: 257 Len: 17 Enqueue: 0
+ID: 258 Len: 0 Enqueue: 0
+ID: 259 Len: 17 Enqueue: 0
+ID: 260 Len: 0 Enqueue: 0
+ID: 261 Len: 25 Enqueue: 0
+ID: 262 Len: 0 Enqueue: 0
+ID: 263 Len: 17 Enqueue: 0
+ID: 264 Len: 0 Enqueue: 0
+ID: 265 Len: 25 Enqueue: 0
+ID: 266 Len: 0 Enqueue: 0
 ID: 267 Len: 9 Enqueue: 0
-ID: 268 Len: 25 Enqueue: 0
-ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 25 Enqueue: 0
-ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
+ID: 268 Len: 0 Enqueue: 0
+ID: 269 Len: 17 Enqueue: 0
+ID: 270 Len: 9 Enqueue: 0
+ID: 271 Len: 25 Enqueue: 0
+ID: 272 Len: 0 Enqueue: 0
 ID: 273 Len: 25 Enqueue: 0
 ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 9 Enqueue: 0
-ID: 276 Len: 9 Enqueue: 0
-ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 17 Enqueue: 0
+ID: 275 Len: 17 Enqueue: 0
+ID: 276 Len: 25 Enqueue: 0
+ID: 277 Len: 17 Enqueue: 0
+ID: 278 Len: 0 Enqueue: 0
 ID: 279 Len: 9 Enqueue: 0
+ID: 280 Len: 0 Enqueue: 0
+ID: 281 Len: 17 Enqueue: 0
+ID: 282 Len: 0 Enqueue: 0
+ID: 283 Len: 9 Enqueue: 0
+ID: 284 Len: 0 Enqueue: 0
+ID: 285 Len: 33 Enqueue: 0
+ID: 286 Len: 0 Enqueue: 0
+ID: 287 Len: 9 Enqueue: 0
+ID: 288 Len: 0 Enqueue: 0
+ID: 289 Len: 41 Enqueue: 0
+ID: 290 Len: 0 Enqueue: 0
+ID: 291 Len: 0 Enqueue: 0
+ID: 292 Len: 0 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 0 Enqueue: 0
+ID: 295 Len: 9 Enqueue: 0
+ID: 296 Len: 0 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 0 Enqueue: 0
+ID: 299 Len: 89 Enqueue: 0
+ID: 300 Len: 0 Enqueue: 0
+ID: 301 Len: 0 Enqueue: 0
+ID: 302 Len: 0 Enqueue: 0
+ID: 303 Len: 9 Enqueue: 0
+ID: 304 Len: 0 Enqueue: 0
+ID: 305 Len: 9 Enqueue: 0
+ID: 306 Len: 0 Enqueue: 0
+ID: 307 Len: 9 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 9 Enqueue: 0
+ID: 310 Len: 0 Enqueue: 0
+ID: 311 Len: 17 Enqueue: 0
+ID: 312 Len: 0 Enqueue: 0
+ID: 313 Len: 25 Enqueue: 0
+ID: 314 Len: 0 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 0 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 9 Enqueue: 0
+ID: 320 Len: 0 Enqueue: 0
+ID: 321 Len: 25 Enqueue: 0
+ID: 322 Len: 0 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 0 Enqueue: 0
+ID: 325 Len: 97 Enqueue: 0
+ID: 326 Len: 0 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
+ID: 331 Len: 9 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -3,54 +3,54 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5490.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5490.expr[1]]
+// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5490]
+// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5494]
 	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5490.expr[0]]
-	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5490.expr[1]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[0]]
+	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	Return 
-// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54c8.expr[0]]
+// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54cc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 51 13 00 00 // ProcessType[**int]
 	Return 
-// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54c8]
+// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54cc]
 	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54c8.expr[0]]
+	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54cc.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb5e60.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb5e60.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Call 90 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@b5e60]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@b6310]
 	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5e60.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5e60.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b5ed4]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b6384]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0xb6668]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0xb6b18]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@b6668]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6668]
+// 0x103: ProcessEvent[Probe[main.condBool]@b6b18]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@b66d0]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@b6b80]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0xb6668]
+// 0x121: ProcessCondition[Probe[main.condBool]@0xb6b18]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@b6668]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6668]
+// 0x159: ProcessEvent[Probe[main.condBool]@b6b18]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
 	PrepareEventRoot e6 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@b66d0]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@b6b80]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0xb6668.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0xb6b18.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@b6668]
+// 0x1af: ProcessEvent[Probe[main.condBool]@b6b18]
 	PrepareEventRoot e8 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6668.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6668.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6b18.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b66d0]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b6b80]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb6508.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb69b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b6508]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b69b8]
 	PrepareEventRoot e0 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb6508.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb69b8.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b6570]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b6a20]
 	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb65b8.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb6a68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@b65b8]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@b6a68]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb65b8.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb6a68.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b6620]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b6ad0]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0xb6038]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0xb64e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb6038.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@b6038]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6038]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@b64e8]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb64e8]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6038.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@b6098]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@b6548]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb6038.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb6038.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@b6038]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@b64e8]
 	PrepareEventRoot c2 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6038.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6038.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb64e8.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b6098]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b6548]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb60e8]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb6598]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@b60e8]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb60e8]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@b6598]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
 	PrepareEventRoot c4 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b6148]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b65f8]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0xb60e8]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0xb6598]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@b60e8]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb60e8]
+// 0x384: ProcessEvent[Probe[main.condInt32]@b6598]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
 	PrepareEventRoot c6 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@b6148]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@b65f8]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb6598.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@b60e8]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@b6598]
 	PrepareEventRoot c8 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb60e8.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb6598.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b6148]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b65f8]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb6198]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb6648]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0xb6198.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@b6198]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6198]
+// 0x437: ProcessEvent[Probe[main.condInt64]@b6648]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6648]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6198.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b61f8]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b66a8]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0xb6198.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb6198.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb6648.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@b6198]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@b6648]
 	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6198.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6198.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6648.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b61f8]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b66a8]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb5f88]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb6438]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,42 +311,42 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@b5f88]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb5f88]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@b6438]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6438]
 	PrepareEventRoot bc 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b5ff0]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b64a0]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0xb6438.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@b5f88]
+// 0x539: ProcessEvent[Probe[main.condInt8]@b6438]
 	PrepareEventRoot be 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5f88.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6438.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b5ff0]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b64a0]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb6c48]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb70f4]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -355,36 +355,36 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x574: ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x596: ProcessEvent[Probe[main.condLine]Line@b6c48]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6c48]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@b70f4]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb70f4]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	Return 
-// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6c48]
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
-	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[0]]
-	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6c48.expr[1]]
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[1]]
 	Return 
-// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0xb6a28]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -394,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6a28]
-	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6a28]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
 	PrepareEventRoot 04 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6a9c]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call ab 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6a28]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	PrepareEventRoot 06 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6a28.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6a9c]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb6b88]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb7038]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@b6b88]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6b88]
+// 0x708: ProcessEvent[Probe[main.condOnly]@b7038]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
 	PrepareEventRoot 0c 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@b6be8]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@b7098]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@b6b88]
+// 0x763: ProcessEvent[Probe[main.condOnly]@b7038]
 	PrepareEventRoot 0e 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6b88.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@b6be8]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@b7098]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb68fc]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -490,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b68fc]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb68fc]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b69e0]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb68fc]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -515,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b68fc]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb68fc]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b69e0]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call ab 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b68fc]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	PrepareEventRoot 02 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb68fc.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b69e0]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6ae8]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6ae8]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6ae8]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	PrepareEventRoot 08 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6b48]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6ae8]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6ae8.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6b48.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6b48]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
 	PrepareEventRoot 0b 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6b48.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0xb6718]
+// 0x958: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@b6718]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6718]
+// 0x99c: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot ea 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@b677c]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0xb6718]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@b6718]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6718]
+// 0x9f9: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@b677c]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0xb6718.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@b6718]
+// 0xa5b: ProcessEvent[Probe[main.condString]@b6bc8]
 	PrepareEventRoot ee 00 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@b677c]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0xb6718]
+// 0xa79: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0xb6718.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@b6718]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6718]
+// 0xadf: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot f0 00 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6718.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@b677c]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@b67dc]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b67dc]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@b67dc]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@b67dc]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f8 00 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b67dc]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb67dc]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
 	Call 79 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@b67dc]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	PrepareEventRoot fc 00 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb67dc.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b68b0]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb62f8]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@b62f8]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb62f8]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@b67a8]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6358]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@b62f8]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@b67a8]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb62f8.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6358]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb63a8]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6858]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@b63a8]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb63a8]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@b6858]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
 	PrepareEventRoot d8 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b6408]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@b63a8]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@b6858]
 	PrepareEventRoot da 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb63a8.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b6408]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6458]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6908]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb6458.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@b6458]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6458]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@b6908]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
 	PrepareEventRoot dc 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6458.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b64b8]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6458.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb6458.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@b6458]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@b6908]
 	PrepareEventRoot de 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6458.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6458.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b64b8]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb6248]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@b6248]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6248]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b62b0]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb6248]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,39 +1008,39 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@b6248]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6248]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot d0 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b62b0]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb6248.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@b6248]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@b66f8]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6248.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6248.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b62b0]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
@@ -1052,53 +1052,53 @@
 	PrepareEventRoot 14 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0xb5d28.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@b5d28]
+// 0x1087: ProcessEvent[Probe[main.inlined]@b61d8]
 	PrepareEventRoot 14 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5d28.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@b5d60]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@b6210]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5a08.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@b5a08]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@b5eb8]
 	PrepareEventRoot a5 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5a08.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5a40]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5ef0]
 	PrepareEventRoot a6 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb5b88.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b5b88]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b6038]
 	PrepareEventRoot af 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5b88.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b5bcc]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
 	PrepareEventRoot b0 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5d00.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
 	Call 27 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5d00]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
 	PrepareEventRoot b5 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5d00.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5af8.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
@@ -1106,95 +1106,95 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Call 73 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5af8]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
 	PrepareEventRoot ad 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5af8.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5b34]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
 	PrepareEventRoot ae 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@b5a78]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot a7 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b5ab4]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot a8 00 00 00 00 00 00 00 
 	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@b5a78]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b5ab4]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot aa 00 00 00 00 00 00 00 
 	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb5de8.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb5de8.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Call 8a 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@b5de8]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@b6298]
 	PrepareEventRoot b6 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5de8.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5de8.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b5e18]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b62c8]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@b5f18]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@b63c8]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b5f50]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b6400]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
 	Call 78 16 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@b5a78]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ab 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5a78.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b5ab4]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb5c98.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
 	Call 27 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b5c98]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b6148]
 	PrepareEventRoot b3 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5c98.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b5cdc]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
 	PrepareEventRoot b4 00 00 00 00 00 00 00 
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb5c08.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
@@ -1202,25 +1202,25 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Call 8d 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b5c08]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
 	PrepareEventRoot b1 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5c08.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b5c44]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
 	PrepareEventRoot b2 00 00 00 00 00 00 00 
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b6f20]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7094.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Call 9c 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7094]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
 	PrepareEventRoot 13 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7094.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	Return 
 // 0x133f: ProcessType[*****int]
 	ProcessPointer 82 00 00 00 

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5494]
-	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	PrepareEventRoot 5d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54cc]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54cc.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6310]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6b18]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b69b8]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6a68]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b64e8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb64e8]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b64e8]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b6598]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6648]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6648]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6648]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6438]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6438]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6438]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb70f4]
@@ -377,7 +377,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	PrepareEventRoot 14 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*main.condFields]
+	Call b8 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	PrepareEventRoot 09 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b7038]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
@@ -470,7 +470,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b7038]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
@@ -520,7 +520,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*main.condFields]
+	Call b8 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	PrepareEventRoot 05 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@b6bc8]
 	PrepareEventRoot f1 00 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 35 1c 00 00 // ProcessType[main.condFields]
+	Call 8c 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	PrepareEventRoot ff 00 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@b67a8]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
@@ -877,7 +877,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@b67a8]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@b6858]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
@@ -921,7 +921,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@b6858]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@b6908]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
@@ -965,7 +965,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@b6908]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@b66f8]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@b66f8]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@b66f8]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@b52a4]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@b61d8]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6210]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[3]string]
+	Call 3a 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
+	Call 86 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b7acc]
-	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	PrepareEventRoot 51 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 35 1c 00 00 // ProcessType[main.condFields]
+	Call 8c 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
-	PrepareEventRoot 45 01 00 00 61 00 00 00 
+	PrepareEventRoot 55 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@b7acc]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@b760c]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb760c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@b760c]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
+	PrepareEventRoot 29 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 2b 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb760c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@b760c]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
+	PrepareEventRoot 2d 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@b760c]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 31 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b771c]
-	PrepareEventRoot 27 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a9 1a 00 00 // ProcessType[*string]
+	Call 00 1e 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b771c]
-	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 35 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*main.lenFields]
+	Call be 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 39 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 49 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 4d 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	PrepareEventRoot 21 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@b73dc]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+	PrepareEventRoot 23 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@b73dc]
-	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 86 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 27 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0xb73dc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 17 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb73dc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 1b 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@b73dc]
+// 0x1898: ProcessEvent[Probe[main.lenString]@b73dc]
 	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 40 1c 00 00 // ProcessType[main.lenFields]
+	Call 97 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 2b 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 37 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 39 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 41 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 43 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call b9 20 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 45 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,437 +1689,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
-	PrepareEventRoot 37 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 47 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@b6298]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@b6298]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b62c8]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b62c8]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@b63c8]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@b63c8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b6400]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b6400]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[3]string]
+	Call 3a 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b6148]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b6148]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]string]
+	Call a0 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 86 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call dd 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d70: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*bucket<string,int>]
+// 0x1d76: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1d7c: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d82: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d88: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*error]
+// 0x1d8e: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*float32]
+// 0x1d94: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*float64]
+// 0x1d9a: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*int]
+// 0x1da0: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*int32]
+// 0x1da6: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*int64]
+// 0x1dac: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*main.bigStruct]
+// 0x1db2: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*main.condFields]
+// 0x1db8: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*main.lenFields]
+// 0x1dbe: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime._defer]
+// 0x1dc4: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime._panic]
+// 0x1dca: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.cgoCallers]
+// 0x1dd0: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.coro]
+// 0x1dd6: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.g]
+// 0x1ddc: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.m]
+// 0x1de2: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*runtime.mapextra]
+// 0x1de8: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*runtime.sudog]
+// 0x1dee: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*runtime.timer]
+// 0x1df4: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*runtime.traceBuf]
+// 0x1dfa: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*string]
+// 0x1e00: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint]
+// 0x1e06: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint16]
+// 0x1e0c: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint32]
+// 0x1e12: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint64]
+// 0x1e18: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint8]
+// 0x1e1e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uintptr]
+// 0x1e24: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
+// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call a3 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call fa 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[3]string]
+// 0x1e3a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1af3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e4a: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 93 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call ea 1e 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aff: ProcessType[[]bucket<string,int>.array]
+// 0x1e56: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9e 1b 00 00 // ProcessType[bucket<string,int>]
+	Call f5 1e 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0b: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x1e62: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call b3 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 0a 1f 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b17: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e6e: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call c8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1f 1f 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b23: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e7a: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call dd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 34 1f 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b2f: ProcessType[[]int]
+// 0x1e86: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1b39: ProcessType[[]key<string>]
+// 0x1e90: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]string]
+// 0x1ea0: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]string.array]
+// 0x1eaa: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]uint8]
+// 0x1eb6: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b69: ProcessType[[]uintptr]
+// 0x1ec0: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b73: ProcessType[[]val<main.bigStruct>]
+// 0x1eca: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*main.bigStruct]
+	Call b2 1d 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1eda: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 6e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call c5 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b93: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1eea: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 19 1a 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 70 1d 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1b9e: ProcessType[bucket<string,int>]
+// 0x1ef5: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 1f 1a 00 00 // ProcessType[*bucket<string,int>]
+	Call 76 1d 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1bb3: ProcessType[bucket<string,main.bigStruct>]
+// 0x1f0a: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
-	Call 73 1b 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 25 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call ca 1e 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 7c 1d 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1bc8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f1f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 39 1b 00 00 // ProcessType[[]key<string>]
-	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 2b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 82 1d 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bdd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f34: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 31 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 88 1d 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bed: ProcessType[error]
+// 0x1f44: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1bef: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f46: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1bfd: ProcessType[hash<string,int>]
+// 0x1f54: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c0b: ProcessType[hash<string,main.bigStruct>]
+// 0x1f62: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c19: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f70: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c27: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f7e: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1c35: ProcessType[main.condFields]
+// 0x1f8c: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	Return 
-// 0x1c40: ProcessType[main.lenFields]
-	Call 62 1d 00 00 // ProcessType[string]
+// 0x1f97: ProcessType[main.lenFields]
+	Call b9 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2f 1b 00 00 // ProcessType[[]int]
+	Call 86 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 74 1c 00 00 // ProcessType[map[string]int]
+	Call cb 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call a9 1a 00 00 // ProcessType[*string]
+	Call 00 1e 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c6e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fc5: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1c74: ProcessType[map[string]int]
+// 0x1fcb: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1c7a: ProcessType[map[string]main.bigStruct]
+// 0x1fd1: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c80: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fd7: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c86: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fdd: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1c8c: ProcessType[runtime.g]
+// 0x1fe3: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime._panic]
+	Call ca 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime._defer]
+	Call c4 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 5f 1b 00 00 // ProcessType[[]uint8]
+	Call b6 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 97 1a 00 00 // ProcessType[*runtime.sudog]
+	Call ee 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*runtime.timer]
+	Call f4 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.coro]
+	Call d6 1d 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x1ce7: ProcessType[runtime.m]
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+// 0x203e: ProcessType[runtime.m]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.g]
+	Call dc 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 62 1d 00 00 // ProcessType[string]
+	Call b9 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d0 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 47 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 9e 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 52 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call a9 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d47: ProcessType[runtime.mLockProfile]
+// 0x209e: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 69 1b 00 00 // ProcessType[[]uintptr]
+	Call c0 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d52: ProcessType[runtime.mTraceState]
+// 0x20a9: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 8b 1a 00 00 // ProcessType[*runtime.m]
+	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call e2 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d62: ProcessType[string]
+// 0x20b9: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2194,12 +2388,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6675
-ID: 6 Len: 8 Enqueue: 6855
+ID: 5 Len: 8 Enqueue: 7530
+ID: 6 Len: 8 Enqueue: 7710
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 6861
+ID: 8 Len: 8 Enqueue: 7716
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 7522
+ID: 10 Len: 16 Enqueue: 8377
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -2207,18 +2401,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 7149
+ID: 18 Len: 16 Enqueue: 8004
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6735
-ID: 21 Len: 8 Enqueue: 6843
-ID: 22 Len: 432 Enqueue: 7308
+ID: 20 Len: 8 Enqueue: 7590
+ID: 21 Len: 8 Enqueue: 7698
+ID: 22 Len: 432 Enqueue: 8163
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6771
+ID: 24 Len: 8 Enqueue: 7626
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6765
+ID: 26 Len: 8 Enqueue: 7620
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6795
-ID: 29 Len: 1760 Enqueue: 7399
+ID: 28 Len: 8 Enqueue: 7650
+ID: 29 Len: 1760 Enqueue: 8254
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2227,41 +2421,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7007
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7862
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6807
+ID: 41 Len: 8 Enqueue: 7662
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7017
-ID: 44 Len: 8 Enqueue: 6813
+ID: 43 Len: 24 Enqueue: 7872
+ID: 44 Len: 8 Enqueue: 7668
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6783
+ID: 47 Len: 8 Enqueue: 7638
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 6789
+ID: 53 Len: 8 Enqueue: 7644
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 6777
+ID: 60 Len: 8 Enqueue: 7632
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 7495
+ID: 64 Len: 64 Enqueue: 8350
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 7506
+ID: 69 Len: 32 Enqueue: 8361
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 6867
-ID: 72 Len: 8 Enqueue: 6819
+ID: 71 Len: 16 Enqueue: 7722
+ID: 72 Len: 8 Enqueue: 7674
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2277,53 +2471,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 6825
+ID: 88 Len: 8 Enqueue: 7680
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 6723
-ID: 93 Len: 8 Enqueue: 6741
-ID: 94 Len: 8 Enqueue: 6729
-ID: 95 Len: 8 Enqueue: 6849
-ID: 96 Len: 8 Enqueue: 6711
-ID: 97 Len: 8 Enqueue: 6717
-ID: 98 Len: 8 Enqueue: 6831
-ID: 99 Len: 8 Enqueue: 6837
-ID: 100 Len: 24 Enqueue: 6959
+ID: 92 Len: 8 Enqueue: 7578
+ID: 93 Len: 8 Enqueue: 7596
+ID: 94 Len: 8 Enqueue: 7584
+ID: 95 Len: 8 Enqueue: 7704
+ID: 96 Len: 8 Enqueue: 7566
+ID: 97 Len: 8 Enqueue: 7572
+ID: 98 Len: 8 Enqueue: 7686
+ID: 99 Len: 8 Enqueue: 7692
+ID: 100 Len: 24 Enqueue: 7814
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 6985
-ID: 103 Len: 48 Enqueue: 6883
-ID: 104 Len: 8 Enqueue: 7284
+ID: 102 Len: 24 Enqueue: 7840
+ID: 103 Len: 48 Enqueue: 7738
+ID: 104 Len: 8 Enqueue: 8139
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 7165
-ID: 107 Len: 8 Enqueue: 6687
-ID: 108 Len: 208 Enqueue: 7070
-ID: 109 Len: 8 Enqueue: 6801
+ID: 106 Len: 48 Enqueue: 8020
+ID: 107 Len: 8 Enqueue: 7542
+ID: 108 Len: 208 Enqueue: 7925
+ID: 109 Len: 8 Enqueue: 7656
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 7290
+ID: 111 Len: 8 Enqueue: 8145
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7179
-ID: 114 Len: 8 Enqueue: 6693
-ID: 115 Len: 208 Enqueue: 7091
-ID: 116 Len: 80 Enqueue: 7221
+ID: 113 Len: 48 Enqueue: 8034
+ID: 114 Len: 8 Enqueue: 7548
+ID: 115 Len: 208 Enqueue: 7946
+ID: 116 Len: 80 Enqueue: 8076
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6753
-ID: 119 Len: 72 Enqueue: 7232
-ID: 120 Len: 8 Enqueue: 6663
-ID: 121 Len: 8 Enqueue: 6759
-ID: 122 Len: 8 Enqueue: 7302
+ID: 118 Len: 8 Enqueue: 7608
+ID: 119 Len: 72 Enqueue: 8087
+ID: 120 Len: 8 Enqueue: 7518
+ID: 121 Len: 8 Enqueue: 7614
+ID: 122 Len: 8 Enqueue: 8157
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 7207
-ID: 125 Len: 8 Enqueue: 6705
-ID: 126 Len: 88 Enqueue: 7133
-ID: 127 Len: 8 Enqueue: 7296
+ID: 124 Len: 48 Enqueue: 8062
+ID: 125 Len: 8 Enqueue: 7560
+ID: 126 Len: 88 Enqueue: 7988
+ID: 127 Len: 8 Enqueue: 8151
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7193
-ID: 130 Len: 8 Enqueue: 6699
-ID: 131 Len: 208 Enqueue: 7112
-ID: 132 Len: 8 Enqueue: 6639
-ID: 133 Len: 8 Enqueue: 6645
-ID: 134 Len: 8 Enqueue: 6657
+ID: 129 Len: 48 Enqueue: 8048
+ID: 130 Len: 8 Enqueue: 7554
+ID: 131 Len: 208 Enqueue: 7967
+ID: 132 Len: 8 Enqueue: 7494
+ID: 133 Len: 8 Enqueue: 7500
+ID: 134 Len: 8 Enqueue: 7512
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2332,30 +2526,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 6995
+ID: 143 Len: 16 Enqueue: 7850
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 6969
+ID: 146 Len: 128 Enqueue: 7824
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 6911
-ID: 149 Len: 64 Enqueue: 7027
-ID: 150 Len: 8 Enqueue: 6747
+ID: 148 Len: 208 Enqueue: 7766
+ID: 149 Len: 64 Enqueue: 7882
+ID: 150 Len: 8 Enqueue: 7602
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 6923
+ID: 152 Len: 208 Enqueue: 7778
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7043
-ID: 155 Len: 8 Enqueue: 7278
+ID: 154 Len: 64 Enqueue: 7898
+ID: 155 Len: 8 Enqueue: 8133
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 7151
-ID: 158 Len: 8 Enqueue: 6681
-ID: 159 Len: 144 Enqueue: 7059
-ID: 160 Len: 88 Enqueue: 6947
-ID: 161 Len: 208 Enqueue: 6935
+ID: 157 Len: 48 Enqueue: 8006
+ID: 158 Len: 8 Enqueue: 7536
+ID: 159 Len: 144 Enqueue: 7914
+ID: 160 Len: 88 Enqueue: 7802
+ID: 161 Len: 208 Enqueue: 7790
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 6899
-ID: 166 Len: 8 Enqueue: 6651
+ID: 165 Len: 144 Enqueue: 7754
+ID: 166 Len: 8 Enqueue: 7506
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
@@ -2476,51 +2670,67 @@ ID: 283 Len: 9 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
 ID: 285 Len: 33 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 9 Enqueue: 0
+ID: 287 Len: 17 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 41 Enqueue: 0
+ID: 289 Len: 9 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
+ID: 291 Len: 17 Enqueue: 0
 ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
+ID: 293 Len: 9 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 9 Enqueue: 0
+ID: 295 Len: 41 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 25 Enqueue: 0
+ID: 297 Len: 17 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 89 Enqueue: 0
+ID: 299 Len: 9 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 0 Enqueue: 0
+ID: 301 Len: 17 Enqueue: 0
 ID: 302 Len: 0 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 9 Enqueue: 0
+ID: 305 Len: 25 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 9 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 9 Enqueue: 0
+ID: 309 Len: 25 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 17 Enqueue: 0
+ID: 311 Len: 89 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 25 Enqueue: 0
+ID: 313 Len: 9 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 0 Enqueue: 0
+ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
 ID: 317 Len: 9 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
 ID: 319 Len: 9 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 25 Enqueue: 0
+ID: 321 Len: 9 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 0 Enqueue: 0
+ID: 323 Len: 17 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
-ID: 325 Len: 97 Enqueue: 0
+ID: 325 Len: 17 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 0 Enqueue: 0
+ID: 327 Len: 17 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
-ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 9 Enqueue: 0
+ID: 329 Len: 25 Enqueue: 0
+ID: 330 Len: 0 Enqueue: 0
 ID: 331 Len: 9 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 17 Enqueue: 0
-ID: 334 Len: 9 Enqueue: 0
+ID: 333 Len: 9 Enqueue: 0
+ID: 334 Len: 0 Enqueue: 0
+ID: 335 Len: 9 Enqueue: 0
+ID: 336 Len: 0 Enqueue: 0
+ID: 337 Len: 25 Enqueue: 0
+ID: 338 Len: 0 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 97 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
+ID: 347 Len: 9 Enqueue: 0
+ID: 348 Len: 0 Enqueue: 0
+ID: 349 Len: 17 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5494]
-	PrepareEventRoot 5d 01 00 00 11 00 00 00 
+	PrepareEventRoot 6d 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54cc]
-	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	PrepareEventRoot 6e 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb54cc.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call d1 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call f0 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6310]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6b18]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b69b8]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6a68]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b64e8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb64e8]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b64e8]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b6598]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6648]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6648]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6648]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6438]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6438]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6438]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb70f4]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b70f4]
-	PrepareEventRoot 14 01 00 00 19 00 00 00 
+	PrepareEventRoot 18 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb70f4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0b 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*main.condFields]
+	Call d7 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
-	PrepareEventRoot 09 01 00 00 19 00 00 00 
+	PrepareEventRoot 0d 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb7038]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b7038]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
-	PrepareEventRoot 0f 01 00 00 19 00 00 00 
+	PrepareEventRoot 13 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@b7098]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b7038]
-	PrepareEventRoot 11 01 00 00 19 00 00 00 
+	PrepareEventRoot 15 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@b7098]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
-	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	PrepareEventRoot 05 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
-	PrepareEventRoot 03 01 00 00 11 00 00 00 
+	PrepareEventRoot 07 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*main.condFields]
+	Call d7 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
-	PrepareEventRoot 05 01 00 00 19 00 00 00 
+	PrepareEventRoot 09 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
-	PrepareEventRoot 0b 01 00 00 09 00 00 00 
+	PrepareEventRoot 0f 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
-	PrepareEventRoot 0e 01 00 00 09 00 00 00 
+	PrepareEventRoot 12 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b6bc8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@b6bc8]
+	PrepareEventRoot f1 00 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@b6c2c]
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@b6bc8]
+	PrepareEventRoot f3 00 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@b6c2c]
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call d8 22 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@b6bc8]
-	PrepareEventRoot f1 00 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@b6bc8]
+	PrepareEventRoot f5 00 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@b6c2c]
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0xb11: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@b6bc8]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
-	PrepareEventRoot f3 00 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
+	PrepareEventRoot f7 00 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@b6c2c]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@b6c2c]
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot f9 00 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+	PrepareEventRoot ff 00 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 8c 1f 00 00 // ProcessType[main.condFields]
+	Call ab 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	PrepareEventRoot ff 00 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	PrepareEventRoot 03 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb67a8]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@b67a8]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@b67a8]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b6808]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@b67a8]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@b67a8]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b6808]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb6858]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0xb6858]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@b6858]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@b6858]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b68b8]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@b6858]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@b6858]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b68b8]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb6908]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0xb6908]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@b6908]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@b6908]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b6968]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@b6908]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@b6908]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b6968]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@b66f8]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@b66f8]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@b66f8]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@b66f8]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@b52a4]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@b52a4]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@b61d8]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6210]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@b5eb8]
+// 0x111f: ProcessEvent[Probe[main.inlined]@b61d8]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@b6210]
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@b5eb8]
 	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b5ef0]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@b5ef0]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b6038]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@b6038]
 	PrepareEventRoot b2 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
 	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[3]string]
+	Call 59 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b7acc]
-	PrepareEventRoot 51 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+	PrepareEventRoot 61 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 8c 1f 00 00 // ProcessType[main.condFields]
+	Call ab 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
-	PrepareEventRoot 55 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+	PrepareEventRoot 65 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@b7acc]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb760c]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0xb760c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@b760c]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
-	PrepareEventRoot 29 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@b760c]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
+	PrepareEventRoot 37 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 39 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@b760c]
-	PrepareEventRoot 2b 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb760c]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0xb760c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@b760c]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
-	PrepareEventRoot 2d 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@b760c]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb760c]
+	PrepareEventRoot 3d 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@b760c]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 3f 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@b760c]
-	PrepareEventRoot 31 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@b760c]
+	PrepareEventRoot 41 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b76cc]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b771c]
-	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 43 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 00 1e 00 00 // ProcessType[*string]
+	Call 1f 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b771c]
-	PrepareEventRoot 35 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@b771c]
+	PrepareEventRoot 45 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call be 1d 00 00 // ProcessType[*main.lenFields]
+	Call dd 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 49 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 59 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 4d 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 5d 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
-	PrepareEventRoot 4f 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
-	PrepareEventRoot 1f 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 2d 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0xb74ec]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
-	PrepareEventRoot 23 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb74ec]
+	PrepareEventRoot 31 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 33 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@b74ec]
-	PrepareEventRoot 27 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@b74ec]
+	PrepareEventRoot 35 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 19 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 1b 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 1d 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0xb73dc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 21 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@b73dc]
-	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 23 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0xb73dc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+	PrepareEventRoot 25 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@b73dc]
-	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 27 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@b73dc]
-	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@b73dc]
+	PrepareEventRoot 29 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b7490]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@b7490]
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 97 1f 00 00 // ProcessType[main.lenFields]
+	Call b6 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 37 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 47 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 39 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 3b 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 4d 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	PrepareEventRoot 41 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
-	PrepareEventRoot 43 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 53 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
-	PrepareEventRoot 45 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 55 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,437 +1812,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
-	PrepareEventRoot 47 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+	PrepareEventRoot 57 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@b6298]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@b6298]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b62c8]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@b62c8]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@b63c8]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@b63c8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b6400]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@b6400]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[3]string]
+	Call 59 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b6148]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@b6148]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]string]
+	Call bf 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call dd 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call fc 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f8f: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*bucket<string,int>]
+// 0x1f95: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1f9b: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1fa1: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1fa7: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*error]
+// 0x1fad: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*float32]
+// 0x1fb3: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*float64]
+// 0x1fb9: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*int]
+// 0x1fbf: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*int32]
+// 0x1fc5: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*int64]
+// 0x1fcb: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*main.bigStruct]
+// 0x1fd1: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*main.condFields]
+// 0x1fd7: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*main.lenFields]
+// 0x1fdd: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime._defer]
+// 0x1fe3: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime._panic]
+// 0x1fe9: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.cgoCallers]
+// 0x1fef: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.coro]
+// 0x1ff5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.g]
+// 0x1ffb: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.m]
+// 0x2001: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*runtime.mapextra]
+// 0x2007: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*runtime.sudog]
+// 0x200d: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*runtime.timer]
+// 0x2013: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*runtime.traceBuf]
+// 0x2019: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*string]
+// 0x201f: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint]
+// 0x2025: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint16]
+// 0x202b: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint32]
+// 0x2031: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint64]
+// 0x2037: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint8]
+// 0x203d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uintptr]
+// 0x2043: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
+// 0x2049: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call fa 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 19 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e3a: ProcessType[[3]string]
+// 0x2059: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e4a: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x2069: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ea 1e 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 09 21 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e56: ProcessType[[]bucket<string,int>.array]
+// 0x2075: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f5 1e 00 00 // ProcessType[bucket<string,int>]
+	Call 14 21 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e62: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x2081: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 0a 1f 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call 29 21 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e6e: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x208d: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 1f 1f 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3e 21 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7a: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x2099: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 34 1f 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 53 21 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e86: ProcessType[[]int]
+// 0x20a5: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1e90: ProcessType[[]key<string>]
+// 0x20af: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]string]
+// 0x20bf: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1eaa: ProcessType[[]string.array]
+// 0x20c9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]uint8]
+// 0x20d5: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1ec0: ProcessType[[]uintptr]
+// 0x20df: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1eca: ProcessType[[]val<main.bigStruct>]
+// 0x20e9: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*main.bigStruct]
+	Call d1 1f 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eda: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x20f9: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call c5 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call e4 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eea: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x2109: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call 70 1d 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 1f 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1ef5: ProcessType[bucket<string,int>]
+// 0x2114: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call 76 1d 00 00 // ProcessType[*bucket<string,int>]
+	Call 95 1f 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1f0a: ProcessType[bucket<string,main.bigStruct>]
+// 0x2129: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
-	Call ca 1e 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 7c 1d 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
+	Call e9 20 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 9b 1f 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1f1f: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x213e: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 1e 00 00 // ProcessType[[]key<string>]
-	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 82 1d 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call af 20 00 00 // ProcessType[[]key<string>]
+	Call f9 20 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call a1 1f 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1f34: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2153: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call da 1e 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 88 1d 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 20 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call a7 1f 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1f44: ProcessType[error]
+// 0x2163: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1f46: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x2165: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1f54: ProcessType[hash<string,int>]
+// 0x2173: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f62: ProcessType[hash<string,main.bigStruct>]
+// 0x2181: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f70: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x218f: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1f7e: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x219d: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1f8c: ProcessType[main.condFields]
+// 0x21ab: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	Return 
-// 0x1f97: ProcessType[main.lenFields]
-	Call b9 20 00 00 // ProcessType[string]
+// 0x21b6: ProcessType[main.lenFields]
+	Call d8 22 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 86 1e 00 00 // ProcessType[[]int]
+	Call a5 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call cb 1f 00 00 // ProcessType[map[string]int]
+	Call ea 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 1e 00 00 // ProcessType[*string]
+	Call 1f 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1fc5: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21e4: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1fcb: ProcessType[map[string]int]
+// 0x21ea: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1fd1: ProcessType[map[string]main.bigStruct]
+// 0x21f0: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1fd7: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21f6: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1fdd: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21fc: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1fe3: ProcessType[runtime.g]
+// 0x2202: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime._panic]
+	Call e9 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime._defer]
+	Call e3 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b6 1e 00 00 // ProcessType[[]uint8]
+	Call d5 20 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ee 1d 00 00 // ProcessType[*runtime.sudog]
+	Call 0d 20 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*runtime.timer]
+	Call 13 20 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.coro]
+	Call f5 1f 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x203e: ProcessType[runtime.m]
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+// 0x225d: ProcessType[runtime.m]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.g]
+	Call fb 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call b9 20 00 00 // ProcessType[string]
+	Call d8 22 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call ef 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 9e 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call bd 22 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a9 20 00 00 // ProcessType[runtime.mTraceState]
+	Call c8 22 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x209e: ProcessType[runtime.mLockProfile]
+// 0x22bd: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1e 00 00 // ProcessType[[]uintptr]
+	Call df 20 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20a9: ProcessType[runtime.mTraceState]
+// 0x22c8: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call e2 1d 00 00 // ProcessType[*runtime.m]
+	Call 49 20 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 01 20 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x20b9: ProcessType[string]
+// 0x22d8: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2388,12 +2511,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7530
-ID: 6 Len: 8 Enqueue: 7710
+ID: 5 Len: 8 Enqueue: 8073
+ID: 6 Len: 8 Enqueue: 8253
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 7716
+ID: 8 Len: 8 Enqueue: 8259
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 8377
+ID: 10 Len: 16 Enqueue: 8920
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -2401,18 +2524,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 8004
+ID: 18 Len: 16 Enqueue: 8547
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 7590
-ID: 21 Len: 8 Enqueue: 7698
-ID: 22 Len: 432 Enqueue: 8163
+ID: 20 Len: 8 Enqueue: 8133
+ID: 21 Len: 8 Enqueue: 8241
+ID: 22 Len: 432 Enqueue: 8706
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7626
+ID: 24 Len: 8 Enqueue: 8169
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7620
+ID: 26 Len: 8 Enqueue: 8163
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7650
-ID: 29 Len: 1760 Enqueue: 8254
+ID: 28 Len: 8 Enqueue: 8193
+ID: 29 Len: 1760 Enqueue: 8797
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2421,41 +2544,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7862
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8405
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7662
+ID: 41 Len: 8 Enqueue: 8205
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7872
-ID: 44 Len: 8 Enqueue: 7668
+ID: 43 Len: 24 Enqueue: 8415
+ID: 44 Len: 8 Enqueue: 8211
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7638
+ID: 47 Len: 8 Enqueue: 8181
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 7644
+ID: 53 Len: 8 Enqueue: 8187
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 7632
+ID: 60 Len: 8 Enqueue: 8175
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 8350
+ID: 64 Len: 64 Enqueue: 8893
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 8361
+ID: 69 Len: 32 Enqueue: 8904
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 7722
-ID: 72 Len: 8 Enqueue: 7674
+ID: 71 Len: 16 Enqueue: 8265
+ID: 72 Len: 8 Enqueue: 8217
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2471,53 +2594,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 7680
+ID: 88 Len: 8 Enqueue: 8223
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 7578
-ID: 93 Len: 8 Enqueue: 7596
-ID: 94 Len: 8 Enqueue: 7584
-ID: 95 Len: 8 Enqueue: 7704
-ID: 96 Len: 8 Enqueue: 7566
-ID: 97 Len: 8 Enqueue: 7572
-ID: 98 Len: 8 Enqueue: 7686
-ID: 99 Len: 8 Enqueue: 7692
-ID: 100 Len: 24 Enqueue: 7814
+ID: 92 Len: 8 Enqueue: 8121
+ID: 93 Len: 8 Enqueue: 8139
+ID: 94 Len: 8 Enqueue: 8127
+ID: 95 Len: 8 Enqueue: 8247
+ID: 96 Len: 8 Enqueue: 8109
+ID: 97 Len: 8 Enqueue: 8115
+ID: 98 Len: 8 Enqueue: 8229
+ID: 99 Len: 8 Enqueue: 8235
+ID: 100 Len: 24 Enqueue: 8357
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 7840
-ID: 103 Len: 48 Enqueue: 7738
-ID: 104 Len: 8 Enqueue: 8139
+ID: 102 Len: 24 Enqueue: 8383
+ID: 103 Len: 48 Enqueue: 8281
+ID: 104 Len: 8 Enqueue: 8682
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 8020
-ID: 107 Len: 8 Enqueue: 7542
-ID: 108 Len: 208 Enqueue: 7925
-ID: 109 Len: 8 Enqueue: 7656
+ID: 106 Len: 48 Enqueue: 8563
+ID: 107 Len: 8 Enqueue: 8085
+ID: 108 Len: 208 Enqueue: 8468
+ID: 109 Len: 8 Enqueue: 8199
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 8145
+ID: 111 Len: 8 Enqueue: 8688
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 8034
-ID: 114 Len: 8 Enqueue: 7548
-ID: 115 Len: 208 Enqueue: 7946
-ID: 116 Len: 80 Enqueue: 8076
+ID: 113 Len: 48 Enqueue: 8577
+ID: 114 Len: 8 Enqueue: 8091
+ID: 115 Len: 208 Enqueue: 8489
+ID: 116 Len: 80 Enqueue: 8619
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 7608
-ID: 119 Len: 72 Enqueue: 8087
-ID: 120 Len: 8 Enqueue: 7518
-ID: 121 Len: 8 Enqueue: 7614
-ID: 122 Len: 8 Enqueue: 8157
+ID: 118 Len: 8 Enqueue: 8151
+ID: 119 Len: 72 Enqueue: 8630
+ID: 120 Len: 8 Enqueue: 8061
+ID: 121 Len: 8 Enqueue: 8157
+ID: 122 Len: 8 Enqueue: 8700
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 8062
-ID: 125 Len: 8 Enqueue: 7560
-ID: 126 Len: 88 Enqueue: 7988
-ID: 127 Len: 8 Enqueue: 8151
+ID: 124 Len: 48 Enqueue: 8605
+ID: 125 Len: 8 Enqueue: 8103
+ID: 126 Len: 88 Enqueue: 8531
+ID: 127 Len: 8 Enqueue: 8694
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 8048
-ID: 130 Len: 8 Enqueue: 7554
-ID: 131 Len: 208 Enqueue: 7967
-ID: 132 Len: 8 Enqueue: 7494
-ID: 133 Len: 8 Enqueue: 7500
-ID: 134 Len: 8 Enqueue: 7512
+ID: 129 Len: 48 Enqueue: 8591
+ID: 130 Len: 8 Enqueue: 8097
+ID: 131 Len: 208 Enqueue: 8510
+ID: 132 Len: 8 Enqueue: 8037
+ID: 133 Len: 8 Enqueue: 8043
+ID: 134 Len: 8 Enqueue: 8055
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2526,30 +2649,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 7850
+ID: 143 Len: 16 Enqueue: 8393
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 7824
+ID: 146 Len: 128 Enqueue: 8367
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 7766
-ID: 149 Len: 64 Enqueue: 7882
-ID: 150 Len: 8 Enqueue: 7602
+ID: 148 Len: 208 Enqueue: 8309
+ID: 149 Len: 64 Enqueue: 8425
+ID: 150 Len: 8 Enqueue: 8145
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 7778
+ID: 152 Len: 208 Enqueue: 8321
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7898
-ID: 155 Len: 8 Enqueue: 8133
+ID: 154 Len: 64 Enqueue: 8441
+ID: 155 Len: 8 Enqueue: 8676
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 8006
-ID: 158 Len: 8 Enqueue: 7536
-ID: 159 Len: 144 Enqueue: 7914
-ID: 160 Len: 88 Enqueue: 7802
-ID: 161 Len: 208 Enqueue: 7790
+ID: 157 Len: 48 Enqueue: 8549
+ID: 158 Len: 8 Enqueue: 8079
+ID: 159 Len: 144 Enqueue: 8457
+ID: 160 Len: 88 Enqueue: 8345
+ID: 161 Len: 208 Enqueue: 8333
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 7754
-ID: 166 Len: 8 Enqueue: 7506
+ID: 165 Len: 144 Enqueue: 8297
+ID: 166 Len: 8 Enqueue: 8049
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0
@@ -2624,13 +2747,13 @@ ID: 237 Len: 17 Enqueue: 0
 ID: 238 Len: 0 Enqueue: 0
 ID: 239 Len: 17 Enqueue: 0
 ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 33 Enqueue: 0
+ID: 241 Len: 2 Enqueue: 0
 ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 33 Enqueue: 0
+ID: 243 Len: 2 Enqueue: 0
 ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 17 Enqueue: 0
+ID: 245 Len: 33 Enqueue: 0
 ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
+ID: 247 Len: 33 Enqueue: 0
 ID: 248 Len: 0 Enqueue: 0
 ID: 249 Len: 17 Enqueue: 0
 ID: 250 Len: 0 Enqueue: 0
@@ -2638,81 +2761,81 @@ ID: 251 Len: 17 Enqueue: 0
 ID: 252 Len: 0 Enqueue: 0
 ID: 253 Len: 17 Enqueue: 0
 ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 97 Enqueue: 0
+ID: 255 Len: 17 Enqueue: 0
 ID: 256 Len: 0 Enqueue: 0
 ID: 257 Len: 17 Enqueue: 0
 ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 17 Enqueue: 0
+ID: 259 Len: 97 Enqueue: 0
 ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 25 Enqueue: 0
+ID: 261 Len: 17 Enqueue: 0
 ID: 262 Len: 0 Enqueue: 0
 ID: 263 Len: 17 Enqueue: 0
 ID: 264 Len: 0 Enqueue: 0
 ID: 265 Len: 25 Enqueue: 0
 ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 9 Enqueue: 0
+ID: 267 Len: 17 Enqueue: 0
 ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
-ID: 270 Len: 9 Enqueue: 0
-ID: 271 Len: 25 Enqueue: 0
+ID: 269 Len: 25 Enqueue: 0
+ID: 270 Len: 0 Enqueue: 0
+ID: 271 Len: 9 Enqueue: 0
 ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 25 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 17 Enqueue: 0
-ID: 276 Len: 25 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
+ID: 273 Len: 17 Enqueue: 0
+ID: 274 Len: 9 Enqueue: 0
+ID: 275 Len: 25 Enqueue: 0
+ID: 276 Len: 0 Enqueue: 0
+ID: 277 Len: 25 Enqueue: 0
 ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 9 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
+ID: 279 Len: 17 Enqueue: 0
+ID: 280 Len: 25 Enqueue: 0
+ID: 281 Len: 2 Enqueue: 0
 ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 9 Enqueue: 0
+ID: 283 Len: 2 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
-ID: 285 Len: 33 Enqueue: 0
+ID: 285 Len: 2 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 17 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 9 Enqueue: 0
+ID: 289 Len: 2 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 17 Enqueue: 0
+ID: 291 Len: 9 Enqueue: 0
 ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 9 Enqueue: 0
+ID: 293 Len: 17 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 41 Enqueue: 0
+ID: 295 Len: 9 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 17 Enqueue: 0
+ID: 297 Len: 33 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 9 Enqueue: 0
+ID: 299 Len: 17 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 17 Enqueue: 0
+ID: 301 Len: 2 Enqueue: 0
 ID: 302 Len: 0 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 25 Enqueue: 0
+ID: 305 Len: 17 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 9 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 25 Enqueue: 0
+ID: 309 Len: 41 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 89 Enqueue: 0
+ID: 311 Len: 17 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 9 Enqueue: 0
+ID: 313 Len: 2 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
 ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 9 Enqueue: 0
+ID: 317 Len: 17 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
 ID: 319 Len: 9 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 9 Enqueue: 0
+ID: 321 Len: 25 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 17 Enqueue: 0
+ID: 323 Len: 9 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
-ID: 325 Len: 17 Enqueue: 0
+ID: 325 Len: 25 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 17 Enqueue: 0
+ID: 327 Len: 89 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
-ID: 329 Len: 25 Enqueue: 0
+ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
 ID: 331 Len: 9 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
@@ -2720,17 +2843,33 @@ ID: 333 Len: 9 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
 ID: 335 Len: 9 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
-ID: 337 Len: 25 Enqueue: 0
+ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
-ID: 339 Len: 0 Enqueue: 0
+ID: 339 Len: 17 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
-ID: 341 Len: 97 Enqueue: 0
+ID: 341 Len: 17 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 0 Enqueue: 0
+ID: 343 Len: 17 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 9 Enqueue: 0
+ID: 345 Len: 25 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
 ID: 347 Len: 9 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 17 Enqueue: 0
-ID: 350 Len: 9 Enqueue: 0
+ID: 349 Len: 9 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0
+ID: 352 Len: 0 Enqueue: 0
+ID: 353 Len: 25 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 97 Enqueue: 0
+ID: 358 Len: 0 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 9 Enqueue: 0
+ID: 363 Len: 9 Enqueue: 0
+ID: 364 Len: 0 Enqueue: 0
+ID: 365 Len: 17 Enqueue: 0
+ID: 366 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5494.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5494]
 	PrepareEventRoot 4d 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b54cc]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6310.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 7a 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6310]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6b18]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6b18]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6b18]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b69b8]
 	PrepareEventRoot e3 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6a68]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b64e8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb64e8]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b64e8]
 	PrepareEventRoot c5 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b6598]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb6598]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b6598]
 	PrepareEventRoot cb 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6648]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6648]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6648]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6438]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6438]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6438]
 	PrepareEventRoot c1 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb70f4]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b70f4]
 	PrepareEventRoot 14 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ed8]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*main.condFields]
+	Call 61 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ed8]
 	PrepareEventRoot 09 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ed8.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6f4c]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb7038]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb7038]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@b7038]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@b7038]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb7038]
 	PrepareEventRoot 0f 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@b7098]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@b7098]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@b7038]
+// 0x767: ProcessEvent[Probe[main.condOnly]@b7038]
 	PrepareEventRoot 11 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb7038.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@b7098]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@b7098]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	PrepareEventRoot 01 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6dac]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*main.condFields]
+	Call 61 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6dac]
 	PrepareEventRoot 05 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6dac.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b6e90]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6f98]
 	PrepareEventRoot 0b 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b6f98]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6f98.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6ff8]
 	PrepareEventRoot 0e 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6ff8.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0x964: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@b6bc8]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0x9a8: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@b6c2c]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@b6bc8]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0xa05: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot ef 00 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@b6c2c]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@b6bc8]
+// 0xa67: ProcessEvent[Probe[main.condString]@b6bc8]
 	PrepareEventRoot f1 00 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@b6c2c]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0xa85: ProcessCondition[Probe[main.condString]@0xb6bc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@b6bc8]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
+// 0xaeb: ProcessEvent[Probe[main.condString]@b6bc8]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6bc8]
 	PrepareEventRoot f3 00 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6bc8.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@b6c2c]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@b6c2c]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6c8c]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6c8c]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 15 1c 00 00 // ProcessType[main.condFields]
+	Call 35 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@b6c8c]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6c8c]
 	PrepareEventRoot ff 00 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6c8c.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b6d60]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb67a8]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@b67a8]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@b67a8]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb67a8]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6808]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@b67a8]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@b67a8]
 	PrepareEventRoot d9 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb67a8.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6808]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b6808]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6858]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb6858]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@b6858]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@b6858]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6858]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b68b8]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@b6858]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@b6858]
 	PrepareEventRoot dd 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6858.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b68b8]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b68b8]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6908]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb6908]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@b6908]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@b6908]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6908]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6968]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@b6908]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@b6908]
 	PrepareEventRoot e1 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6908.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6968]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b6968]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@b66f8]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@b66f8]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@b66f8]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb66f8]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@b66f8]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@b66f8]
 	PrepareEventRoot d5 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb66f8.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6760]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b6760]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@b52a4]
+// 0x106e: ProcessEvent[Probe[main.inlined]@b52a4]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb52a4.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@b61d8]
+// 0x1093: ProcessEvent[Probe[main.inlined]@b61d8]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb61d8.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@b6210]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6210]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@b5eb8]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@b5eb8]
 	PrepareEventRoot a8 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5eb8.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5ef0]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b5ef0]
 	PrepareEventRoot a9 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b6038]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b6038]
 	PrepareEventRoot b2 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb6038.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b607c]
 	PrepareEventRoot b3 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[3]string]
+	Call e3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b61b0]
 	PrepareEventRoot b8 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb61b0.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5fa8]
 	PrepareEventRoot b0 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b5fe4]
 	PrepareEventRoot b1 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b7acc]
 	PrepareEventRoot 41 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb7acc.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
 	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 15 1c 00 00 // ProcessType[main.condFields]
+	Call 35 1c 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
 	PrepareEventRoot 45 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb7bcc.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
 	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@b7acc]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@b7acc]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b7b80]
 	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b7bcc]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b7c9c]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@b760c]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@b760c]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b76cc]
 	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@b760c]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@b760c]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb760c.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b76cc]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b76cc]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b771c]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b771c]
 	PrepareEventRoot 27 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 89 1a 00 00 // ProcessType[*string]
+	Call a9 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b771c]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b771c]
 	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb771c.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b77c4]
 	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*main.lenFields]
+	Call 67 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
 	PrepareEventRoot 39 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
 	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
 	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
 	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@b797c]
 	PrepareEventRoot 3f 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb797c.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@b7a74]
 	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@b74ec]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@b74ec]
 	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b74ec]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b74ec]
 	PrepareEventRoot 21 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb74ec.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b75ac]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb73dc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x1525: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@b73dc]
+// 0x1559: ProcessEvent[Probe[main.lenString]@b73dc]
 	PrepareEventRoot 17 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0xb73dc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@b73dc]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@b73dc]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb73dc]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@b73dc]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@b73dc]
 	PrepareEventRoot 1b 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@b73dc]
+// 0x1642: ProcessEvent[Probe[main.lenString]@b73dc]
 	PrepareEventRoot 1d 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb73dc.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@b7490]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@b7490]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 20 1c 00 00 // ProcessType[main.lenFields]
+	Call 40 1c 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 2b 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 2e 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 33 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b781c]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b781c]
 	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,437 +1495,437 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b781c]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b781c]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb781c]
 	PrepareEventRoot 37 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb781c.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@b7930]
 	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot aa 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ab 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ac 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot ad 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@b6298]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@b6298]
 	PrepareEventRoot b9 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb6298.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b62c8]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b62c8]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@b63c8]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@b63c8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b6400]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b6400]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@b5f28]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@b5f28]
 	PrepareEventRoot ae 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5f28.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b5f64]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b5f64]
 	PrepareEventRoot af 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[3]string]
+	Call e3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b6148]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b6148]
 	PrepareEventRoot b6 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb6148.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b618c]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]string]
+	Call 49 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b60b8]
 	PrepareEventRoot b4 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb60b8.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b60f4]
 	PrepareEventRoot b5 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7cf0]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 86 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7e64]
 	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7e64.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 5e 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a19: ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9f 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*bucket<string,int>]
+// 0x1a1f: ProcessType[*bucket<string,int>]
 	ProcessPointer 6c 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*bucket<string,main.bigStruct>]
+// 0x1a25: ProcessType[*bucket<string,main.bigStruct>]
 	ProcessPointer 73 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a2b: ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a31: ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*error]
+// 0x1a37: ProcessType[*error]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*float32]
+// 0x1a3d: ProcessType[*float32]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*float64]
+// 0x1a43: ProcessType[*float64]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*int]
+// 0x1a49: ProcessType[*int]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*int32]
+// 0x1a4f: ProcessType[*int32]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*int64]
+// 0x1a55: ProcessType[*int64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*main.bigStruct]
+// 0x1a5b: ProcessType[*main.bigStruct]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*main.condFields]
+// 0x1a61: ProcessType[*main.condFields]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*main.lenFields]
+// 0x1a67: ProcessType[*main.lenFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime._defer]
+// 0x1a6d: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime._panic]
+// 0x1a73: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.cgoCallers]
+// 0x1a79: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3d 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.coro]
+// 0x1a7f: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.g]
+// 0x1a85: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.m]
+// 0x1a8b: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*runtime.mapextra]
+// 0x1a91: ProcessType[*runtime.mapextra]
 	ProcessPointer 6e 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*runtime.sudog]
+// 0x1a97: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*runtime.timer]
+// 0x1a9d: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*runtime.traceBuf]
+// 0x1aa3: ProcessType[*runtime.traceBuf]
 	ProcessPointer 49 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*string]
+// 0x1aa9: ProcessType[*string]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint]
+// 0x1aaf: ProcessType[*uint]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint16]
+// 0x1ab5: ProcessType[*uint16]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint32]
+// 0x1abb: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint64]
+// 0x1ac1: ProcessType[*uint64]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint8]
+// 0x1ac7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uintptr]
+// 0x1acd: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 83 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call a3 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ac3: ProcessType[[3]string]
+// 0x1ae3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1af3: ProcessType[[]bucket<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 73 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 93 1b 00 00 // ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[]bucket<string,int>.array]
+// 0x1aff: ProcessType[[]bucket<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7e 1b 00 00 // ProcessType[bucket<string,int>]
+	Call 9e 1b 00 00 // ProcessType[bucket<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aeb: ProcessType[[]bucket<string,main.bigStruct>.array]
+// 0x1b0b: ProcessType[[]bucket<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 93 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
+	Call b3 1b 00 00 // ProcessType[bucket<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af7: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b17: ProcessType[[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call c8 1b 00 00 // ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b03: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b23: ProcessType[[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call bd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call dd 1b 00 00 // ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0f: ProcessType[[]int]
+// 0x1b2f: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]key<string>]
+// 0x1b39: ProcessType[[]key<string>]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]string]
+// 0x1b49: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x1b33: ProcessType[[]string.array]
+// 0x1b53: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]uint8]
+// 0x1b5f: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]uintptr]
+// 0x1b69: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]val<main.bigStruct>]
+// 0x1b73: ProcessType[[]val<main.bigStruct>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 5b 1a 00 00 // ProcessType[*main.bigStruct]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b63: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1b83: ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessArrayDataPrep 40 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 6e 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b73: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
+// 0x1b93: ProcessType[bucket<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 88 00 00 00 
-	Call f9 19 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 1a 00 00 // ProcessType[*bucket<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1b7e: ProcessType[bucket<string,int>]
+// 0x1b9e: ProcessType[bucket<string,int>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
 	IncrementOutputOffset 40 00 00 00 
-	Call ff 19 00 00 // ProcessType[*bucket<string,int>]
+	Call 1f 1a 00 00 // ProcessType[*bucket<string,int>]
 	Return 
-// 0x1b93: ProcessType[bucket<string,main.bigStruct>]
+// 0x1bb3: ProcessType[bucket<string,main.bigStruct>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
-	Call 53 1b 00 00 // ProcessType[[]val<main.bigStruct>]
-	Call 05 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 73 1b 00 00 // ProcessType[[]val<main.bigStruct>]
+	Call 25 1a 00 00 // ProcessType[*bucket<string,main.bigStruct>]
 	Return 
-// 0x1ba8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bc8: ProcessType[bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 08 00 00 00 
-	Call 19 1b 00 00 // ProcessType[[]key<string>]
-	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 0b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 39 1b 00 00 // ProcessType[[]key<string>]
+	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2b 1a 00 00 // ProcessType[*bucket<string,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bbd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bdd: ProcessType[bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 63 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
-	Call 11 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 83 1b 00 00 // ProcessType[[]val<map[int]main.aStructNotUsedAsAnArgument>]
+	Call 31 1a 00 00 // ProcessType[*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1bcd: ProcessType[error]
+// 0x1bed: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1bcf: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
+// 0x1bef: ProcessType[hash<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a5 00 00 00 90 00 00 00 08 09 10 18 
 	Return 
-// 0x1bdd: ProcessType[hash<string,int>]
+// 0x1bfd: ProcessType[hash<string,int>]
 	ProcessGoHmap 94 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1beb: ProcessType[hash<string,main.bigStruct>]
+// 0x1c0b: ProcessType[hash<string,main.bigStruct>]
 	ProcessGoHmap 98 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1bf9: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c19: ProcessType[hash<string,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a1 00 00 00 d0 00 00 00 08 09 10 18 
 	Return 
-// 0x1c07: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c27: ProcessType[hash<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoHmap a0 00 00 00 58 00 00 00 08 09 10 18 
 	Return 
-// 0x1c15: ProcessType[main.condFields]
+// 0x1c35: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c20: ProcessType[main.lenFields]
-	Call 42 1d 00 00 // ProcessType[string]
+// 0x1c40: ProcessType[main.lenFields]
+	Call 62 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]int]
+	Call 2f 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]int]
+	Call 74 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 89 1a 00 00 // ProcessType[*string]
+	Call a9 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c4e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c6e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 9d 00 00 00 
 	Return 
-// 0x1c54: ProcessType[map[string]int]
+// 0x1c74: ProcessType[map[string]int]
 	ProcessPointer 6a 00 00 00 
 	Return 
-// 0x1c5a: ProcessType[map[string]main.bigStruct]
+// 0x1c7a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c60: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c80: ProcessType[map[string]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c66: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c86: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1c6c: ProcessType[runtime.g]
+// 0x1c8c: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime._panic]
+	Call 73 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime._defer]
+	Call 6d 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 3f 1b 00 00 // ProcessType[[]uint8]
+	Call 5f 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 77 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 97 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*runtime.timer]
+	Call 9d 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.coro]
+	Call 7f 1a 00 00 // ProcessType[*runtime.coro]
 	Return 
-// 0x1cc7: ProcessType[runtime.m]
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+// 0x1ce7: ProcessType[runtime.m]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.g]
+	Call 85 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 42 1d 00 00 // ProcessType[string]
+	Call 62 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 79 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 27 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 47 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 32 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 52 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d27: ProcessType[runtime.mLockProfile]
+// 0x1d47: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]uintptr]
+	Call 69 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d32: ProcessType[runtime.mTraceState]
+// 0x1d52: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
-	Call 6b 1a 00 00 // ProcessType[*runtime.m]
+	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 8b 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d42: ProcessType[string]
+// 0x1d62: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
 // Extra illegal ops to simplify code bound checks
@@ -2194,12 +2194,12 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6643
-ID: 6 Len: 8 Enqueue: 6823
+ID: 5 Len: 8 Enqueue: 6675
+ID: 6 Len: 8 Enqueue: 6855
 ID: 7 Len: 2 Enqueue: 0
-ID: 8 Len: 8 Enqueue: 6829
+ID: 8 Len: 8 Enqueue: 6861
 ID: 9 Len: 8 Enqueue: 0
-ID: 10 Len: 16 Enqueue: 7490
+ID: 10 Len: 16 Enqueue: 7522
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 8 Enqueue: 0
 ID: 13 Len: 4 Enqueue: 0
@@ -2207,18 +2207,18 @@ ID: 14 Len: 8 Enqueue: 0
 ID: 15 Len: 1 Enqueue: 0
 ID: 16 Len: 4 Enqueue: 0
 ID: 17 Len: 8 Enqueue: 0
-ID: 18 Len: 16 Enqueue: 7117
+ID: 18 Len: 16 Enqueue: 7149
 ID: 19 Len: 8 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6703
-ID: 21 Len: 8 Enqueue: 6811
-ID: 22 Len: 432 Enqueue: 7276
+ID: 20 Len: 8 Enqueue: 6735
+ID: 21 Len: 8 Enqueue: 6843
+ID: 22 Len: 432 Enqueue: 7308
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6739
+ID: 24 Len: 8 Enqueue: 6771
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6733
+ID: 26 Len: 8 Enqueue: 6765
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6763
-ID: 29 Len: 1760 Enqueue: 7367
+ID: 28 Len: 8 Enqueue: 6795
+ID: 29 Len: 1760 Enqueue: 7399
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2227,41 +2227,41 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 6975
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7007
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6775
+ID: 41 Len: 8 Enqueue: 6807
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 6985
-ID: 44 Len: 8 Enqueue: 6781
+ID: 43 Len: 24 Enqueue: 7017
+ID: 44 Len: 8 Enqueue: 6813
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6751
+ID: 47 Len: 8 Enqueue: 6783
 ID: 48 Len: 8 Enqueue: 0
 ID: 49 Len: 32 Enqueue: 0
 ID: 50 Len: 32 Enqueue: 0
 ID: 51 Len: 12 Enqueue: 0
 ID: 52 Len: 16 Enqueue: 0
-ID: 53 Len: 8 Enqueue: 6757
+ID: 53 Len: 8 Enqueue: 6789
 ID: 54 Len: 40 Enqueue: 0
 ID: 55 Len: 8 Enqueue: 0
 ID: 56 Len: 48 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 8 Enqueue: 0
 ID: 59 Len: 4 Enqueue: 0
-ID: 60 Len: 8 Enqueue: 6745
+ID: 60 Len: 8 Enqueue: 6777
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 8 Enqueue: 0
 ID: 63 Len: 256 Enqueue: 0
-ID: 64 Len: 64 Enqueue: 7463
+ID: 64 Len: 64 Enqueue: 7495
 ID: 65 Len: 8 Enqueue: 0
 ID: 66 Len: 0 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 1 Enqueue: 0
-ID: 69 Len: 32 Enqueue: 7474
+ID: 69 Len: 32 Enqueue: 7506
 ID: 70 Len: 8 Enqueue: 0
-ID: 71 Len: 16 Enqueue: 6835
-ID: 72 Len: 8 Enqueue: 6787
+ID: 71 Len: 16 Enqueue: 6867
+ID: 72 Len: 8 Enqueue: 6819
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 48 Enqueue: 0
 ID: 75 Len: 0 Enqueue: 0
@@ -2277,53 +2277,53 @@ ID: 84 Len: 32 Enqueue: 0
 ID: 85 Len: 160 Enqueue: 0
 ID: 86 Len: 16 Enqueue: 0
 ID: 87 Len: 8 Enqueue: 0
-ID: 88 Len: 8 Enqueue: 6793
+ID: 88 Len: 8 Enqueue: 6825
 ID: 89 Len: 2 Enqueue: 0
 ID: 90 Len: 8 Enqueue: 0
 ID: 91 Len: 16 Enqueue: 0
-ID: 92 Len: 8 Enqueue: 6691
-ID: 93 Len: 8 Enqueue: 6709
-ID: 94 Len: 8 Enqueue: 6697
-ID: 95 Len: 8 Enqueue: 6817
-ID: 96 Len: 8 Enqueue: 6679
-ID: 97 Len: 8 Enqueue: 6685
-ID: 98 Len: 8 Enqueue: 6799
-ID: 99 Len: 8 Enqueue: 6805
-ID: 100 Len: 24 Enqueue: 6927
+ID: 92 Len: 8 Enqueue: 6723
+ID: 93 Len: 8 Enqueue: 6741
+ID: 94 Len: 8 Enqueue: 6729
+ID: 95 Len: 8 Enqueue: 6849
+ID: 96 Len: 8 Enqueue: 6711
+ID: 97 Len: 8 Enqueue: 6717
+ID: 98 Len: 8 Enqueue: 6831
+ID: 99 Len: 8 Enqueue: 6837
+ID: 100 Len: 24 Enqueue: 6959
 ID: 101 Len: 24 Enqueue: 0
-ID: 102 Len: 24 Enqueue: 6953
-ID: 103 Len: 48 Enqueue: 6851
-ID: 104 Len: 8 Enqueue: 7252
+ID: 102 Len: 24 Enqueue: 6985
+ID: 103 Len: 48 Enqueue: 6883
+ID: 104 Len: 8 Enqueue: 7284
 ID: 105 Len: 8 Enqueue: 0
-ID: 106 Len: 48 Enqueue: 7133
-ID: 107 Len: 8 Enqueue: 6655
-ID: 108 Len: 208 Enqueue: 7038
-ID: 109 Len: 8 Enqueue: 6769
+ID: 106 Len: 48 Enqueue: 7165
+ID: 107 Len: 8 Enqueue: 6687
+ID: 108 Len: 208 Enqueue: 7070
+ID: 109 Len: 8 Enqueue: 6801
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 8 Enqueue: 7258
+ID: 111 Len: 8 Enqueue: 7290
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7147
-ID: 114 Len: 8 Enqueue: 6661
-ID: 115 Len: 208 Enqueue: 7059
-ID: 116 Len: 80 Enqueue: 7189
+ID: 113 Len: 48 Enqueue: 7179
+ID: 114 Len: 8 Enqueue: 6693
+ID: 115 Len: 208 Enqueue: 7091
+ID: 116 Len: 80 Enqueue: 7221
 ID: 117 Len: 6 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6721
-ID: 119 Len: 72 Enqueue: 7200
-ID: 120 Len: 8 Enqueue: 6631
-ID: 121 Len: 8 Enqueue: 6727
-ID: 122 Len: 8 Enqueue: 7270
+ID: 118 Len: 8 Enqueue: 6753
+ID: 119 Len: 72 Enqueue: 7232
+ID: 120 Len: 8 Enqueue: 6663
+ID: 121 Len: 8 Enqueue: 6759
+ID: 122 Len: 8 Enqueue: 7302
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 7175
-ID: 125 Len: 8 Enqueue: 6673
-ID: 126 Len: 88 Enqueue: 7101
-ID: 127 Len: 8 Enqueue: 7264
+ID: 124 Len: 48 Enqueue: 7207
+ID: 125 Len: 8 Enqueue: 6705
+ID: 126 Len: 88 Enqueue: 7133
+ID: 127 Len: 8 Enqueue: 7296
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7161
-ID: 130 Len: 8 Enqueue: 6667
-ID: 131 Len: 208 Enqueue: 7080
-ID: 132 Len: 8 Enqueue: 6607
-ID: 133 Len: 8 Enqueue: 6613
-ID: 134 Len: 8 Enqueue: 6625
+ID: 129 Len: 48 Enqueue: 7193
+ID: 130 Len: 8 Enqueue: 6699
+ID: 131 Len: 208 Enqueue: 7112
+ID: 132 Len: 8 Enqueue: 6639
+ID: 133 Len: 8 Enqueue: 6645
+ID: 134 Len: 8 Enqueue: 6657
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2332,30 +2332,30 @@ ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 6963
+ID: 143 Len: 16 Enqueue: 6995
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 128 Enqueue: 6937
+ID: 146 Len: 128 Enqueue: 6969
 ID: 147 Len: 64 Enqueue: 0
-ID: 148 Len: 208 Enqueue: 6879
-ID: 149 Len: 64 Enqueue: 6995
-ID: 150 Len: 8 Enqueue: 6715
+ID: 148 Len: 208 Enqueue: 6911
+ID: 149 Len: 64 Enqueue: 7027
+ID: 150 Len: 8 Enqueue: 6747
 ID: 151 Len: 184 Enqueue: 0
-ID: 152 Len: 208 Enqueue: 6891
+ID: 152 Len: 208 Enqueue: 6923
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 64 Enqueue: 7011
-ID: 155 Len: 8 Enqueue: 7246
+ID: 154 Len: 64 Enqueue: 7043
+ID: 155 Len: 8 Enqueue: 7278
 ID: 156 Len: 8 Enqueue: 0
-ID: 157 Len: 48 Enqueue: 7119
-ID: 158 Len: 8 Enqueue: 6649
-ID: 159 Len: 144 Enqueue: 7027
-ID: 160 Len: 88 Enqueue: 6915
-ID: 161 Len: 208 Enqueue: 6903
+ID: 157 Len: 48 Enqueue: 7151
+ID: 158 Len: 8 Enqueue: 6681
+ID: 159 Len: 144 Enqueue: 7059
+ID: 160 Len: 88 Enqueue: 6947
+ID: 161 Len: 208 Enqueue: 6935
 ID: 162 Len: 64 Enqueue: 0
 ID: 163 Len: 64 Enqueue: 0
 ID: 164 Len: 8 Enqueue: 0
-ID: 165 Len: 144 Enqueue: 6867
-ID: 166 Len: 8 Enqueue: 6619
+ID: 165 Len: 144 Enqueue: 6899
+ID: 166 Len: 8 Enqueue: 6651
 ID: 167 Len: 128 Enqueue: 0
 ID: 168 Len: 9 Enqueue: 0
 ID: 169 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -3,54 +3,54 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5310.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5310.expr[1]]
+// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5310]
+// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5314]
 	PrepareEventRoot 27 01 00 00 11 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5310.expr[0]]
-	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5310.expr[1]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[0]]
+	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	Return 
-// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5348.expr[0]]
+// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb534c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 78 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
-// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b5348]
+// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b534c]
 	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb5348.expr[0]]
+	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb534c.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb5cc0.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 69 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb5cc0.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 69 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@b5cc0]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@b6170]
 	PrepareEventRoot c9 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5cc0.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb5cc0.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b5d34]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b61e4]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0xb6468]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0xb6918]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@b6468]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6468]
+// 0x103: ProcessEvent[Probe[main.condBool]@b6918]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@b64d0]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@b6980]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0xb6468]
+// 0x121: ProcessCondition[Probe[main.condBool]@0xb6918]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@b6468]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6468]
+// 0x159: ProcessEvent[Probe[main.condBool]@b6918]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@b64d0]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@b6980]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0xb6468.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0xb6918.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@b6468]
+// 0x1af: ProcessEvent[Probe[main.condBool]@b6918]
 	PrepareEventRoot f9 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6468.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6468.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b64d0]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b6980]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb6308.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb67b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b6308]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b67b8]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb6308.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb67b8.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b636c]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b681c]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb63b8.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb6868.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@b63b8]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@b6868]
 	PrepareEventRoot f3 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb63b8.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb6868.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b641c]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b68cc]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0xb5e98]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0xb6348]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@b5e98]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb5e98]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@b6348]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6348]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@b5ef8]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@b63a8]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb6348.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@b5e98]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@b6348]
 	PrepareEventRoot d3 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb5e98.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b5ef8]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b63a8]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb5f38]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@b5f38]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb5f38]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@b63e8]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	PrepareEventRoot d5 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b5f98]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b6448]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0xb5f38]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@b5f38]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb5f38]
+// 0x384: ProcessEvent[Probe[main.condInt32]@b63e8]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@b5f98]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@b6448]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@b5f38]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@b63e8]
 	PrepareEventRoot d9 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb5f38.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b5f98]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b6448]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb5fd8]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb6488]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@b5fd8]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb5fd8]
+// 0x437: ProcessEvent[Probe[main.condInt64]@b6488]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6488]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b6038]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b64e8]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb6488.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@b5fd8]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@b6488]
 	PrepareEventRoot dd 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb5fd8.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b6038]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b64e8]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb5de8]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb6298]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,86 +311,80 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@b5de8]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb5de8]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@b6298]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6298]
 	PrepareEventRoot cd 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b5e50]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b6300]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0xb6298.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@b5de8]
+// 0x539: ProcessEvent[Probe[main.condInt8]@b6298]
 	PrepareEventRoot cf 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb5de8.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b5e50]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b6300]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb6a08]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
 	ConditionBegin 
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprPushOffset 08 00 00 00 
 	ExprLoadLiteral 08 00 07 00 00 00 00 00 00 00 
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x57a: ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x59c: ProcessEvent[Probe[main.condLine]Line@b6a08]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6a08]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@b6eb4]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
 	PrepareEventRoot 21 01 00 00 11 00 00 00 
-	Call 7a 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	Return 
-// 0x5b0: ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x5ee: ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6eb4]
+	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[1]]
 	Return 
-// 0x604: ProcessEvent[Probe[main.condLine]Line@b6a08]
-	PrepareEventRoot 22 01 00 00 21 00 00 00 
-	Call b0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[1]]
-	Call ee 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6a08.expr[2]]
-	Return 
-// 0x61d: ProcessCondition[Probe[main.condNilPtrStruct]@0xb67f8]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x63f: ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x661: ProcessEvent[Probe[main.condNilPtrStruct]@b67f8]
-	Call 1d 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb67f8]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call 3f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Return 
-// 0x675: ProcessEvent[Probe[main.condNilPtrStruct]Return@b686c]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0x67f: ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x69a: ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessEvent[Probe[main.condNilPtrStruct]@b67f8]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	PrepareEventRoot 17 01 00 00 19 00 00 00 
-	Call 7f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[0]]
-	Call 9a 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb67f8.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	Return 
-// 0x6d0: ProcessEvent[Probe[main.condNilPtrStruct]Return@b686c]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x6da: ProcessCondition[Probe[main.condOnly]@0xb6958]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6f7: ProcessExpression[Probe[main.condOnly]@0xb6958.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x70d: ProcessExpression[Probe[main.condOnly]@0xb6958.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x72f: ProcessEvent[Probe[main.condOnly]@b6958]
-	Call da 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6958]
+// 0x708: ProcessEvent[Probe[main.condOnly]@b6e08]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	PrepareEventRoot 1d 01 00 00 19 00 00 00 
-	Call f7 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6958.expr[0]]
-	Call 0d 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6958.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
-// 0x748: ProcessEvent[Probe[main.condOnly]Return@b69b8]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@b6e68]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x752: ProcessExpression[Probe[main.condOnly]@0xb6958.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x768: ProcessExpression[Probe[main.condOnly]@0xb6958.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x78a: ProcessEvent[Probe[main.condOnly]@b6958]
+// 0x763: ProcessEvent[Probe[main.condOnly]@b6e08]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
-	Call 52 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6958.expr[0]]
-	Call 68 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6958.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
-// 0x79e: ProcessEvent[Probe[main.condOnly]Return@b69b8]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@b6e68]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x7a8: ProcessCondition[Probe[main.condPtrStructArg]@0xb66dc]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7ca: ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x7ec: ProcessEvent[Probe[main.condPtrStructArg]@b66dc]
-	Call a8 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb66dc]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call ca 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
-// 0x800: ProcessEvent[Probe[main.condPtrStructArg]Return@b67b4]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0x80a: ProcessCondition[Probe[main.condPtrStructArg]@0xb66dc]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x82e: ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x850: ProcessEvent[Probe[main.condPtrStructArg]@b66dc]
-	Call 0a 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb66dc]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 2e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
-// 0x864: ProcessEvent[Probe[main.condPtrStructArg]Return@b67b4]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x889: ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x8ab: ProcessEvent[Probe[main.condPtrStructArg]@b66dc]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	PrepareEventRoot 13 01 00 00 19 00 00 00 
-	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[0]]
-	Call 89 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb66dc.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	Return 
-// 0x8bf: ProcessEvent[Probe[main.condPtrStructArg]Return@b67b4]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0x8c9: ProcessCondition[Probe[main.condReturnAndLocal]@0xb68b8]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8e6: ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8fc: ProcessEvent[Probe[main.condReturnAndLocal]@b68b8]
-	Call c9 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb68b8]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	PrepareEventRoot 19 01 00 00 09 00 00 00 
-	Call e6 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Return 
-// 0x910: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6918]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x91a: ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x930: ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x946: ProcessEvent[Probe[main.condReturnAndLocal]@b68b8]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
 	PrepareEventRoot 1b 01 00 00 11 00 00 00 
-	Call 1a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[0]]
-	Call 30 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb68b8.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	Return 
-// 0x95a: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6918.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x970: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6918]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
 	PrepareEventRoot 1c 01 00 00 09 00 00 00 
-	Call 5a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6918.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	Return 
-// 0x97f: ProcessCondition[Probe[main.condString]@0xb6518]
+// 0x958: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9a1: ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x9c3: ProcessEvent[Probe[main.condString]@b6518]
-	Call 7f 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6518]
+// 0x99c: ProcessEvent[Probe[main.condString]@b69c8]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call a1 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
-// 0x9d7: ProcessEvent[Probe[main.condString]Return@b657c]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0x9e1: ProcessCondition[Probe[main.condString]@0xb6518]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9fe: ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa20: ProcessEvent[Probe[main.condString]@b6518]
-	Call e1 09 00 00 // ProcessCondition[Probe[main.condString]@0xb6518]
+// 0x9f9: ProcessEvent[Probe[main.condString]@b69c8]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call fe 09 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
-// 0xa34: ProcessEvent[Probe[main.condString]Return@b657c]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0xa3e: ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa60: ProcessExpression[Probe[main.condString]@0xb6518.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xa82: ProcessEvent[Probe[main.condString]@b6518]
+// 0xa5b: ProcessEvent[Probe[main.condString]@b69c8]
 	PrepareEventRoot ff 00 00 00 21 00 00 00 
-	Call 3e 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
-	Call 60 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xa96: ProcessEvent[Probe[main.condString]Return@b657c]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0xaa0: ProcessCondition[Probe[main.condString]@0xb6518]
+// 0xa79: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xac2: ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xae4: ProcessExpression[Probe[main.condString]@0xb6518.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xb06: ProcessEvent[Probe[main.condString]@b6518]
-	Call a0 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb6518]
+// 0xadf: ProcessEvent[Probe[main.condString]@b69c8]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot 01 01 00 00 21 00 00 00 
-	Call c2 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[0]]
-	Call e4 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb6518.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xb1f: ProcessEvent[Probe[main.condString]Return@b657c]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0xb29: ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb48: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xb6a: ProcessEvent[Probe[main.condStructArg]@b65cc]
-	Call 29 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 48 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xb7e: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0xb88: ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xba4: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xbc6: ProcessEvent[Probe[main.condStructArg]@b65cc]
-	Call 88 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call a4 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xbda: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0xbe4: ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc07: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xc29: ProcessEvent[Probe[main.condStructArg]@b65cc]
-	Call e4 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call 07 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc3d: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xc47: ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc66: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xc88: ProcessEvent[Probe[main.condStructArg]@b65cc]
-	Call 47 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 09 01 00 00 11 00 00 00 
-	Call 66 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc9c: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xca6: ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcc7: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xce9: ProcessEvent[Probe[main.condStructArg]@b65cc]
-	Call a6 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb65cc]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call c7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xcfd: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xd07: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 22 15 00 00 // ProcessType[main.condFields]
+	Call fb 14 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd28: ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xd4a: ProcessEvent[Probe[main.condStructArg]@b65cc]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	PrepareEventRoot 0d 01 00 00 61 00 00 00 
-	Call 07 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[0]]
-	Call 28 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb65cc.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	Return 
-// 0xd5e: ProcessEvent[Probe[main.condStructArg]Return@b6698]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xd68: ProcessCondition[Probe[main.condUint16]@0xb6128]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd7f: ProcessExpression[Probe[main.condUint16]@0xb6128.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xda1: ProcessEvent[Probe[main.condUint16]@b6128]
-	Call 68 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb6128]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@b65d8]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
-	Call 7f 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb6128.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	Return 
-// 0xdb5: ProcessEvent[Probe[main.condUint16]Return@b6188]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
-// 0xdbf: ProcessExpression[Probe[main.condUint16]@0xb6128.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdd5: ProcessExpression[Probe[main.condUint16]@0xb6128.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xdf7: ProcessEvent[Probe[main.condUint16]@b6128]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@b65d8]
 	PrepareEventRoot e7 00 00 00 13 00 00 00 
-	Call bf 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb6128.expr[0]]
-	Call d5 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb6128.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	Return 
-// 0xe0b: ProcessEvent[Probe[main.condUint16]Return@b6188]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xe15: ProcessCondition[Probe[main.condUint32]@0xb61c8]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6678]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe2e: ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xe50: ProcessEvent[Probe[main.condUint32]@b61c8]
-	Call 15 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xb61c8]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@b6678]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call 2e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	Return 
-// 0xe64: ProcessEvent[Probe[main.condUint32]Return@b6228]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xe6e: ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe84: ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xea6: ProcessEvent[Probe[main.condUint32]@b61c8]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@b6678]
 	PrepareEventRoot eb 00 00 00 15 00 00 00 
-	Call 6e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[0]]
-	Call 84 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb61c8.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	Return 
-// 0xeba: ProcessEvent[Probe[main.condUint32]Return@b6228]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0xec4: ProcessCondition[Probe[main.condUint64]@0xb6268]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6718]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xee1: ProcessExpression[Probe[main.condUint64]@0xb6268.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xf03: ProcessEvent[Probe[main.condUint64]@b6268]
-	Call c4 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6268]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@b6718]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call e1 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6268.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	Return 
-// 0xf17: ProcessEvent[Probe[main.condUint64]Return@b62c8]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xf21: ProcessExpression[Probe[main.condUint64]@0xb6268.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf37: ProcessExpression[Probe[main.condUint64]@0xb6268.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xf59: ProcessEvent[Probe[main.condUint64]@b6268]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@b6718]
 	PrepareEventRoot ef 00 00 00 19 00 00 00 
-	Call 21 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6268.expr[0]]
-	Call 37 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6268.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	Return 
-// 0xf6d: ProcessEvent[Probe[main.condUint64]Return@b62c8]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xf77: ProcessCondition[Probe[main.condUint8]@0xb6078]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf8d: ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0xfaf: ProcessEvent[Probe[main.condUint8]@b6078]
-	Call 77 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6078]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call 8d 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0xfc3: ProcessEvent[Probe[main.condUint8]Return@b60e0]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0xfcd: ProcessCondition[Probe[main.condUint8]@0xb6078]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,544 +1008,544 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfe3: ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1005: ProcessEvent[Probe[main.condUint8]@b6078]
-	Call cd 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6078]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot e1 00 00 00 11 00 00 00 
-	Call e3 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0x1019: ProcessEvent[Probe[main.condUint8]Return@b60e0]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0x1023: ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1039: ProcessExpression[Probe[main.condUint8]@0xb6078.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x105b: ProcessEvent[Probe[main.condUint8]@b6078]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@b6528]
 	PrepareEventRoot e3 00 00 00 12 00 00 00 
-	Call 23 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6078.expr[0]]
-	Call 39 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6078.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	Return 
-// 0x106f: ProcessEvent[Probe[main.condUint8]Return@b60e0]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
-// 0x1079: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1089: ProcessEvent[Probe[main.inlined]@b5130]
+// 0x1062: ProcessEvent[Probe[main.inlined]@b5130]
 	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call 79 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	Return 
-// 0x1098: ProcessExpression[Probe[main.inlined]@0xb5b88.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ae: ProcessEvent[Probe[main.inlined]@b5b88]
+// 0x1087: ProcessEvent[Probe[main.inlined]@b6038]
 	PrepareEventRoot 25 01 00 00 09 00 00 00 
-	Call 98 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5b88.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	Return 
-// 0x10bd: ProcessEvent[Probe[main.inlined]Return@b5bc0]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@b6070]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x10c7: ProcessExpression[Probe[main.intArg]@0xb5888.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10dd: ProcessEvent[Probe[main.intArg]@b5888]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@b5d38]
 	PrepareEventRoot b6 00 00 00 09 00 00 00 
-	Call c7 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5888.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	Return 
-// 0x10ec: ProcessEvent[Probe[main.intArg]Return@b58c0]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5d70]
 	PrepareEventRoot b7 00 00 00 00 00 00 00 
 	Return 
-// 0x10f6: ProcessExpression[Probe[main.intArrayArg]@0xb59f8.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x1112: ProcessEvent[Probe[main.intArrayArg]@b59f8]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
 	PrepareEventRoot c0 00 00 00 19 00 00 00 
-	Call f6 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb59f8.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	Return 
-// 0x1121: ProcessEvent[Probe[main.intArrayArg]Return@b5a3c]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x112b: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5b60.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 58 14 00 00 // ProcessType[[3]string]
+	Call 31 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x114c: ProcessEvent[Probe[main.stringArrayArgFrameless]@b5b60]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
 	PrepareEventRoot c6 00 00 00 31 00 00 00 
-	Call 2b 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb5b60.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	Return 
-// 0x115b: ProcessExpression[Probe[main.intSliceArg]@0xb5978.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 98 14 00 00 // ProcessType[[]int]
+	Call 71 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1184: ProcessEvent[Probe[main.intSliceArg]@b5978]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5e28]
 	PrepareEventRoot be 00 00 00 19 00 00 00 
-	Call 5b 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5978.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	Return 
-// 0x1193: ProcessEvent[Probe[main.intSliceArg]Return@b59b4]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x119d: ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x11bf: ProcessEvent[Probe[main.stringArg]@b58f8]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 9d 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.stringArg]Return@b5934]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot b9 00 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessEvent[Probe[main.stringArg]@b58f8]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x11e2: ProcessEvent[Probe[main.stringArg]Return@b5934]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot bb 00 00 00 00 00 00 00 
 	Return 
-// 0x11ec: ProcessExpression[Probe[main.mapArg]@0xb5c48.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 63 15 00 00 // ProcessType[map[string]int]
+	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1207: ProcessExpression[Probe[main.mapArg]@0xb5c48.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 63 15 00 00 // ProcessType[map[string]int]
+	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1222: ProcessEvent[Probe[main.mapArg]@b5c48]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@b60f8]
 	PrepareEventRoot c7 00 00 00 11 00 00 00 
-	Call ec 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5c48.expr[0]]
-	Call 07 12 00 00 // ProcessExpression[Probe[main.mapArg]@0xb5c48.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	Return 
-// 0x1236: ProcessEvent[Probe[main.mapArg]Return@b5c78]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b6128]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1240: ProcessEvent[Probe[main.noArgs]@b5d78]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@b6228]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x124a: ProcessEvent[Probe[main.noArgs]Return@b5db0]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b6260]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1254: ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1276: ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x1298: ProcessEvent[Probe[main.stringArg]@b58f8]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bc 00 00 00 21 00 00 00 
-	Call 54 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[0]]
-	Call 76 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb58f8.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	Return 
-// 0x12ac: ProcessEvent[Probe[main.stringArg]Return@b5934]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x12b6: ProcessExpression[Probe[main.stringArrayArg]@0xb5af8.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 58 14 00 00 // ProcessType[[3]string]
+	Call 31 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12d7: ProcessEvent[Probe[main.stringArrayArg]@b5af8]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
 	PrepareEventRoot c4 00 00 00 31 00 00 00 
-	Call b6 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5af8.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x12e6: ProcessEvent[Probe[main.stringArrayArg]Return@b5b3c]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x12f0: ProcessExpression[Probe[main.stringSliceArg]@0xb5a78.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call c6 14 00 00 // ProcessType[[]string]
+	Call 9f 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1319: ProcessEvent[Probe[main.stringSliceArg]@b5a78]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
 	PrepareEventRoot c2 00 00 00 19 00 00 00 
-	Call f0 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5a78.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1328: ProcessEvent[Probe[main.stringSliceArg]Return@b5ab4]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1332: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b6cd0]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x133c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb6e50.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6f 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 48 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1357: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b6e50]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
 	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 3c 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb6e50.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	Return 
-// 0x1366: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 80 00 00 00 
 	Return 
-// 0x136c: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer b4 00 00 00 
 	Return 
-// 0x1372: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1378: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x137e: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1384: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x138a: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1390: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1396: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x139c: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*main.bigStruct]
+// 0x1387: ProcessType[*main.bigStruct]
 	ProcessPointer 9b 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*main.condFields]
+// 0x138d: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*runtime._defer]
+// 0x1393: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*runtime._panic]
+// 0x1399: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime.cgoCallers]
+// 0x139f: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime.coro]
+// 0x13a5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.g]
+// 0x13ab: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.m]
+// 0x13b1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.sudog]
+// 0x13b7: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.synctestGroup]
+// 0x13bd: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.timer]
+// 0x13c3: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.traceBuf]
+// 0x13c9: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*string]
+// 0x13cf: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13d5: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1402: ProcessType[*table<string,int>]
+// 0x13db: ProcessType[*table<string,int>]
 	ProcessPointer 8c 00 00 00 
 	Return 
-// 0x1408: ProcessType[*table<string,main.bigStruct>]
+// 0x13e1: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13e7: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1414: ProcessType[*uint]
+// 0x13ed: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x141a: ProcessType[*uint16]
+// 0x13f3: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1420: ProcessType[*uint32]
+// 0x13f9: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint64]
+// 0x13ff: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint8]
+// 0x1405: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uintptr]
+// 0x140b: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1438: ProcessType[[2]*runtime.traceBuf]
+// 0x1411: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call c9 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1448: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1421: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 38 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 11 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1458: ProcessType[[3]string]
+// 0x1431: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1468: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1441: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call fc 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call d5 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1474: ProcessType[[]*table<string,int>.array]
+// 0x144d: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 02 14 00 00 // ProcessType[*table<string,int>]
+	Call db 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1480: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1459: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 08 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call e1 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x148c: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1465: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call e7 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1498: ProcessType[[]int]
+// 0x1471: ProcessType[[]int]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x14a2: ProcessType[[]noalg.map.group[string]int.array]
+// 0x147b: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call a5 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 7e 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ae: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1487: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call b0 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 89 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ba: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1493: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call bb 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 94 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14c6: ProcessType[[]string]
+// 0x149f: ProcessType[[]string]
 	ProcessSlice 8a 00 00 00 10 00 00 00 
 	Return 
-// 0x14d0: ProcessType[[]string.array]
+// 0x14a9: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14dc: ProcessType[[]uint8]
+// 0x14b5: ProcessType[[]uint8]
 	ProcessSlice 84 00 00 00 01 00 00 00 
 	Return 
-// 0x14e6: ProcessType[[]uintptr]
+// 0x14bf: ProcessType[[]uintptr]
 	ProcessSlice 86 00 00 00 08 00 00 00 
 	Return 
-// 0x14f0: ProcessType[error]
+// 0x14c9: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14f2: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14cb: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b3 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14fe: ProcessType[groupReference<string,int>]
+// 0x14d7: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 93 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x150a: ProcessType[groupReference<string,main.bigStruct>]
+// 0x14e3: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1516: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x14ef: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups aa 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1522: ProcessType[main.condFields]
+// 0x14fb: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x152d: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1506: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b2 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1539: ProcessType[map<string,int>]
+// 0x1512: ProcessType[map<string,int>]
 	ProcessGoSwissMap 92 00 00 00 8f 00 00 00 10 18 
 	Return 
-// 0x1545: ProcessType[map<string,main.bigStruct>]
+// 0x151e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9c 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1551: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x152a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap a9 00 00 00 a1 00 00 00 10 18 
 	Return 
-// 0x155d: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1536: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1563: ProcessType[map[string]int]
+// 0x153c: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1569: ProcessType[map[string]main.bigStruct]
+// 0x1542: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x156f: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1548: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1575: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x154e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c6 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 9f 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1585: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x155e: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d6 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call af 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1595: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x156e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call dc 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call b5 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15a5: ProcessType[noalg.map.group[string]int]
+// 0x157e: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 85 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 5e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15b0: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1589: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 75 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 4e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15bb: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1594: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 95 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 6e 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15c6: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call c7 16 00 00 // ProcessType[string]
+// 0x159f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a0 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ae 13 00 00 // ProcessType[*main.bigStruct]
+	Call 87 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15d6: ProcessType[noalg.struct { key string; elem int }]
-	Call c7 16 00 00 // ProcessType[string]
+// 0x15af: ProcessType[noalg.struct { key string; elem int }]
+	Call a0 16 00 00 // ProcessType[string]
 	Return 
-// 0x15dc: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15b5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5d 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 36 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15e7: ProcessType[runtime.g]
+// 0x15c0: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c0 13 00 00 // ProcessType[*runtime._panic]
+	Call 99 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 13 00 00 // ProcessType[*runtime._defer]
+	Call 93 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call dc 14 00 00 // ProcessType[[]uint8]
+	Call b5 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 7e 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.sudog]
+	Call b7 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call e6 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.timer]
+	Call c3 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime.coro]
+	Call a5 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.synctestGroup]
+	Call bd 13 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x164c: ProcessType[runtime.m]
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+// 0x1625: ProcessType[runtime.m]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c7 16 00 00 // ProcessType[string]
+	Call a0 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call ac 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 85 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call e6 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b7 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 90 16 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16ac: ProcessType[runtime.mLockProfile]
+// 0x1685: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call e6 14 00 00 // ProcessType[[]uintptr]
+	Call bf 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16b7: ProcessType[runtime.mTraceState]
+// 0x1690: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call 21 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16c7: ProcessType[string]
+// 0x16a0: ProcessType[string]
 	ProcessString 82 00 00 00 
 	Return 
-// 0x16cd: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16a6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f2 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call cb 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16d8: ProcessType[table<string,int>]
+// 0x16b1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call fe 14 00 00 // ProcessType[groupReference<string,int>]
+	Call d7 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16e3: ProcessType[table<string,main.bigStruct>]
+// 0x16bc: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0a 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call e3 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16ee: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x16c7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 16 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ef 14 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1819,31 +1813,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5164
+ID: 5 Len: 8 Enqueue: 5125
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5831
+ID: 9 Len: 16 Enqueue: 5792
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4996
+ID: 11 Len: 8 Enqueue: 4957
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 5360
+ID: 14 Len: 16 Enqueue: 5321
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5170
-ID: 20 Len: 8 Enqueue: 5026
-ID: 21 Len: 8 Enqueue: 5152
-ID: 22 Len: 440 Enqueue: 5607
+ID: 19 Len: 8 Enqueue: 5131
+ID: 20 Len: 8 Enqueue: 4987
+ID: 21 Len: 8 Enqueue: 5113
+ID: 22 Len: 440 Enqueue: 5568
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5056
+ID: 24 Len: 8 Enqueue: 5017
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5050
+ID: 26 Len: 8 Enqueue: 5011
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5080
-ID: 29 Len: 1808 Enqueue: 5708
+ID: 28 Len: 8 Enqueue: 5041
+ID: 29 Len: 1808 Enqueue: 5669
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1852,45 +1846,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5340
-ID: 39 Len: 8 Enqueue: 4990
+ID: 38 Len: 24 Enqueue: 5301
+ID: 39 Len: 8 Enqueue: 4951
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5086
+ID: 41 Len: 8 Enqueue: 5047
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5350
-ID: 44 Len: 8 Enqueue: 5098
+ID: 43 Len: 24 Enqueue: 5311
+ID: 44 Len: 8 Enqueue: 5059
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5068
+ID: 47 Len: 8 Enqueue: 5029
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5092
+ID: 49 Len: 8 Enqueue: 5053
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5074
+ID: 55 Len: 8 Enqueue: 5035
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 5062
+ID: 62 Len: 8 Enqueue: 5023
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 5804
+ID: 67 Len: 64 Enqueue: 5765
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 5815
+ID: 72 Len: 56 Enqueue: 5776
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 5192
-ID: 75 Len: 16 Enqueue: 5176
-ID: 76 Len: 8 Enqueue: 5104
+ID: 74 Len: 32 Enqueue: 5153
+ID: 75 Len: 16 Enqueue: 5137
+ID: 76 Len: 8 Enqueue: 5065
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -1907,43 +1901,43 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 5110
+ID: 93 Len: 8 Enqueue: 5071
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 5014
-ID: 98 Len: 8 Enqueue: 5032
-ID: 99 Len: 8 Enqueue: 5020
-ID: 100 Len: 8 Enqueue: 5158
-ID: 101 Len: 8 Enqueue: 5002
-ID: 102 Len: 8 Enqueue: 5008
-ID: 103 Len: 8 Enqueue: 5140
-ID: 104 Len: 8 Enqueue: 5146
-ID: 105 Len: 24 Enqueue: 5272
+ID: 97 Len: 8 Enqueue: 4975
+ID: 98 Len: 8 Enqueue: 4993
+ID: 99 Len: 8 Enqueue: 4981
+ID: 100 Len: 8 Enqueue: 5119
+ID: 101 Len: 8 Enqueue: 4963
+ID: 102 Len: 8 Enqueue: 4969
+ID: 103 Len: 8 Enqueue: 5101
+ID: 104 Len: 8 Enqueue: 5107
+ID: 105 Len: 24 Enqueue: 5233
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 5318
-ID: 108 Len: 48 Enqueue: 5208
-ID: 109 Len: 8 Enqueue: 5475
+ID: 107 Len: 24 Enqueue: 5279
+ID: 108 Len: 48 Enqueue: 5169
+ID: 109 Len: 8 Enqueue: 5436
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 5433
+ID: 111 Len: 48 Enqueue: 5394
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 5122
-ID: 114 Len: 8 Enqueue: 5481
+ID: 113 Len: 8 Enqueue: 5083
+ID: 114 Len: 8 Enqueue: 5442
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 5445
+ID: 116 Len: 48 Enqueue: 5406
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5128
-ID: 119 Len: 80 Enqueue: 5410
+ID: 118 Len: 8 Enqueue: 5089
+ID: 119 Len: 80 Enqueue: 5371
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 5044
-ID: 122 Len: 8 Enqueue: 5487
+ID: 121 Len: 8 Enqueue: 5005
+ID: 122 Len: 8 Enqueue: 5448
 ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 5457
+ID: 124 Len: 48 Enqueue: 5418
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 5134
-ID: 127 Len: 8 Enqueue: 4966
-ID: 128 Len: 8 Enqueue: 4972
-ID: 129 Len: 8 Enqueue: 4984
+ID: 126 Len: 8 Enqueue: 5095
+ID: 127 Len: 8 Enqueue: 4927
+ID: 128 Len: 8 Enqueue: 4933
+ID: 129 Len: 8 Enqueue: 4945
 ID: 130 Len: 1 Enqueue: 0
 ID: 131 Len: 8 Enqueue: 0
 ID: 132 Len: 1 Enqueue: 0
@@ -1952,49 +1946,49 @@ ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
-ID: 138 Len: 16 Enqueue: 5328
+ID: 138 Len: 16 Enqueue: 5289
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 32 Enqueue: 5848
-ID: 141 Len: 16 Enqueue: 5374
+ID: 140 Len: 32 Enqueue: 5809
+ID: 141 Len: 16 Enqueue: 5335
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 5541
-ID: 144 Len: 192 Enqueue: 5509
-ID: 145 Len: 24 Enqueue: 5590
-ID: 146 Len: 8 Enqueue: 5236
-ID: 147 Len: 200 Enqueue: 5282
-ID: 148 Len: 32 Enqueue: 5859
-ID: 149 Len: 16 Enqueue: 5386
+ID: 143 Len: 200 Enqueue: 5502
+ID: 144 Len: 192 Enqueue: 5470
+ID: 145 Len: 24 Enqueue: 5551
+ID: 146 Len: 8 Enqueue: 5197
+ID: 147 Len: 200 Enqueue: 5243
+ID: 148 Len: 32 Enqueue: 5820
+ID: 149 Len: 16 Enqueue: 5347
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 5552
-ID: 152 Len: 192 Enqueue: 5493
-ID: 153 Len: 24 Enqueue: 5574
-ID: 154 Len: 8 Enqueue: 5038
+ID: 151 Len: 200 Enqueue: 5513
+ID: 152 Len: 192 Enqueue: 5454
+ID: 153 Len: 24 Enqueue: 5535
+ID: 154 Len: 8 Enqueue: 4999
 ID: 155 Len: 184 Enqueue: 0
-ID: 156 Len: 8 Enqueue: 5248
-ID: 157 Len: 200 Enqueue: 5294
-ID: 158 Len: 32 Enqueue: 5870
-ID: 159 Len: 16 Enqueue: 5398
+ID: 156 Len: 8 Enqueue: 5209
+ID: 157 Len: 200 Enqueue: 5255
+ID: 158 Len: 32 Enqueue: 5831
+ID: 159 Len: 16 Enqueue: 5359
 ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 136 Enqueue: 5563
-ID: 162 Len: 128 Enqueue: 5525
-ID: 163 Len: 16 Enqueue: 5596
-ID: 164 Len: 8 Enqueue: 5469
+ID: 161 Len: 136 Enqueue: 5524
+ID: 162 Len: 128 Enqueue: 5486
+ID: 163 Len: 16 Enqueue: 5557
+ID: 164 Len: 8 Enqueue: 5430
 ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 48 Enqueue: 5421
+ID: 166 Len: 48 Enqueue: 5382
 ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 8 Enqueue: 5116
-ID: 169 Len: 8 Enqueue: 5260
-ID: 170 Len: 136 Enqueue: 5306
-ID: 171 Len: 32 Enqueue: 5837
-ID: 172 Len: 16 Enqueue: 5362
+ID: 168 Len: 8 Enqueue: 5077
+ID: 169 Len: 8 Enqueue: 5221
+ID: 170 Len: 136 Enqueue: 5267
+ID: 171 Len: 32 Enqueue: 5798
+ID: 172 Len: 16 Enqueue: 5323
 ID: 173 Len: 8 Enqueue: 0
 ID: 174 Len: 136 Enqueue: 0
 ID: 175 Len: 128 Enqueue: 0
 ID: 176 Len: 16 Enqueue: 0
 ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5224
+ID: 178 Len: 8 Enqueue: 5185
 ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 4978
+ID: 180 Len: 8 Enqueue: 4939
 ID: 181 Len: 128 Enqueue: 0
 ID: 182 Len: 9 Enqueue: 0
 ID: 183 Len: 0 Enqueue: 0
@@ -2104,7 +2098,7 @@ ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 25 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
 ID: 289 Len: 17 Enqueue: 0
-ID: 290 Len: 33 Enqueue: 0
+ID: 290 Len: 25 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 9 Enqueue: 0
 ID: 293 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5314]
 	PrepareEventRoot 5e 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b534c]
 	PrepareEventRoot 5f 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6170]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6918]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6918]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6918]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b67b8]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6868]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b6348]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6348]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b6348]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b63e8]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6488]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6488]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6488]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6298]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6298]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6298]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
 	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	PrepareEventRoot 1a 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb6e08]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@b6e08]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@b6e08]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@b6e68]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@b6e68]
 	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@b6e08]
+// 0x767: ProcessEvent[Probe[main.condOnly]@b6e08]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@b6e68]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@b6e68]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	PrepareEventRoot 16 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	PrepareEventRoot 1c 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
 	PrepareEventRoot 1e 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
 	PrepareEventRoot 1f 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0x964: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@b69c8]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0x9a8: ProcessEvent[Probe[main.condString]@b69c8]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@b6a2c]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@b69c8]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0xa05: ProcessEvent[Probe[main.condString]@b69c8]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@b6a2c]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@b69c8]
+// 0xa67: ProcessEvent[Probe[main.condString]@b69c8]
 	PrepareEventRoot 02 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@b6a2c]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0xa85: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@b69c8]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0xaeb: ProcessEvent[Probe[main.condString]@b69c8]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
 	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@b6a2c]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@b6a2c]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 06 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 97 1b 00 00 // ProcessType[main.condFields]
+	Call b7 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	PrepareEventRoot 10 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb65d8]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@b65d8]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@b65d8]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	PrepareEventRoot e8 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6638]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@b65d8]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@b65d8]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6638]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6678]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb6678]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@b6678]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@b6678]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b66d8]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@b6678]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@b6678]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b66d8]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6718]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb6718]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@b6718]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@b6718]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
 	PrepareEventRoot f0 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6778]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@b6718]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@b6718]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6778]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@b6528]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@b6528]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@b6528]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@b6528]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@b5130]
+// 0x106e: ProcessEvent[Probe[main.inlined]@b5130]
 	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@b6038]
+// 0x1093: ProcessEvent[Probe[main.inlined]@b6038]
 	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@b6070]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6070]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@b5d38]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@b5d38]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5d70]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b5d70]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[3]string]
+	Call ed 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5e28]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5e28]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@b782c]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b782c]
 	PrepareEventRoot 52 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
 	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 97 1b 00 00 // ProcessType[main.condFields]
+	Call b7 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b792c]
 	PrepareEventRoot 56 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
 	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@b782c]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@b782c]
 	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
 	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b792c]
 	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@b739c]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@b739c]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b745c]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b745c]
 	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@b739c]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@b739c]
 	PrepareEventRoot 36 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b745c]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b745c]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b74ac]
 	PrepareEventRoot 38 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*string]
+	Call 8b 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b74ac]
 	PrepareEventRoot 3a 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Call 49 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
 	PrepareEventRoot 4a 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
 	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
 	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
 	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
 	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@b728c]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@b728c]
 	PrepareEventRoot 30 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b734c]
 	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b728c]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b728c]
 	PrepareEventRoot 32 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b734c]
 	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb718c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@b718c]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x1525: ProcessEvent[Probe[main.lenString]@b718c]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
 	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@b718c]
+// 0x1559: ProcessEvent[Probe[main.lenString]@b718c]
 	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 29 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0xb718c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@b718c]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@b718c]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
 	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@b718c]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@b718c]
 	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@b718c]
+// 0x1642: ProcessEvent[Probe[main.lenString]@b718c]
 	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call a2 1b 00 00 // ProcessType[main.lenFields]
+	Call c2 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 3c 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b759c]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b759c]
 	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,471 +1495,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@b60f8]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@b60f8]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b6128]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b6128]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@b6228]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@b6228]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b6260]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b6260]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[3]string]
+	Call ed 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 3b 1b 00 00 // ProcessType[[]string]
+	Call 5b 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
 	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 12 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 32 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
 	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*main.bigStruct]
+// 0x1a3d: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.condFields]
+// 0x1a43: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.lenFields]
+// 0x1a49: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*runtime._defer]
+// 0x1a4f: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._panic]
+// 0x1a55: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime.cgoCallers]
+// 0x1a5b: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.coro]
+// 0x1a61: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.g]
+// 0x1a67: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.m]
+// 0x1a6d: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.sudog]
+// 0x1a73: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.synctestGroup]
+// 0x1a79: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.timer]
+// 0x1a7f: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.traceBuf]
+// 0x1a85: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*string]
+// 0x1a8b: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a91: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*table<string,int>]
+// 0x1a97: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*table<string,main.bigStruct>]
+// 0x1a9d: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1aa3: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*uint]
+// 0x1aa9: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint16]
+// 0x1aaf: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint32]
+// 0x1ab5: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint64]
+// 0x1abb: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint8]
+// 0x1ac1: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uintptr]
+// 0x1ac7: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1aad: ProcessType[[2]*runtime.traceBuf]
+// 0x1acd: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 85 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1abd: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1add: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call ad 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call cd 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1acd: ProcessType[[3]string]
+// 0x1aed: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1add: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1afd: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 71 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 91 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae9: ProcessType[[]*table<string,int>.array]
+// 0x1b09: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 77 1a 00 00 // ProcessType[*table<string,int>]
+	Call 97 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af5: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b15: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 7d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 9d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b01: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b21: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a3 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b0d: ProcessType[[]int]
+// 0x1b2d: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b17: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b37: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 48 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 68 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b23: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b43: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 53 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 73 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b2f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b4f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 5e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 7e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b3b: ProcessType[[]string]
+// 0x1b5b: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1b45: ProcessType[[]string.array]
+// 0x1b65: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b51: ProcessType[[]uint8]
+// 0x1b71: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1b5b: ProcessType[[]uintptr]
+// 0x1b7b: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1b65: ProcessType[error]
+// 0x1b85: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b67: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1b87: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b73: ProcessType[groupReference<string,int>]
+// 0x1b93: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b7f: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1b9f: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b8b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bab: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b97: ProcessType[main.condFields]
+// 0x1bb7: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1ba2: ProcessType[main.lenFields]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1bc2: ProcessType[main.lenFields]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0d 1b 00 00 // ProcessType[[]int]
+	Call 2d 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 06 1c 00 00 // ProcessType[map[string]int]
+	Call 26 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*string]
+	Call 8b 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bd0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1bf0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1bdc: ProcessType[map<string,int>]
+// 0x1bfc: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1be8: ProcessType[map<string,main.bigStruct>]
+// 0x1c08: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1bf4: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c14: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c00: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c20: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1c06: ProcessType[map[string]int]
+// 0x1c26: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1c0c: ProcessType[map[string]main.bigStruct]
+// 0x1c2c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1c12: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c32: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1c18: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c38: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 69 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 89 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c28: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c48: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 79 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 99 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c38: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c58: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 7f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c48: ProcessType[noalg.map.group[string]int]
+// 0x1c68: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 48 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c53: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c73: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 18 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c5e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c7e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 58 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c69: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1c89: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c79: ProcessType[noalg.struct { key string; elem int }]
-	Call 6a 1d 00 00 // ProcessType[string]
+// 0x1c99: ProcessType[noalg.struct { key string; elem int }]
+	Call 8a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c7f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c9f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 00 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 20 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1c8a: ProcessType[runtime.g]
+// 0x1caa: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._panic]
+	Call 55 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
+	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 51 1b 00 00 // ProcessType[[]uint8]
+	Call 71 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 73 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.timer]
+	Call 7f 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.coro]
+	Call 61 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 79 1a 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1cef: ProcessType[runtime.m]
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d0f: ProcessType[runtime.m]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6a 1d 00 00 // ProcessType[string]
+	Call 8a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 4f 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 6f 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 7a 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d4f: ProcessType[runtime.mLockProfile]
+// 0x1d6f: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]uintptr]
+	Call 7b 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d5a: ProcessType[runtime.mTraceState]
+// 0x1d7a: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call dd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d6a: ProcessType[string]
+// 0x1d8a: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x1d70: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d90: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 67 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 87 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1d7b: ProcessType[table<string,int>]
+// 0x1d9b: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 73 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 93 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1d86: ProcessType[table<string,main.bigStruct>]
+// 0x1da6: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 7f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1d91: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1db1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8b 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ab 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2227,31 +2227,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6817
+ID: 5 Len: 8 Enqueue: 6849
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7530
+ID: 9 Len: 16 Enqueue: 7562
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6643
+ID: 11 Len: 8 Enqueue: 6675
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7013
+ID: 14 Len: 16 Enqueue: 7045
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6823
-ID: 20 Len: 8 Enqueue: 6673
-ID: 21 Len: 8 Enqueue: 6805
-ID: 22 Len: 440 Enqueue: 7306
+ID: 19 Len: 8 Enqueue: 6855
+ID: 20 Len: 8 Enqueue: 6705
+ID: 21 Len: 8 Enqueue: 6837
+ID: 22 Len: 440 Enqueue: 7338
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6709
+ID: 24 Len: 8 Enqueue: 6741
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6703
+ID: 26 Len: 8 Enqueue: 6735
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6733
-ID: 29 Len: 1808 Enqueue: 7407
+ID: 28 Len: 8 Enqueue: 6765
+ID: 29 Len: 1808 Enqueue: 7439
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2260,45 +2260,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 6993
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7025
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6739
+ID: 41 Len: 8 Enqueue: 6771
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7003
-ID: 44 Len: 8 Enqueue: 6751
+ID: 43 Len: 24 Enqueue: 7035
+ID: 44 Len: 8 Enqueue: 6783
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6721
+ID: 47 Len: 8 Enqueue: 6753
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6745
+ID: 49 Len: 8 Enqueue: 6777
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6727
+ID: 55 Len: 8 Enqueue: 6759
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 6715
+ID: 62 Len: 8 Enqueue: 6747
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 7503
+ID: 67 Len: 64 Enqueue: 7535
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 7514
+ID: 72 Len: 56 Enqueue: 7546
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 6845
-ID: 75 Len: 16 Enqueue: 6829
-ID: 76 Len: 8 Enqueue: 6757
+ID: 74 Len: 32 Enqueue: 6877
+ID: 75 Len: 16 Enqueue: 6861
+ID: 76 Len: 8 Enqueue: 6789
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2315,46 +2315,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 6763
+ID: 93 Len: 8 Enqueue: 6795
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 6661
-ID: 98 Len: 8 Enqueue: 6679
-ID: 99 Len: 8 Enqueue: 6667
-ID: 100 Len: 8 Enqueue: 6811
-ID: 101 Len: 8 Enqueue: 6649
-ID: 102 Len: 8 Enqueue: 6655
-ID: 103 Len: 8 Enqueue: 6793
-ID: 104 Len: 8 Enqueue: 6799
-ID: 105 Len: 24 Enqueue: 6925
+ID: 97 Len: 8 Enqueue: 6693
+ID: 98 Len: 8 Enqueue: 6711
+ID: 99 Len: 8 Enqueue: 6699
+ID: 100 Len: 8 Enqueue: 6843
+ID: 101 Len: 8 Enqueue: 6681
+ID: 102 Len: 8 Enqueue: 6687
+ID: 103 Len: 8 Enqueue: 6825
+ID: 104 Len: 8 Enqueue: 6831
+ID: 105 Len: 24 Enqueue: 6957
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 6971
-ID: 108 Len: 48 Enqueue: 6861
-ID: 109 Len: 8 Enqueue: 7174
+ID: 107 Len: 24 Enqueue: 7003
+ID: 108 Len: 48 Enqueue: 6893
+ID: 109 Len: 8 Enqueue: 7206
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 7132
+ID: 111 Len: 48 Enqueue: 7164
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 6775
-ID: 114 Len: 8 Enqueue: 7180
+ID: 113 Len: 8 Enqueue: 6807
+ID: 114 Len: 8 Enqueue: 7212
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 7144
+ID: 116 Len: 48 Enqueue: 7176
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6781
-ID: 119 Len: 80 Enqueue: 7063
+ID: 118 Len: 8 Enqueue: 6813
+ID: 119 Len: 80 Enqueue: 7095
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 6691
-ID: 122 Len: 72 Enqueue: 7074
-ID: 123 Len: 8 Enqueue: 6631
-ID: 124 Len: 8 Enqueue: 6697
-ID: 125 Len: 8 Enqueue: 7186
+ID: 121 Len: 8 Enqueue: 6723
+ID: 122 Len: 72 Enqueue: 7106
+ID: 123 Len: 8 Enqueue: 6663
+ID: 124 Len: 8 Enqueue: 6729
+ID: 125 Len: 8 Enqueue: 7218
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 7156
+ID: 127 Len: 48 Enqueue: 7188
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 6787
-ID: 130 Len: 8 Enqueue: 6607
-ID: 131 Len: 8 Enqueue: 6613
-ID: 132 Len: 8 Enqueue: 6625
+ID: 129 Len: 8 Enqueue: 6819
+ID: 130 Len: 8 Enqueue: 6639
+ID: 131 Len: 8 Enqueue: 6645
+ID: 132 Len: 8 Enqueue: 6657
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2363,49 +2363,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 6981
+ID: 141 Len: 16 Enqueue: 7013
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 7547
-ID: 144 Len: 16 Enqueue: 7027
+ID: 143 Len: 32 Enqueue: 7579
+ID: 144 Len: 16 Enqueue: 7059
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 7240
-ID: 147 Len: 192 Enqueue: 7208
-ID: 148 Len: 24 Enqueue: 7289
-ID: 149 Len: 8 Enqueue: 6889
-ID: 150 Len: 200 Enqueue: 6935
-ID: 151 Len: 32 Enqueue: 7558
-ID: 152 Len: 16 Enqueue: 7039
+ID: 146 Len: 200 Enqueue: 7272
+ID: 147 Len: 192 Enqueue: 7240
+ID: 148 Len: 24 Enqueue: 7321
+ID: 149 Len: 8 Enqueue: 6921
+ID: 150 Len: 200 Enqueue: 6967
+ID: 151 Len: 32 Enqueue: 7590
+ID: 152 Len: 16 Enqueue: 7071
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 7251
-ID: 155 Len: 192 Enqueue: 7192
-ID: 156 Len: 24 Enqueue: 7273
-ID: 157 Len: 8 Enqueue: 6685
+ID: 154 Len: 200 Enqueue: 7283
+ID: 155 Len: 192 Enqueue: 7224
+ID: 156 Len: 24 Enqueue: 7305
+ID: 157 Len: 8 Enqueue: 6717
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 6901
-ID: 160 Len: 200 Enqueue: 6947
-ID: 161 Len: 32 Enqueue: 7569
-ID: 162 Len: 16 Enqueue: 7051
+ID: 159 Len: 8 Enqueue: 6933
+ID: 160 Len: 200 Enqueue: 6979
+ID: 161 Len: 32 Enqueue: 7601
+ID: 162 Len: 16 Enqueue: 7083
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 7262
-ID: 165 Len: 128 Enqueue: 7224
-ID: 166 Len: 16 Enqueue: 7295
-ID: 167 Len: 8 Enqueue: 7168
+ID: 164 Len: 136 Enqueue: 7294
+ID: 165 Len: 128 Enqueue: 7256
+ID: 166 Len: 16 Enqueue: 7327
+ID: 167 Len: 8 Enqueue: 7200
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 7120
+ID: 169 Len: 48 Enqueue: 7152
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 6769
-ID: 172 Len: 8 Enqueue: 6913
-ID: 173 Len: 136 Enqueue: 6959
-ID: 174 Len: 32 Enqueue: 7536
-ID: 175 Len: 16 Enqueue: 7015
+ID: 171 Len: 8 Enqueue: 6801
+ID: 172 Len: 8 Enqueue: 6945
+ID: 173 Len: 136 Enqueue: 6991
+ID: 174 Len: 32 Enqueue: 7568
+ID: 175 Len: 16 Enqueue: 7047
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6877
+ID: 181 Len: 8 Enqueue: 6909
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 6619
+ID: 183 Len: 8 Enqueue: 6651
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5314]
-	PrepareEventRoot 6e 01 00 00 11 00 00 00 
+	PrepareEventRoot 7e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b534c]
-	PrepareEventRoot 6f 01 00 00 09 00 00 00 
+	PrepareEventRoot 7f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb534c.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call a2 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call a2 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6170]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6918]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6918]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6918]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b67b8]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6868]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b6348]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6348]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b6348]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b63e8]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6488]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6488]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6488]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6298]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6298]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6298]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
-	PrepareEventRoot 24 01 00 00 11 00 00 00 
+	PrepareEventRoot 28 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6eb4]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
-	PrepareEventRoot 18 01 00 00 11 00 00 00 
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
-	PrepareEventRoot 1a 01 00 00 19 00 00 00 
+	PrepareEventRoot 1e 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b6e08]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
-	PrepareEventRoot 20 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@b6e68]
-	PrepareEventRoot 21 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b6e08]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 26 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@b6e68]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
-	PrepareEventRoot 12 01 00 00 11 00 00 00 
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
-	PrepareEventRoot 16 01 00 00 19 00 00 00 
+	PrepareEventRoot 1a 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
-	PrepareEventRoot 1c 01 00 00 09 00 00 00 
+	PrepareEventRoot 20 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
-	PrepareEventRoot 1e 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
-	PrepareEventRoot 1f 01 00 00 09 00 00 00 
+	PrepareEventRoot 23 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b69c8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b69c8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@b69c8]
+	PrepareEventRoot 02 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@b6a2c]
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@b69c8]
+	PrepareEventRoot 04 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@b6a2c]
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 00 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@b69c8]
-	PrepareEventRoot 02 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@b69c8]
+	PrepareEventRoot 06 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@b6a2c]
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0xb69c8]
+// 0xb11: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@b69c8]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
-	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@b69c8]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
+	PrepareEventRoot 08 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@b6a2c]
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 06 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+	PrepareEventRoot 0c 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+	PrepareEventRoot 0e 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0b 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 0e 1f 00 00 // ProcessType[main.condFields]
+	Call 2d 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	PrepareEventRoot 10 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@b6a7c]
+	PrepareEventRoot 14 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb65d8]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@b65d8]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@b65d8]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	PrepareEventRoot e8 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b6638]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@b65d8]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@b65d8]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b6638]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@b6638]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb6678]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0xb6678]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@b6678]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@b6678]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b66d8]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@b6678]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@b6678]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b66d8]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@b66d8]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb6718]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0xb6718]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@b6718]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@b6718]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
 	PrepareEventRoot f0 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b6778]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@b6718]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@b6718]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b6778]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@b6778]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@b6528]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot e2 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@b6528]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@b6528]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@b6528]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@b6528]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b6590]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@b6590]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@b5130]
-	PrepareEventRoot 6c 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@b5130]
+	PrepareEventRoot 7c 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@b6038]
-	PrepareEventRoot 6c 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6070]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@b5d38]
+// 0x111f: ProcessEvent[Probe[main.inlined]@b6038]
+	PrepareEventRoot 7c 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@b6070]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@b5d38]
 	PrepareEventRoot b9 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b5d70]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@b5d70]
 	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 44 1e 00 00 // ProcessType[[3]string]
+	Call 63 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5e28]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@b5e28]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b782c]
-	PrepareEventRoot 62 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@b782c]
+	PrepareEventRoot 72 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 0e 1f 00 00 // ProcessType[main.condFields]
+	Call 2d 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b792c]
-	PrepareEventRoot 66 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+	PrepareEventRoot 76 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@b782c]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@b782c]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
-	PrepareEventRoot 65 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+	PrepareEventRoot 75 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b792c]
-	PrepareEventRoot 68 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+	PrepareEventRoot 78 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb739c]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0xb739c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@b739c]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
-	PrepareEventRoot 3a 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@b739c]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 4a 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@b739c]
-	PrepareEventRoot 3c 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb739c]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0xb739c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@b739c]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
-	PrepareEventRoot 3e 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@b739c]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
+	PrepareEventRoot 4e 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@b739c]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@b739c]
-	PrepareEventRoot 42 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b74ac]
-	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 54 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*string]
+	Call 01 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b74ac]
-	PrepareEventRoot 46 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 56 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.lenFields]
+	Call bf 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 5a 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 6a 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 5e 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 6e 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 70 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb728c]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0xb728c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b728c]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@b728c]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
+	PrepareEventRoot 3c 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 3e 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@b728c]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb728c]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0xb728c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@b728c]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@b728c]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
+	PrepareEventRoot 42 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b728c]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@b728c]
-	PrepareEventRoot 38 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 46 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2a 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2c 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2e 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0xb718c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@b718c]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@b718c]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 32 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@b718c]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 34 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 29 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0xb718c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@b718c]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
-	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@b718c]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 36 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@b718c]
-	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 38 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@b718c]
-	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 3a 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 19 1f 00 00 // ProcessType[main.lenFields]
+	Call 38 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 48 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 58 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 52 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 62 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
-	PrepareEventRoot 54 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 64 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
-	PrepareEventRoot 56 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 66 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,471 +1812,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
-	PrepareEventRoot 58 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 68 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@b60f8]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@b60f8]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b6128]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@b6128]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@b6228]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@b6228]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b6260]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@b6260]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 44 1e 00 00 // ProcessType[[3]string]
+	Call 63 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b2 1e 00 00 // ProcessType[[]string]
+	Call d1 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
-	PrepareEventRoot 6a 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
+	PrepareEventRoot 7a 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 89 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a8 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
-	PrepareEventRoot 6b 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
+	PrepareEventRoot 7b 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*main.bigStruct]
+// 0x1fb3: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.condFields]
+// 0x1fb9: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.lenFields]
+// 0x1fbf: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*runtime._defer]
+// 0x1fc5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._panic]
+// 0x1fcb: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime.cgoCallers]
+// 0x1fd1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.coro]
+// 0x1fd7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.g]
+// 0x1fdd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.m]
+// 0x1fe3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.sudog]
+// 0x1fe9: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.synctestGroup]
+// 0x1fef: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.timer]
+// 0x1ff5: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.traceBuf]
+// 0x1ffb: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*string]
+// 0x2001: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2007: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*table<string,int>]
+// 0x200d: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*table<string,main.bigStruct>]
+// 0x2013: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2019: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*uint]
+// 0x201f: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint16]
+// 0x2025: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint32]
+// 0x202b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint64]
+// 0x2031: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint8]
+// 0x2037: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uintptr]
+// 0x203d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e24: ProcessType[[2]*runtime.traceBuf]
+// 0x2043: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call fb 1f 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e34: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2053: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 24 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 43 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e44: ProcessType[[3]string]
+// 0x2063: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e54: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x2073: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e8 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 07 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e60: ProcessType[[]*table<string,int>.array]
+// 0x207f: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call ee 1d 00 00 // ProcessType[*table<string,int>]
+	Call 0d 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e6c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x208b: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call f4 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 13 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e78: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x2097: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 19 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e84: ProcessType[[]int]
+// 0x20a3: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1e8e: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20ad: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call bf 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call de 21 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e9a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20b9: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call ca 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call e9 21 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ea6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20c5: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call d5 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f4 21 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eb2: ProcessType[[]string]
+// 0x20d1: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1ebc: ProcessType[[]string.array]
+// 0x20db: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ec8: ProcessType[[]uint8]
+// 0x20e7: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1ed2: ProcessType[[]uintptr]
+// 0x20f1: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1edc: ProcessType[error]
+// 0x20fb: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1ede: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x20fd: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1eea: ProcessType[groupReference<string,int>]
+// 0x2109: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ef6: ProcessType[groupReference<string,main.bigStruct>]
+// 0x2115: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f02: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2121: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f0e: ProcessType[main.condFields]
+// 0x212d: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f19: ProcessType[main.lenFields]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x2138: ProcessType[main.lenFields]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 84 1e 00 00 // ProcessType[[]int]
+	Call a3 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7d 1f 00 00 // ProcessType[map[string]int]
+	Call 9c 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*string]
+	Call 01 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f47: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x2166: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1f53: ProcessType[map<string,int>]
+// 0x2172: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1f5f: ProcessType[map<string,main.bigStruct>]
+// 0x217e: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1f6b: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x218a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1f77: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x2196: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1f7d: ProcessType[map[string]int]
+// 0x219c: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1f83: ProcessType[map[string]main.bigStruct]
+// 0x21a2: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1f89: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21a8: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1f8f: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21ae: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call e0 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call ff 21 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1f9f: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21be: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call f0 1f 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 0f 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1faf: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21ce: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call f6 1f 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 15 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fbf: ProcessType[noalg.map.group[string]int]
+// 0x21de: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call be 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1fca: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x21e9: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ae 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1fd5: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21f4: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call af 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call ce 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1fe0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x21ff: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b3 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1ff0: ProcessType[noalg.struct { key string; elem int }]
-	Call e1 20 00 00 // ProcessType[string]
+// 0x220f: ProcessType[noalg.struct { key string; elem int }]
+	Call 00 23 00 00 // ProcessType[string]
 	Return 
-// 0x1ff6: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2215: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 96 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2001: ProcessType[runtime.g]
+// 0x2220: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._panic]
+	Call cb 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*runtime._defer]
+	Call c5 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call c8 1e 00 00 // ProcessType[[]uint8]
+	Call e7 20 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.sudog]
+	Call e9 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.timer]
+	Call f5 1f 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.coro]
+	Call d7 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.synctestGroup]
+	Call ef 1f 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x2066: ProcessType[runtime.m]
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+// 0x2285: ProcessType[runtime.m]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call e1 20 00 00 // ProcessType[string]
+	Call 00 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d1 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call c6 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call e5 22 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d1 20 00 00 // ProcessType[runtime.mTraceState]
+	Call f0 22 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x20c6: ProcessType[runtime.mLockProfile]
+// 0x22e5: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call d2 1e 00 00 // ProcessType[[]uintptr]
+	Call f1 20 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20d1: ProcessType[runtime.mTraceState]
+// 0x22f0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 34 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call 53 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x20e1: ProcessType[string]
+// 0x2300: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x20e7: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2306: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call de 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call fd 20 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x20f2: ProcessType[table<string,int>]
+// 0x2311: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ea 1e 00 00 // ProcessType[groupReference<string,int>]
+	Call 09 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x20fd: ProcessType[table<string,main.bigStruct>]
+// 0x231c: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f6 1e 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 15 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x2108: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2327: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 02 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 21 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2421,31 +2544,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7704
+ID: 5 Len: 8 Enqueue: 8247
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8417
+ID: 9 Len: 16 Enqueue: 8960
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 7530
+ID: 11 Len: 8 Enqueue: 8073
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7900
+ID: 14 Len: 16 Enqueue: 8443
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 7710
-ID: 20 Len: 8 Enqueue: 7560
-ID: 21 Len: 8 Enqueue: 7692
-ID: 22 Len: 440 Enqueue: 8193
+ID: 19 Len: 8 Enqueue: 8253
+ID: 20 Len: 8 Enqueue: 8103
+ID: 21 Len: 8 Enqueue: 8235
+ID: 22 Len: 440 Enqueue: 8736
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7596
+ID: 24 Len: 8 Enqueue: 8139
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7590
+ID: 26 Len: 8 Enqueue: 8133
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7620
-ID: 29 Len: 1808 Enqueue: 8294
+ID: 28 Len: 8 Enqueue: 8163
+ID: 29 Len: 1808 Enqueue: 8837
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2454,45 +2577,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7880
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8423
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7626
+ID: 41 Len: 8 Enqueue: 8169
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7890
-ID: 44 Len: 8 Enqueue: 7638
+ID: 43 Len: 24 Enqueue: 8433
+ID: 44 Len: 8 Enqueue: 8181
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7608
+ID: 47 Len: 8 Enqueue: 8151
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 7632
+ID: 49 Len: 8 Enqueue: 8175
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 7614
+ID: 55 Len: 8 Enqueue: 8157
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 7602
+ID: 62 Len: 8 Enqueue: 8145
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 8390
+ID: 67 Len: 64 Enqueue: 8933
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 8401
+ID: 72 Len: 56 Enqueue: 8944
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 7732
-ID: 75 Len: 16 Enqueue: 7716
-ID: 76 Len: 8 Enqueue: 7644
+ID: 74 Len: 32 Enqueue: 8275
+ID: 75 Len: 16 Enqueue: 8259
+ID: 76 Len: 8 Enqueue: 8187
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2509,46 +2632,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 7650
+ID: 93 Len: 8 Enqueue: 8193
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 7548
-ID: 98 Len: 8 Enqueue: 7566
-ID: 99 Len: 8 Enqueue: 7554
-ID: 100 Len: 8 Enqueue: 7698
-ID: 101 Len: 8 Enqueue: 7536
-ID: 102 Len: 8 Enqueue: 7542
-ID: 103 Len: 8 Enqueue: 7680
-ID: 104 Len: 8 Enqueue: 7686
-ID: 105 Len: 24 Enqueue: 7812
+ID: 97 Len: 8 Enqueue: 8091
+ID: 98 Len: 8 Enqueue: 8109
+ID: 99 Len: 8 Enqueue: 8097
+ID: 100 Len: 8 Enqueue: 8241
+ID: 101 Len: 8 Enqueue: 8079
+ID: 102 Len: 8 Enqueue: 8085
+ID: 103 Len: 8 Enqueue: 8223
+ID: 104 Len: 8 Enqueue: 8229
+ID: 105 Len: 24 Enqueue: 8355
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 7858
-ID: 108 Len: 48 Enqueue: 7748
-ID: 109 Len: 8 Enqueue: 8061
+ID: 107 Len: 24 Enqueue: 8401
+ID: 108 Len: 48 Enqueue: 8291
+ID: 109 Len: 8 Enqueue: 8604
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 8019
+ID: 111 Len: 48 Enqueue: 8562
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 7662
-ID: 114 Len: 8 Enqueue: 8067
+ID: 113 Len: 8 Enqueue: 8205
+ID: 114 Len: 8 Enqueue: 8610
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 8031
+ID: 116 Len: 48 Enqueue: 8574
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 7668
-ID: 119 Len: 80 Enqueue: 7950
+ID: 118 Len: 8 Enqueue: 8211
+ID: 119 Len: 80 Enqueue: 8493
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 7578
-ID: 122 Len: 72 Enqueue: 7961
-ID: 123 Len: 8 Enqueue: 7518
-ID: 124 Len: 8 Enqueue: 7584
-ID: 125 Len: 8 Enqueue: 8073
+ID: 121 Len: 8 Enqueue: 8121
+ID: 122 Len: 72 Enqueue: 8504
+ID: 123 Len: 8 Enqueue: 8061
+ID: 124 Len: 8 Enqueue: 8127
+ID: 125 Len: 8 Enqueue: 8616
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 8043
+ID: 127 Len: 48 Enqueue: 8586
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 7674
-ID: 130 Len: 8 Enqueue: 7494
-ID: 131 Len: 8 Enqueue: 7500
-ID: 132 Len: 8 Enqueue: 7512
+ID: 129 Len: 8 Enqueue: 8217
+ID: 130 Len: 8 Enqueue: 8037
+ID: 131 Len: 8 Enqueue: 8043
+ID: 132 Len: 8 Enqueue: 8055
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2557,49 +2680,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 7868
+ID: 141 Len: 16 Enqueue: 8411
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 8434
-ID: 144 Len: 16 Enqueue: 7914
+ID: 143 Len: 32 Enqueue: 8977
+ID: 144 Len: 16 Enqueue: 8457
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 8127
-ID: 147 Len: 192 Enqueue: 8095
-ID: 148 Len: 24 Enqueue: 8176
-ID: 149 Len: 8 Enqueue: 7776
-ID: 150 Len: 200 Enqueue: 7822
-ID: 151 Len: 32 Enqueue: 8445
-ID: 152 Len: 16 Enqueue: 7926
+ID: 146 Len: 200 Enqueue: 8670
+ID: 147 Len: 192 Enqueue: 8638
+ID: 148 Len: 24 Enqueue: 8719
+ID: 149 Len: 8 Enqueue: 8319
+ID: 150 Len: 200 Enqueue: 8365
+ID: 151 Len: 32 Enqueue: 8988
+ID: 152 Len: 16 Enqueue: 8469
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 8138
-ID: 155 Len: 192 Enqueue: 8079
-ID: 156 Len: 24 Enqueue: 8160
-ID: 157 Len: 8 Enqueue: 7572
+ID: 154 Len: 200 Enqueue: 8681
+ID: 155 Len: 192 Enqueue: 8622
+ID: 156 Len: 24 Enqueue: 8703
+ID: 157 Len: 8 Enqueue: 8115
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 7788
-ID: 160 Len: 200 Enqueue: 7834
-ID: 161 Len: 32 Enqueue: 8456
-ID: 162 Len: 16 Enqueue: 7938
+ID: 159 Len: 8 Enqueue: 8331
+ID: 160 Len: 200 Enqueue: 8377
+ID: 161 Len: 32 Enqueue: 8999
+ID: 162 Len: 16 Enqueue: 8481
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 8149
-ID: 165 Len: 128 Enqueue: 8111
-ID: 166 Len: 16 Enqueue: 8182
-ID: 167 Len: 8 Enqueue: 8055
+ID: 164 Len: 136 Enqueue: 8692
+ID: 165 Len: 128 Enqueue: 8654
+ID: 166 Len: 16 Enqueue: 8725
+ID: 167 Len: 8 Enqueue: 8598
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 8007
+ID: 169 Len: 48 Enqueue: 8550
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 7656
-ID: 172 Len: 8 Enqueue: 7800
-ID: 173 Len: 136 Enqueue: 7846
-ID: 174 Len: 32 Enqueue: 8423
-ID: 175 Len: 16 Enqueue: 7902
+ID: 171 Len: 8 Enqueue: 8199
+ID: 172 Len: 8 Enqueue: 8343
+ID: 173 Len: 136 Enqueue: 8389
+ID: 174 Len: 32 Enqueue: 8966
+ID: 175 Len: 16 Enqueue: 8445
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 7764
+ID: 181 Len: 8 Enqueue: 8307
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 7506
+ID: 183 Len: 8 Enqueue: 8049
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
@@ -2674,13 +2797,13 @@ ID: 254 Len: 17 Enqueue: 0
 ID: 255 Len: 0 Enqueue: 0
 ID: 256 Len: 17 Enqueue: 0
 ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 33 Enqueue: 0
+ID: 258 Len: 2 Enqueue: 0
 ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 33 Enqueue: 0
+ID: 260 Len: 2 Enqueue: 0
 ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 17 Enqueue: 0
+ID: 262 Len: 33 Enqueue: 0
 ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 17 Enqueue: 0
+ID: 264 Len: 33 Enqueue: 0
 ID: 265 Len: 0 Enqueue: 0
 ID: 266 Len: 17 Enqueue: 0
 ID: 267 Len: 0 Enqueue: 0
@@ -2688,81 +2811,81 @@ ID: 268 Len: 17 Enqueue: 0
 ID: 269 Len: 0 Enqueue: 0
 ID: 270 Len: 17 Enqueue: 0
 ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 97 Enqueue: 0
+ID: 272 Len: 17 Enqueue: 0
 ID: 273 Len: 0 Enqueue: 0
 ID: 274 Len: 17 Enqueue: 0
 ID: 275 Len: 0 Enqueue: 0
-ID: 276 Len: 17 Enqueue: 0
+ID: 276 Len: 97 Enqueue: 0
 ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 25 Enqueue: 0
+ID: 278 Len: 17 Enqueue: 0
 ID: 279 Len: 0 Enqueue: 0
 ID: 280 Len: 17 Enqueue: 0
 ID: 281 Len: 0 Enqueue: 0
 ID: 282 Len: 25 Enqueue: 0
 ID: 283 Len: 0 Enqueue: 0
-ID: 284 Len: 9 Enqueue: 0
+ID: 284 Len: 17 Enqueue: 0
 ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 17 Enqueue: 0
-ID: 287 Len: 9 Enqueue: 0
-ID: 288 Len: 25 Enqueue: 0
+ID: 286 Len: 25 Enqueue: 0
+ID: 287 Len: 0 Enqueue: 0
+ID: 288 Len: 9 Enqueue: 0
 ID: 289 Len: 0 Enqueue: 0
-ID: 290 Len: 25 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 17 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
-ID: 294 Len: 17 Enqueue: 0
+ID: 290 Len: 17 Enqueue: 0
+ID: 291 Len: 9 Enqueue: 0
+ID: 292 Len: 25 Enqueue: 0
+ID: 293 Len: 0 Enqueue: 0
+ID: 294 Len: 25 Enqueue: 0
 ID: 295 Len: 0 Enqueue: 0
-ID: 296 Len: 9 Enqueue: 0
-ID: 297 Len: 0 Enqueue: 0
-ID: 298 Len: 17 Enqueue: 0
+ID: 296 Len: 17 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 2 Enqueue: 0
 ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 9 Enqueue: 0
+ID: 300 Len: 2 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 33 Enqueue: 0
+ID: 302 Len: 2 Enqueue: 0
 ID: 303 Len: 0 Enqueue: 0
 ID: 304 Len: 17 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 9 Enqueue: 0
+ID: 306 Len: 2 Enqueue: 0
 ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 17 Enqueue: 0
+ID: 308 Len: 9 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 9 Enqueue: 0
+ID: 310 Len: 17 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 41 Enqueue: 0
+ID: 312 Len: 9 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 17 Enqueue: 0
+ID: 314 Len: 33 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 9 Enqueue: 0
+ID: 316 Len: 17 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 17 Enqueue: 0
+ID: 318 Len: 2 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
 ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 25 Enqueue: 0
+ID: 322 Len: 17 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
 ID: 324 Len: 9 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 25 Enqueue: 0
+ID: 326 Len: 41 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 89 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 9 Enqueue: 0
+ID: 330 Len: 2 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
 ID: 332 Len: 9 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
-ID: 334 Len: 9 Enqueue: 0
+ID: 334 Len: 17 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
 ID: 336 Len: 9 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 9 Enqueue: 0
+ID: 338 Len: 25 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 17 Enqueue: 0
+ID: 340 Len: 9 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 17 Enqueue: 0
+ID: 342 Len: 25 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 17 Enqueue: 0
+ID: 344 Len: 89 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 25 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
 ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
@@ -2770,17 +2893,33 @@ ID: 350 Len: 9 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
 ID: 352 Len: 9 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 25 Enqueue: 0
+ID: 354 Len: 9 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 0 Enqueue: 0
+ID: 356 Len: 17 Enqueue: 0
 ID: 357 Len: 0 Enqueue: 0
-ID: 358 Len: 97 Enqueue: 0
+ID: 358 Len: 17 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
-ID: 360 Len: 0 Enqueue: 0
+ID: 360 Len: 17 Enqueue: 0
 ID: 361 Len: 0 Enqueue: 0
-ID: 362 Len: 0 Enqueue: 0
-ID: 363 Len: 9 Enqueue: 0
+ID: 362 Len: 25 Enqueue: 0
+ID: 363 Len: 0 Enqueue: 0
 ID: 364 Len: 9 Enqueue: 0
 ID: 365 Len: 0 Enqueue: 0
-ID: 366 Len: 17 Enqueue: 0
-ID: 367 Len: 9 Enqueue: 0
+ID: 366 Len: 9 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 9 Enqueue: 0
+ID: 369 Len: 0 Enqueue: 0
+ID: 370 Len: 25 Enqueue: 0
+ID: 371 Len: 0 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 0 Enqueue: 0
+ID: 374 Len: 97 Enqueue: 0
+ID: 375 Len: 0 Enqueue: 0
+ID: 376 Len: 0 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 0 Enqueue: 0
+ID: 379 Len: 9 Enqueue: 0
+ID: 380 Len: 9 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 17 Enqueue: 0
+ID: 383 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5314]
-	PrepareEventRoot 27 01 00 00 11 00 00 00 
+	PrepareEventRoot 5e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b534c]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb534c.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 42 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 0c 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6170]
-	PrepareEventRoot c9 00 00 00 11 00 00 00 
+	PrepareEventRoot cc 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b61e4]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0xb6918]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6918]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
-	PrepareEventRoot f5 00 00 00 11 00 00 00 
+	PrepareEventRoot f8 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@b6980]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0xb6918]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6918]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
+	PrepareEventRoot fa 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@b6980]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6918]
-	PrepareEventRoot f9 00 00 00 12 00 00 00 
+	PrepareEventRoot fc 00 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb6918.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@b6980]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb67b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b67b8]
-	PrepareEventRoot f1 00 00 00 11 00 00 00 
+	PrepareEventRoot f4 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb67b8.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b681c]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0xb6868.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6868]
-	PrepareEventRoot f3 00 00 00 11 00 00 00 
+	PrepareEventRoot f6 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb6868.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@b68cc]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0xb6348]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b6348]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6348]
-	PrepareEventRoot d1 00 00 00 11 00 00 00 
+	PrepareEventRoot d4 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@b63a8]
-	PrepareEventRoot d2 00 00 00 00 00 00 00 
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b6348]
-	PrepareEventRoot d3 00 00 00 13 00 00 00 
+	PrepareEventRoot d6 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb6348.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b63a8]
-	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
-	PrepareEventRoot d5 00 00 00 11 00 00 00 
+	PrepareEventRoot d8 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@b6448]
-	PrepareEventRoot d6 00 00 00 00 00 00 00 
+	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0xb63e8]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
-	PrepareEventRoot d7 00 00 00 11 00 00 00 
+	PrepareEventRoot da 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@b6448]
-	PrepareEventRoot d8 00 00 00 00 00 00 00 
+	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b63e8]
-	PrepareEventRoot d9 00 00 00 15 00 00 00 
+	PrepareEventRoot dc 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb63e8.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b6448]
-	PrepareEventRoot da 00 00 00 00 00 00 00 
+	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb6488]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6488]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6488]
-	PrepareEventRoot db 00 00 00 11 00 00 00 
+	PrepareEventRoot de 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@b64e8]
-	PrepareEventRoot dc 00 00 00 00 00 00 00 
+	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6488]
-	PrepareEventRoot dd 00 00 00 19 00 00 00 
+	PrepareEventRoot e0 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb6488.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b64e8]
-	PrepareEventRoot de 00 00 00 00 00 00 00 
+	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb6298]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6298]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6298]
-	PrepareEventRoot cd 00 00 00 11 00 00 00 
+	PrepareEventRoot d0 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b6300]
-	PrepareEventRoot ce 00 00 00 00 00 00 00 
+	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6298]
-	PrepareEventRoot cf 00 00 00 12 00 00 00 
+	PrepareEventRoot d2 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb6298.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@b6300]
-	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
-	PrepareEventRoot 21 01 00 00 11 00 00 00 
+	PrepareEventRoot 24 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6eb4]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb6eb4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
-	PrepareEventRoot 17 01 00 00 19 00 00 00 
+	PrepareEventRoot 1a 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b6d1c]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb6e08]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@b6e08]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
-	PrepareEventRoot 1d 01 00 00 19 00 00 00 
+	PrepareEventRoot 20 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@b6e68]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@b6e08]
-	PrepareEventRoot 1f 01 00 00 19 00 00 00 
+	PrepareEventRoot 22 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb6e08.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@b6e68]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
-	PrepareEventRoot 13 01 00 00 19 00 00 00 
+	PrepareEventRoot 16 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b6c64]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb6d68]
-	PrepareEventRoot 19 01 00 00 09 00 00 00 
+	PrepareEventRoot 1c 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b6d68]
-	PrepareEventRoot 1b 01 00 00 11 00 00 00 
+	PrepareEventRoot 1e 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb6d68.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b6dc8]
-	PrepareEventRoot 1c 01 00 00 09 00 00 00 
+	PrepareEventRoot 1f 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb6dc8.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@b69c8]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	PrepareEventRoot fe 00 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@b69c8]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	PrepareEventRoot 00 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@b69c8]
-	PrepareEventRoot ff 00 00 00 21 00 00 00 
+	PrepareEventRoot 02 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0xb69c8]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@b69c8]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
-	PrepareEventRoot 01 01 00 00 21 00 00 00 
+	PrepareEventRoot 04 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@b6a2c]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 03 01 00 00 11 00 00 00 
+	PrepareEventRoot 06 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 05 01 00 00 11 00 00 00 
+	PrepareEventRoot 08 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 09 01 00 00 11 00 00 00 
+	PrepareEventRoot 0c 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
-	PrepareEventRoot 0b 01 00 00 11 00 00 00 
+	PrepareEventRoot 0e 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call fb 14 00 00 // ProcessType[main.condFields]
+	Call 97 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@b6a7c]
-	PrepareEventRoot 0d 01 00 00 61 00 00 00 
+	PrepareEventRoot 10 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b6b48]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0xb65d8]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@b65d8]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
-	PrepareEventRoot e5 00 00 00 11 00 00 00 
+	PrepareEventRoot e8 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b6638]
-	PrepareEventRoot e6 00 00 00 00 00 00 00 
+	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@b65d8]
-	PrepareEventRoot e7 00 00 00 13 00 00 00 
+	PrepareEventRoot ea 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb65d8.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@b6638]
-	PrepareEventRoot e8 00 00 00 00 00 00 00 
+	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0xb6678]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@b6678]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
-	PrepareEventRoot e9 00 00 00 11 00 00 00 
+	PrepareEventRoot ec 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b66d8]
-	PrepareEventRoot ea 00 00 00 00 00 00 00 
+	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@b6678]
-	PrepareEventRoot eb 00 00 00 15 00 00 00 
+	PrepareEventRoot ee 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb6678.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@b66d8]
-	PrepareEventRoot ec 00 00 00 00 00 00 00 
+	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb6718]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@b6718]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
-	PrepareEventRoot ed 00 00 00 11 00 00 00 
+	PrepareEventRoot f0 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@b6778]
-	PrepareEventRoot ee 00 00 00 00 00 00 00 
+	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@b6718]
-	PrepareEventRoot ef 00 00 00 19 00 00 00 
+	PrepareEventRoot f2 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb6718.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@b6778]
-	PrepareEventRoot f0 00 00 00 00 00 00 00 
+	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@b6528]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
-	PrepareEventRoot df 00 00 00 11 00 00 00 
+	PrepareEventRoot e2 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b6590]
-	PrepareEventRoot e0 00 00 00 00 00 00 00 
+	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb6528]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@b6528]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
-	PrepareEventRoot e1 00 00 00 11 00 00 00 
+	PrepareEventRoot e4 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@b6590]
-	PrepareEventRoot e2 00 00 00 00 00 00 00 
+	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@b6528]
-	PrepareEventRoot e3 00 00 00 12 00 00 00 
+	PrepareEventRoot e6 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb6528.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@b6590]
-	PrepareEventRoot e4 00 00 00 00 00 00 00 
+	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@b5130]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@b6038]
-	PrepareEventRoot 25 01 00 00 09 00 00 00 
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@b6070]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@b5d38]
-	PrepareEventRoot b6 00 00 00 09 00 00 00 
+	PrepareEventRoot b9 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@b5d70]
-	PrepareEventRoot b7 00 00 00 00 00 00 00 
+	PrepareEventRoot ba 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b5ea8]
-	PrepareEventRoot c0 00 00 00 19 00 00 00 
+	PrepareEventRoot c3 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb5ea8.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b5eec]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 31 14 00 00 // ProcessType[[3]string]
+	Call cd 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
-	PrepareEventRoot c6 00 00 00 31 00 00 00 
+	PrepareEventRoot c9 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb6010.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
@@ -1104,448 +1104,862 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 71 14 00 00 // ProcessType[[]int]
+	Call 0d 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@b5e28]
-	PrepareEventRoot be 00 00 00 19 00 00 00 
+	PrepareEventRoot c1 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb5e28.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b5e64]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@b5da8]
-	PrepareEventRoot b8 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b5de4]
-	PrepareEventRoot b9 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@b5da8]
-	PrepareEventRoot ba 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b5de4]
-	PrepareEventRoot bb 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3c 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3c 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@b60f8]
-	PrepareEventRoot c7 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@b782c]
+	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b6128]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@b6228]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b6260]
-	PrepareEventRoot cc 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call 97 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@b5da8]
-	PrepareEventRoot bc 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+	PrepareEventRoot 56 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b5de4]
-	PrepareEventRoot bd 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@b782c]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@b792c]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 31 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
-	PrepareEventRoot c4 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 36 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 38 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 3a 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 4a 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 30 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 9f 14 00 00 // ProcessType[[]string]
+	Call 0d 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
-	PrepareEventRoot c2 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 32 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb718c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@b718c]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0xb718c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@b718c]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 2a 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2c 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2e 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call a2 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 3c 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 46 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@b5da8]
+	PrepareEventRoot bb 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@b5da8]
+	PrepareEventRoot bd 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+	PrepareEventRoot be 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 48 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
-	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 80 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@b60f8]
+	PrepareEventRoot ca 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer b4 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b6128]
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 81 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@b6228]
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b6260]
+	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 6a 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@b5da8]
+	PrepareEventRoot bf 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+	PrepareEventRoot c0 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call cd 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
+	PrepareEventRoot c7 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 3b 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
+	PrepareEventRoot c5 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 12 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
+	PrepareEventRoot 5b 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 83 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer b7 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 84 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 69 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1387: ProcessType[*main.bigStruct]
-	ProcessPointer 9b 00 00 00 
-	Return 
-// 0x138d: ProcessType[*main.condFields]
-	ProcessPointer 77 00 00 00 
-	Return 
-// 0x1393: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 3f 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.synctestGroup]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.traceBuf]
-	ProcessPointer 4d 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer ab 00 00 00 
-	Return 
-// 0x13db: ProcessType[*table<string,int>]
-	ProcessPointer 8c 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 94 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a1d: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x13ed: ProcessType[*uint]
+// 0x1a23: ProcessType[*main.condFields]
+	ProcessPointer 77 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*main.lenFields]
+	ProcessPointer 7a 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 3f 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.synctestGroup]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.traceBuf]
+	ProcessPointer 4d 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ae 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*table<string,int>]
+	ProcessPointer 8f 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 97 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a1 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x13f3: ProcessType[*uint16]
+// 0x1a8f: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x13f9: ProcessType[*uint32]
+// 0x1a95: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint64]
+// 0x1a9b: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint8]
+// 0x1aa1: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uintptr]
+// 0x1aa7: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1411: ProcessType[[2]*runtime.traceBuf]
+// 0x1aad: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 65 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1421: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1abd: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 11 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call ad 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1431: ProcessType[[3]string]
+// 0x1acd: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1441: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1add: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call d5 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 71 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x144d: ProcessType[[]*table<string,int>.array]
+// 0x1ae9: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call db 13 00 00 // ProcessType[*table<string,int>]
+	Call 77 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1459: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1af5: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call e1 13 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 7d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1465: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b01: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 83 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1471: ProcessType[[]int]
-	ProcessSlice 88 00 00 00 08 00 00 00 
+// 0x1b0d: ProcessType[[]int]
+	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x147b: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b17: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 7e 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 48 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1487: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b23: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 89 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 53 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1493: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b2f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 94 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 5e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x149f: ProcessType[[]string]
-	ProcessSlice 8a 00 00 00 10 00 00 00 
+// 0x1b3b: ProcessType[[]string]
+	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x14a9: ProcessType[[]string.array]
+// 0x1b45: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14b5: ProcessType[[]uint8]
-	ProcessSlice 84 00 00 00 01 00 00 00 
+// 0x1b51: ProcessType[[]uint8]
+	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x14bf: ProcessType[[]uintptr]
-	ProcessSlice 86 00 00 00 08 00 00 00 
+// 0x1b5b: ProcessType[[]uintptr]
+	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x14c9: ProcessType[error]
+// 0x1b65: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14cb: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b3 00 00 00 88 00 00 00 00 08 
+// 0x1b67: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14d7: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 93 00 00 00 c8 00 00 00 00 08 
+// 0x1b73: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14e3: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
+// 0x1b7f: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14ef: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups aa 00 00 00 88 00 00 00 00 08 
+// 0x1b8b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14fb: ProcessType[main.condFields]
+// 0x1b97: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1506: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b2 00 00 00 ae 00 00 00 10 18 
+// 0x1ba2: ProcessType[main.lenFields]
+	Call 6a 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 0d 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 06 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 6b 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1512: ProcessType[map<string,int>]
-	ProcessGoSwissMap 92 00 00 00 8f 00 00 00 10 18 
+// 0x1bd0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x151e: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap 9c 00 00 00 97 00 00 00 10 18 
+// 0x1bdc: ProcessType[map<string,int>]
+	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x152a: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap a9 00 00 00 a1 00 00 00 10 18 
+// 0x1be8: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1536: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer a6 00 00 00 
+// 0x1bf4: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x153c: ProcessType[map[string]int]
+// 0x1c00: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer a9 00 00 00 
+	Return 
+// 0x1c06: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1542: ProcessType[map[string]main.bigStruct]
+// 0x1c0c: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1548: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 7c 00 00 00 
+// 0x1c12: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x154e: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c18: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 9f 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 69 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x155e: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c28: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call af 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 79 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x156e: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c38: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call b5 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 7f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x157e: ProcessType[noalg.map.group[string]int]
+// 0x1c48: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 28 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1589: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c53: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 18 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1594: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c5e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6e 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x159f: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call a0 16 00 00 // ProcessType[string]
+// 0x1c69: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 6a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 13 00 00 // ProcessType[*main.bigStruct]
+	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15af: ProcessType[noalg.struct { key string; elem int }]
-	Call a0 16 00 00 // ProcessType[string]
+// 0x1c79: ProcessType[noalg.struct { key string; elem int }]
+	Call 6a 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15b5: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c7f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 36 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 00 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15c0: ProcessType[runtime.g]
+// 0x1c8a: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._panic]
+	Call 35 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 13 00 00 // ProcessType[*runtime._defer]
+	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call b5 14 00 00 // ProcessType[[]uint8]
+	Call 51 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.sudog]
+	Call 53 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.timer]
+	Call 5f 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.coro]
+	Call 41 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.synctestGroup]
+	Call 59 1a 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1625: ProcessType[runtime.m]
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+// 0x1cef: ProcessType[runtime.m]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call a0 16 00 00 // ProcessType[string]
+	Call 6a 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 85 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 4f 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 90 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 5a 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1685: ProcessType[runtime.mLockProfile]
+// 0x1d4f: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call bf 14 00 00 // ProcessType[[]uintptr]
+	Call 5b 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1690: ProcessType[runtime.mTraceState]
+// 0x1d5a: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 21 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call bd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16a0: ProcessType[string]
-	ProcessString 82 00 00 00 
+// 0x1d6a: ProcessType[string]
+	ProcessString 85 00 00 00 
 	Return 
-// 0x16a6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d70: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call cb 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 67 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16b1: ProcessType[table<string,int>]
+// 0x1d7b: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d7 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 73 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16bc: ProcessType[table<string,main.bigStruct>]
+// 0x1d86: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e3 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 7f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16c7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1d91: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ef 14 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 8b 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1813,31 +2227,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5125
+ID: 5 Len: 8 Enqueue: 6817
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5792
+ID: 9 Len: 16 Enqueue: 7530
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4957
+ID: 11 Len: 8 Enqueue: 6643
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 5321
+ID: 14 Len: 16 Enqueue: 7013
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5131
-ID: 20 Len: 8 Enqueue: 4987
-ID: 21 Len: 8 Enqueue: 5113
-ID: 22 Len: 440 Enqueue: 5568
+ID: 19 Len: 8 Enqueue: 6823
+ID: 20 Len: 8 Enqueue: 6673
+ID: 21 Len: 8 Enqueue: 6805
+ID: 22 Len: 440 Enqueue: 7306
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5017
+ID: 24 Len: 8 Enqueue: 6709
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5011
+ID: 26 Len: 8 Enqueue: 6703
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5041
-ID: 29 Len: 1808 Enqueue: 5669
+ID: 28 Len: 8 Enqueue: 6733
+ID: 29 Len: 1808 Enqueue: 7407
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1846,45 +2260,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5301
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 6993
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5047
+ID: 41 Len: 8 Enqueue: 6739
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5311
-ID: 44 Len: 8 Enqueue: 5059
+ID: 43 Len: 24 Enqueue: 7003
+ID: 44 Len: 8 Enqueue: 6751
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5029
+ID: 47 Len: 8 Enqueue: 6721
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5053
+ID: 49 Len: 8 Enqueue: 6745
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5035
+ID: 55 Len: 8 Enqueue: 6727
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 5023
+ID: 62 Len: 8 Enqueue: 6715
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 5765
+ID: 67 Len: 64 Enqueue: 7503
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 5776
+ID: 72 Len: 56 Enqueue: 7514
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 5153
-ID: 75 Len: 16 Enqueue: 5137
-ID: 76 Len: 8 Enqueue: 5065
+ID: 74 Len: 32 Enqueue: 6845
+ID: 75 Len: 16 Enqueue: 6829
+ID: 76 Len: 8 Enqueue: 6757
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -1901,207 +2315,262 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 5071
+ID: 93 Len: 8 Enqueue: 6763
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 4975
-ID: 98 Len: 8 Enqueue: 4993
-ID: 99 Len: 8 Enqueue: 4981
-ID: 100 Len: 8 Enqueue: 5119
-ID: 101 Len: 8 Enqueue: 4963
-ID: 102 Len: 8 Enqueue: 4969
-ID: 103 Len: 8 Enqueue: 5101
-ID: 104 Len: 8 Enqueue: 5107
-ID: 105 Len: 24 Enqueue: 5233
+ID: 97 Len: 8 Enqueue: 6661
+ID: 98 Len: 8 Enqueue: 6679
+ID: 99 Len: 8 Enqueue: 6667
+ID: 100 Len: 8 Enqueue: 6811
+ID: 101 Len: 8 Enqueue: 6649
+ID: 102 Len: 8 Enqueue: 6655
+ID: 103 Len: 8 Enqueue: 6793
+ID: 104 Len: 8 Enqueue: 6799
+ID: 105 Len: 24 Enqueue: 6925
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 5279
-ID: 108 Len: 48 Enqueue: 5169
-ID: 109 Len: 8 Enqueue: 5436
+ID: 107 Len: 24 Enqueue: 6971
+ID: 108 Len: 48 Enqueue: 6861
+ID: 109 Len: 8 Enqueue: 7174
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 5394
+ID: 111 Len: 48 Enqueue: 7132
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 5083
-ID: 114 Len: 8 Enqueue: 5442
+ID: 113 Len: 8 Enqueue: 6775
+ID: 114 Len: 8 Enqueue: 7180
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 5406
+ID: 116 Len: 48 Enqueue: 7144
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 5089
-ID: 119 Len: 80 Enqueue: 5371
+ID: 118 Len: 8 Enqueue: 6781
+ID: 119 Len: 80 Enqueue: 7063
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 5005
-ID: 122 Len: 8 Enqueue: 5448
-ID: 123 Len: 8 Enqueue: 0
-ID: 124 Len: 48 Enqueue: 5418
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 8 Enqueue: 5095
-ID: 127 Len: 8 Enqueue: 4927
-ID: 128 Len: 8 Enqueue: 4933
-ID: 129 Len: 8 Enqueue: 4945
-ID: 130 Len: 1 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 0
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
+ID: 121 Len: 8 Enqueue: 6691
+ID: 122 Len: 72 Enqueue: 7074
+ID: 123 Len: 8 Enqueue: 6631
+ID: 124 Len: 8 Enqueue: 6697
+ID: 125 Len: 8 Enqueue: 7186
+ID: 126 Len: 8 Enqueue: 0
+ID: 127 Len: 48 Enqueue: 7156
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 8 Enqueue: 6787
+ID: 130 Len: 8 Enqueue: 6607
+ID: 131 Len: 8 Enqueue: 6613
+ID: 132 Len: 8 Enqueue: 6625
+ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
-ID: 138 Len: 16 Enqueue: 5289
+ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
-ID: 140 Len: 32 Enqueue: 5809
-ID: 141 Len: 16 Enqueue: 5335
+ID: 140 Len: 8 Enqueue: 0
+ID: 141 Len: 16 Enqueue: 6981
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 200 Enqueue: 5502
-ID: 144 Len: 192 Enqueue: 5470
-ID: 145 Len: 24 Enqueue: 5551
-ID: 146 Len: 8 Enqueue: 5197
-ID: 147 Len: 200 Enqueue: 5243
-ID: 148 Len: 32 Enqueue: 5820
-ID: 149 Len: 16 Enqueue: 5347
-ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 5513
-ID: 152 Len: 192 Enqueue: 5454
-ID: 153 Len: 24 Enqueue: 5535
-ID: 154 Len: 8 Enqueue: 4999
-ID: 155 Len: 184 Enqueue: 0
-ID: 156 Len: 8 Enqueue: 5209
-ID: 157 Len: 200 Enqueue: 5255
-ID: 158 Len: 32 Enqueue: 5831
-ID: 159 Len: 16 Enqueue: 5359
-ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 136 Enqueue: 5524
-ID: 162 Len: 128 Enqueue: 5486
-ID: 163 Len: 16 Enqueue: 5557
-ID: 164 Len: 8 Enqueue: 5430
-ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 48 Enqueue: 5382
-ID: 167 Len: 8 Enqueue: 0
-ID: 168 Len: 8 Enqueue: 5077
-ID: 169 Len: 8 Enqueue: 5221
-ID: 170 Len: 136 Enqueue: 5267
-ID: 171 Len: 32 Enqueue: 5798
-ID: 172 Len: 16 Enqueue: 5323
-ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 0
-ID: 175 Len: 128 Enqueue: 0
-ID: 176 Len: 16 Enqueue: 0
-ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5185
-ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 8 Enqueue: 4939
-ID: 181 Len: 128 Enqueue: 0
-ID: 182 Len: 9 Enqueue: 0
-ID: 183 Len: 0 Enqueue: 0
-ID: 184 Len: 17 Enqueue: 0
-ID: 185 Len: 0 Enqueue: 0
+ID: 143 Len: 32 Enqueue: 7547
+ID: 144 Len: 16 Enqueue: 7027
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 200 Enqueue: 7240
+ID: 147 Len: 192 Enqueue: 7208
+ID: 148 Len: 24 Enqueue: 7289
+ID: 149 Len: 8 Enqueue: 6889
+ID: 150 Len: 200 Enqueue: 6935
+ID: 151 Len: 32 Enqueue: 7558
+ID: 152 Len: 16 Enqueue: 7039
+ID: 153 Len: 8 Enqueue: 0
+ID: 154 Len: 200 Enqueue: 7251
+ID: 155 Len: 192 Enqueue: 7192
+ID: 156 Len: 24 Enqueue: 7273
+ID: 157 Len: 8 Enqueue: 6685
+ID: 158 Len: 184 Enqueue: 0
+ID: 159 Len: 8 Enqueue: 6901
+ID: 160 Len: 200 Enqueue: 6947
+ID: 161 Len: 32 Enqueue: 7569
+ID: 162 Len: 16 Enqueue: 7051
+ID: 163 Len: 8 Enqueue: 0
+ID: 164 Len: 136 Enqueue: 7262
+ID: 165 Len: 128 Enqueue: 7224
+ID: 166 Len: 16 Enqueue: 7295
+ID: 167 Len: 8 Enqueue: 7168
+ID: 168 Len: 8 Enqueue: 0
+ID: 169 Len: 48 Enqueue: 7120
+ID: 170 Len: 8 Enqueue: 0
+ID: 171 Len: 8 Enqueue: 6769
+ID: 172 Len: 8 Enqueue: 6913
+ID: 173 Len: 136 Enqueue: 6959
+ID: 174 Len: 32 Enqueue: 7536
+ID: 175 Len: 16 Enqueue: 7015
+ID: 176 Len: 8 Enqueue: 0
+ID: 177 Len: 136 Enqueue: 0
+ID: 178 Len: 128 Enqueue: 0
+ID: 179 Len: 16 Enqueue: 0
+ID: 180 Len: 8 Enqueue: 0
+ID: 181 Len: 8 Enqueue: 6877
+ID: 182 Len: 136 Enqueue: 0
+ID: 183 Len: 8 Enqueue: 6619
+ID: 184 Len: 128 Enqueue: 0
+ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
-ID: 187 Len: 0 Enqueue: 0
-ID: 188 Len: 33 Enqueue: 0
+ID: 187 Len: 17 Enqueue: 0
+ID: 188 Len: 0 Enqueue: 0
 ID: 189 Len: 0 Enqueue: 0
-ID: 190 Len: 25 Enqueue: 0
-ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 25 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 25 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
-ID: 196 Len: 49 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 49 Enqueue: 0
-ID: 199 Len: 17 Enqueue: 0
+ID: 190 Len: 0 Enqueue: 0
+ID: 191 Len: 33 Enqueue: 0
+ID: 192 Len: 0 Enqueue: 0
+ID: 193 Len: 25 Enqueue: 0
+ID: 194 Len: 0 Enqueue: 0
+ID: 195 Len: 25 Enqueue: 0
+ID: 196 Len: 0 Enqueue: 0
+ID: 197 Len: 25 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
+ID: 199 Len: 49 Enqueue: 0
 ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 17 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
+ID: 201 Len: 49 Enqueue: 0
+ID: 202 Len: 17 Enqueue: 0
 ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 0 Enqueue: 0
-ID: 205 Len: 17 Enqueue: 0
+ID: 204 Len: 17 Enqueue: 0
+ID: 205 Len: 0 Enqueue: 0
 ID: 206 Len: 0 Enqueue: 0
-ID: 207 Len: 18 Enqueue: 0
-ID: 208 Len: 0 Enqueue: 0
-ID: 209 Len: 17 Enqueue: 0
-ID: 210 Len: 0 Enqueue: 0
-ID: 211 Len: 19 Enqueue: 0
-ID: 212 Len: 0 Enqueue: 0
-ID: 213 Len: 17 Enqueue: 0
-ID: 214 Len: 0 Enqueue: 0
-ID: 215 Len: 17 Enqueue: 0
-ID: 216 Len: 0 Enqueue: 0
-ID: 217 Len: 21 Enqueue: 0
-ID: 218 Len: 0 Enqueue: 0
-ID: 219 Len: 17 Enqueue: 0
-ID: 220 Len: 0 Enqueue: 0
-ID: 221 Len: 25 Enqueue: 0
-ID: 222 Len: 0 Enqueue: 0
-ID: 223 Len: 17 Enqueue: 0
-ID: 224 Len: 0 Enqueue: 0
-ID: 225 Len: 17 Enqueue: 0
-ID: 226 Len: 0 Enqueue: 0
-ID: 227 Len: 18 Enqueue: 0
-ID: 228 Len: 0 Enqueue: 0
-ID: 229 Len: 17 Enqueue: 0
-ID: 230 Len: 0 Enqueue: 0
-ID: 231 Len: 19 Enqueue: 0
-ID: 232 Len: 0 Enqueue: 0
-ID: 233 Len: 17 Enqueue: 0
-ID: 234 Len: 0 Enqueue: 0
-ID: 235 Len: 21 Enqueue: 0
-ID: 236 Len: 0 Enqueue: 0
-ID: 237 Len: 17 Enqueue: 0
-ID: 238 Len: 0 Enqueue: 0
-ID: 239 Len: 25 Enqueue: 0
-ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 17 Enqueue: 0
-ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 17 Enqueue: 0
-ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 17 Enqueue: 0
-ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
-ID: 248 Len: 0 Enqueue: 0
-ID: 249 Len: 18 Enqueue: 0
-ID: 250 Len: 0 Enqueue: 0
-ID: 251 Len: 17 Enqueue: 0
-ID: 252 Len: 0 Enqueue: 0
-ID: 253 Len: 17 Enqueue: 0
-ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 33 Enqueue: 0
-ID: 256 Len: 0 Enqueue: 0
-ID: 257 Len: 33 Enqueue: 0
-ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 17 Enqueue: 0
-ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 17 Enqueue: 0
-ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 17 Enqueue: 0
-ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 17 Enqueue: 0
-ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 17 Enqueue: 0
-ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 97 Enqueue: 0
-ID: 270 Len: 0 Enqueue: 0
-ID: 271 Len: 17 Enqueue: 0
-ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 17 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 25 Enqueue: 0
-ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
-ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 25 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 9 Enqueue: 0
-ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 17 Enqueue: 0
+ID: 207 Len: 0 Enqueue: 0
+ID: 208 Len: 17 Enqueue: 0
+ID: 209 Len: 0 Enqueue: 0
+ID: 210 Len: 18 Enqueue: 0
+ID: 211 Len: 0 Enqueue: 0
+ID: 212 Len: 17 Enqueue: 0
+ID: 213 Len: 0 Enqueue: 0
+ID: 214 Len: 19 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
+ID: 216 Len: 17 Enqueue: 0
+ID: 217 Len: 0 Enqueue: 0
+ID: 218 Len: 17 Enqueue: 0
+ID: 219 Len: 0 Enqueue: 0
+ID: 220 Len: 21 Enqueue: 0
+ID: 221 Len: 0 Enqueue: 0
+ID: 222 Len: 17 Enqueue: 0
+ID: 223 Len: 0 Enqueue: 0
+ID: 224 Len: 25 Enqueue: 0
+ID: 225 Len: 0 Enqueue: 0
+ID: 226 Len: 17 Enqueue: 0
+ID: 227 Len: 0 Enqueue: 0
+ID: 228 Len: 17 Enqueue: 0
+ID: 229 Len: 0 Enqueue: 0
+ID: 230 Len: 18 Enqueue: 0
+ID: 231 Len: 0 Enqueue: 0
+ID: 232 Len: 17 Enqueue: 0
+ID: 233 Len: 0 Enqueue: 0
+ID: 234 Len: 19 Enqueue: 0
+ID: 235 Len: 0 Enqueue: 0
+ID: 236 Len: 17 Enqueue: 0
+ID: 237 Len: 0 Enqueue: 0
+ID: 238 Len: 21 Enqueue: 0
+ID: 239 Len: 0 Enqueue: 0
+ID: 240 Len: 17 Enqueue: 0
+ID: 241 Len: 0 Enqueue: 0
+ID: 242 Len: 25 Enqueue: 0
+ID: 243 Len: 0 Enqueue: 0
+ID: 244 Len: 17 Enqueue: 0
+ID: 245 Len: 0 Enqueue: 0
+ID: 246 Len: 17 Enqueue: 0
+ID: 247 Len: 0 Enqueue: 0
+ID: 248 Len: 17 Enqueue: 0
+ID: 249 Len: 0 Enqueue: 0
+ID: 250 Len: 17 Enqueue: 0
+ID: 251 Len: 0 Enqueue: 0
+ID: 252 Len: 18 Enqueue: 0
+ID: 253 Len: 0 Enqueue: 0
+ID: 254 Len: 17 Enqueue: 0
+ID: 255 Len: 0 Enqueue: 0
+ID: 256 Len: 17 Enqueue: 0
+ID: 257 Len: 0 Enqueue: 0
+ID: 258 Len: 33 Enqueue: 0
+ID: 259 Len: 0 Enqueue: 0
+ID: 260 Len: 33 Enqueue: 0
+ID: 261 Len: 0 Enqueue: 0
+ID: 262 Len: 17 Enqueue: 0
+ID: 263 Len: 0 Enqueue: 0
+ID: 264 Len: 17 Enqueue: 0
+ID: 265 Len: 0 Enqueue: 0
+ID: 266 Len: 17 Enqueue: 0
+ID: 267 Len: 0 Enqueue: 0
+ID: 268 Len: 17 Enqueue: 0
+ID: 269 Len: 0 Enqueue: 0
+ID: 270 Len: 17 Enqueue: 0
+ID: 271 Len: 0 Enqueue: 0
+ID: 272 Len: 97 Enqueue: 0
+ID: 273 Len: 0 Enqueue: 0
+ID: 274 Len: 17 Enqueue: 0
+ID: 275 Len: 0 Enqueue: 0
+ID: 276 Len: 17 Enqueue: 0
+ID: 277 Len: 0 Enqueue: 0
+ID: 278 Len: 25 Enqueue: 0
+ID: 279 Len: 0 Enqueue: 0
+ID: 280 Len: 17 Enqueue: 0
+ID: 281 Len: 0 Enqueue: 0
+ID: 282 Len: 25 Enqueue: 0
+ID: 283 Len: 0 Enqueue: 0
 ID: 284 Len: 9 Enqueue: 0
-ID: 285 Len: 25 Enqueue: 0
-ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 25 Enqueue: 0
-ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 17 Enqueue: 0
+ID: 285 Len: 0 Enqueue: 0
+ID: 286 Len: 17 Enqueue: 0
+ID: 287 Len: 9 Enqueue: 0
+ID: 288 Len: 25 Enqueue: 0
+ID: 289 Len: 0 Enqueue: 0
 ID: 290 Len: 25 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 9 Enqueue: 0
-ID: 293 Len: 9 Enqueue: 0
-ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 17 Enqueue: 0
+ID: 292 Len: 17 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 17 Enqueue: 0
+ID: 295 Len: 0 Enqueue: 0
 ID: 296 Len: 9 Enqueue: 0
+ID: 297 Len: 0 Enqueue: 0
+ID: 298 Len: 17 Enqueue: 0
+ID: 299 Len: 0 Enqueue: 0
+ID: 300 Len: 9 Enqueue: 0
+ID: 301 Len: 0 Enqueue: 0
+ID: 302 Len: 33 Enqueue: 0
+ID: 303 Len: 0 Enqueue: 0
+ID: 304 Len: 9 Enqueue: 0
+ID: 305 Len: 0 Enqueue: 0
+ID: 306 Len: 41 Enqueue: 0
+ID: 307 Len: 0 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 0 Enqueue: 0
+ID: 310 Len: 25 Enqueue: 0
+ID: 311 Len: 0 Enqueue: 0
+ID: 312 Len: 9 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 25 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 89 Enqueue: 0
+ID: 317 Len: 0 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 0 Enqueue: 0
+ID: 320 Len: 9 Enqueue: 0
+ID: 321 Len: 0 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 9 Enqueue: 0
+ID: 325 Len: 0 Enqueue: 0
+ID: 326 Len: 9 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 25 Enqueue: 0
+ID: 331 Len: 0 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 0 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0
+ID: 335 Len: 0 Enqueue: 0
+ID: 336 Len: 9 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 25 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 0 Enqueue: 0
+ID: 342 Len: 97 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
+ID: 347 Len: 9 Enqueue: 0
+ID: 348 Len: 9 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 17 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b5314]
-	PrepareEventRoot 5e 01 00 00 11 00 00 00 
+	PrepareEventRoot 6e 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb5314.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b534c]
-	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	PrepareEventRoot 6f 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb534c.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb6170.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 2c 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 83 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b6170]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b6918]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b6918]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb6918]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b6918]
 	PrepareEventRoot fc 00 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b67b8]
 	PrepareEventRoot f4 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b6868]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b6348]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb6348]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b6348]
 	PrepareEventRoot d6 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b63e8]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb63e8]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b63e8]
 	PrepareEventRoot dc 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b6488]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb6488]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b6488]
 	PrepareEventRoot e0 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b6298]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb6298]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b6298]
 	PrepareEventRoot d2 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb6eb4]
@@ -377,7 +377,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b6eb4]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb6ca8]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb6ca8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b6ca8]
 	PrepareEventRoot 1a 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b6e08]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb6e08]
@@ -470,7 +470,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b6e08]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
@@ -520,7 +520,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb6b8c]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb6b8c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b6b8c]
 	PrepareEventRoot 16 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b69c8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b69c8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@b69c8]
 	PrepareEventRoot 02 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0xb69c8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@b69c8]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb69c8]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb6a7c]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b7 1b 00 00 // ProcessType[main.condFields]
+	Call 0e 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb6a7c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@b6a7c]
 	PrepareEventRoot 10 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@b65d8]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb65d8]
@@ -877,7 +877,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@b65d8]
 	PrepareEventRoot ea 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@b6678]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb6678]
@@ -921,7 +921,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@b6678]
 	PrepareEventRoot ee 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@b6718]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb6718]
@@ -965,7 +965,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@b6718]
 	PrepareEventRoot f2 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@b6528]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@b6528]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb6528]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@b6528]
 	PrepareEventRoot e6 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@b5130]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb5130.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@b6038]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb6038.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@b6070]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0xb5d38.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ed 1a 00 00 // ProcessType[[3]string]
+	Call 44 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b6010]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
+	Call 84 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@b5e28]
 	PrepareEventRoot c1 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@b782c]
-	PrepareEventRoot 52 01 00 00 19 00 00 00 
+	PrepareEventRoot 62 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xb782c.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b7 1b 00 00 // ProcessType[main.condFields]
+	Call 0e 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@b792c]
-	PrepareEventRoot 56 01 00 00 61 00 00 00 
+	PrepareEventRoot 66 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xb792c.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@b782c]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@b78e0]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@b792c]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@b79fc]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@b739c]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb739c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@b739c]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 3c 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb739c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@b739c]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb739c]
+	PrepareEventRoot 3e 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@b739c]
-	PrepareEventRoot 36 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@b739c]
+	PrepareEventRoot 42 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb739c.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b745c]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b745c]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b74ac]
-	PrepareEventRoot 38 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 44 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*string]
+	Call e2 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b74ac]
-	PrepareEventRoot 3a 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b74ac]
+	PrepareEventRoot 46 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb74ac.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b7554]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.lenFields]
+	Call a0 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 4a 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 5a 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@b76ec]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xb76ec.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@b77e4]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@b728c]
-	PrepareEventRoot 30 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b728c]
-	PrepareEventRoot 32 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b734c]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb728c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@b718c]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b728c]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@b718c]
-	PrepareEventRoot 28 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 29 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0xb718c]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb728c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@b718c]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
-	PrepareEventRoot 2a 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@b728c]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb728c]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b7240]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@b718c]
-	PrepareEventRoot 2c 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 84 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@b728c]
+	PrepareEventRoot 38 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb728c.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b734c]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0xb718c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@b718c]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb718c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@b718c]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb718c]
+	PrepareEventRoot 2a 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@b7240]
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@b718c]
+	PrepareEventRoot 2c 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@b718c]
+// 0x1898: ProcessEvent[Probe[main.lenString]@b718c]
 	PrepareEventRoot 2e 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb718c.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@b7240]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b7240]
 	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call c2 1b 00 00 // ProcessType[main.lenFields]
+	Call 19 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 3c 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 48 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 44 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	PrepareEventRoot 52 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 54 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call e1 20 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 56 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb759c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,471 +1689,471 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b759c]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
-	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b759c]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb759c]
+	PrepareEventRoot 58 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb759c.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@b76b0]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bb 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bd 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@b60f8]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@b60f8]
 	PrepareEventRoot ca 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb60f8.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b6128]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b6128]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@b6228]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@b6228]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b6260]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b6260]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@b5da8]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@b5da8]
 	PrepareEventRoot bf 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb5da8.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b5de4]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b5de4]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ed 1a 00 00 // ProcessType[[3]string]
+	Call 44 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b5fa8]
 	PrepareEventRoot c7 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb5fa8.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b5fec]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 5b 1b 00 00 // ProcessType[[]string]
+	Call b2 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b5f28]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb5f28.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b5f64]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b7a40]
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 32 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 89 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
-	PrepareEventRoot 5b 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b7bc0]
+	PrepareEventRoot 6b 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb7bc0.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer b7 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 84 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 63 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*main.bigStruct]
+// 0x1d94: ProcessType[*main.bigStruct]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.condFields]
+// 0x1d9a: ProcessType[*main.condFields]
 	ProcessPointer 77 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.lenFields]
+// 0x1da0: ProcessType[*main.lenFields]
 	ProcessPointer 7a 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*runtime._defer]
+// 0x1da6: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._panic]
+// 0x1dac: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime.cgoCallers]
+// 0x1db2: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 3f 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.coro]
+// 0x1db8: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.g]
+// 0x1dbe: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.m]
+// 0x1dc4: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.sudog]
+// 0x1dca: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.synctestGroup]
+// 0x1dd0: ProcessType[*runtime.synctestGroup]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.timer]
+// 0x1dd6: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.traceBuf]
+// 0x1ddc: ProcessType[*runtime.traceBuf]
 	ProcessPointer 4d 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*string]
+// 0x1de2: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1de8: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*table<string,int>]
+// 0x1dee: ProcessType[*table<string,int>]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*table<string,main.bigStruct>]
+// 0x1df4: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 97 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1dfa: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*uint]
+// 0x1e00: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint16]
+// 0x1e06: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint32]
+// 0x1e0c: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint64]
+// 0x1e12: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint8]
+// 0x1e18: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uintptr]
+// 0x1e1e: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1acd: ProcessType[[2]*runtime.traceBuf]
+// 0x1e24: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call dc 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1add: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e34: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call cd 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 24 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1aed: ProcessType[[3]string]
+// 0x1e44: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1afd: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e54: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 91 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e8 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b09: ProcessType[[]*table<string,int>.array]
+// 0x1e60: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 97 1a 00 00 // ProcessType[*table<string,int>]
+	Call ee 1d 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b15: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e6c: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 9d 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f4 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b21: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e78: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call fa 1d 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b2d: ProcessType[[]int]
+// 0x1e84: ProcessType[[]int]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b37: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1e8e: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 68 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call bf 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b43: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1e9a: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 73 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call ca 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4f: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ea6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 7e 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call d5 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b5b: ProcessType[[]string]
+// 0x1eb2: ProcessType[[]string]
 	ProcessSlice 8d 00 00 00 10 00 00 00 
 	Return 
-// 0x1b65: ProcessType[[]string.array]
+// 0x1ebc: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b71: ProcessType[[]uint8]
+// 0x1ec8: ProcessType[[]uint8]
 	ProcessSlice 87 00 00 00 01 00 00 00 
 	Return 
-// 0x1b7b: ProcessType[[]uintptr]
+// 0x1ed2: ProcessType[[]uintptr]
 	ProcessSlice 89 00 00 00 08 00 00 00 
 	Return 
-// 0x1b85: ProcessType[error]
+// 0x1edc: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b87: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1ede: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b6 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b93: ProcessType[groupReference<string,int>]
+// 0x1eea: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 96 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b9f: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1ef6: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bab: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f02: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups ad 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bb7: ProcessType[main.condFields]
+// 0x1f0e: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1bc2: ProcessType[main.lenFields]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1f19: ProcessType[main.lenFields]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2d 1b 00 00 // ProcessType[[]int]
+	Call 84 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 26 1c 00 00 // ProcessType[map[string]int]
+	Call 7d 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*string]
+	Call e2 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bf0: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f47: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b5 00 00 00 b1 00 00 00 10 18 
 	Return 
-// 0x1bfc: ProcessType[map<string,int>]
+// 0x1f53: ProcessType[map<string,int>]
 	ProcessGoSwissMap 95 00 00 00 92 00 00 00 10 18 
 	Return 
-// 0x1c08: ProcessType[map<string,main.bigStruct>]
+// 0x1f5f: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap 9f 00 00 00 9a 00 00 00 10 18 
 	Return 
-// 0x1c14: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f6b: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ac 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c20: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f77: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer a9 00 00 00 
 	Return 
-// 0x1c26: ProcessType[map[string]int]
+// 0x1f7d: ProcessType[map[string]int]
 	ProcessPointer 6f 00 00 00 
 	Return 
-// 0x1c2c: ProcessType[map[string]main.bigStruct]
+// 0x1f83: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 74 00 00 00 
 	Return 
-// 0x1c32: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f89: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7f 00 00 00 
 	Return 
-// 0x1c38: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1f8f: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 89 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call e0 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c48: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1f9f: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 99 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call f0 1f 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c58: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1faf: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 9f 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call f6 1f 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c68: ProcessType[noalg.map.group[string]int]
+// 0x1fbf: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 9f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c73: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1fca: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 38 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 8f 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c7e: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fd5: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 58 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call af 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c89: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1fe0: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c99: ProcessType[noalg.struct { key string; elem int }]
-	Call 8a 1d 00 00 // ProcessType[string]
+// 0x1ff0: ProcessType[noalg.struct { key string; elem int }]
+	Call e1 20 00 00 // ProcessType[string]
 	Return 
-// 0x1c9f: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1ff6: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 20 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 77 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1caa: ProcessType[runtime.g]
+// 0x2001: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._panic]
+	Call ac 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
+	Call a6 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 71 1b 00 00 // ProcessType[[]uint8]
+	Call c8 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.sudog]
+	Call ca 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.timer]
+	Call d6 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.coro]
+	Call b8 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.synctestGroup]
+	Call d0 1d 00 00 // ProcessType[*runtime.synctestGroup]
 	Return 
-// 0x1d0f: ProcessType[runtime.m]
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+// 0x2066: ProcessType[runtime.m]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 50 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 8a 1d 00 00 // ProcessType[string]
+	Call e1 20 00 00 // ProcessType[string]
 	IncrementOutputOffset 40 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 28 01 00 00 
-	Call 6f 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call c6 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 38 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7a 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call d1 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d6f: ProcessType[runtime.mLockProfile]
+// 0x20c6: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7b 1b 00 00 // ProcessType[[]uintptr]
+	Call d2 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d7a: ProcessType[runtime.mTraceState]
+// 0x20d1: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call dd 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call 34 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d8a: ProcessType[string]
+// 0x20e1: ProcessType[string]
 	ProcessString 85 00 00 00 
 	Return 
-// 0x1d90: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x20e7: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call de 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1d9b: ProcessType[table<string,int>]
+// 0x20f2: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 93 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call ea 1e 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1da6: ProcessType[table<string,main.bigStruct>]
+// 0x20fd: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9f 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call f6 1e 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1db1: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2108: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ab 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 02 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2227,31 +2421,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6849
+ID: 5 Len: 8 Enqueue: 7704
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7562
+ID: 9 Len: 16 Enqueue: 8417
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6675
+ID: 11 Len: 8 Enqueue: 7530
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7045
+ID: 14 Len: 16 Enqueue: 7900
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 1 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 8 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6855
-ID: 20 Len: 8 Enqueue: 6705
-ID: 21 Len: 8 Enqueue: 6837
-ID: 22 Len: 440 Enqueue: 7338
+ID: 19 Len: 8 Enqueue: 7710
+ID: 20 Len: 8 Enqueue: 7560
+ID: 21 Len: 8 Enqueue: 7692
+ID: 22 Len: 440 Enqueue: 8193
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6741
+ID: 24 Len: 8 Enqueue: 7596
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6735
+ID: 26 Len: 8 Enqueue: 7590
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6765
-ID: 29 Len: 1808 Enqueue: 7439
+ID: 28 Len: 8 Enqueue: 7620
+ID: 29 Len: 1808 Enqueue: 8294
 ID: 30 Len: 56 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2260,45 +2454,45 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7025
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7880
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6771
+ID: 41 Len: 8 Enqueue: 7626
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7035
-ID: 44 Len: 8 Enqueue: 6783
+ID: 43 Len: 24 Enqueue: 7890
+ID: 44 Len: 8 Enqueue: 7638
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6753
+ID: 47 Len: 8 Enqueue: 7608
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6777
+ID: 49 Len: 8 Enqueue: 7632
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6759
+ID: 55 Len: 8 Enqueue: 7614
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 8 Enqueue: 6747
+ID: 62 Len: 8 Enqueue: 7602
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 256 Enqueue: 0
 ID: 66 Len: 8 Enqueue: 0
-ID: 67 Len: 64 Enqueue: 7535
+ID: 67 Len: 64 Enqueue: 8390
 ID: 68 Len: 8 Enqueue: 0
 ID: 69 Len: 0 Enqueue: 0
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 1 Enqueue: 0
-ID: 72 Len: 56 Enqueue: 7546
+ID: 72 Len: 56 Enqueue: 8401
 ID: 73 Len: 8 Enqueue: 0
-ID: 74 Len: 32 Enqueue: 6877
-ID: 75 Len: 16 Enqueue: 6861
-ID: 76 Len: 8 Enqueue: 6789
+ID: 74 Len: 32 Enqueue: 7732
+ID: 75 Len: 16 Enqueue: 7716
+ID: 76 Len: 8 Enqueue: 7644
 ID: 77 Len: 8 Enqueue: 0
 ID: 78 Len: 48 Enqueue: 0
 ID: 79 Len: 0 Enqueue: 0
@@ -2315,46 +2509,46 @@ ID: 89 Len: 160 Enqueue: 0
 ID: 90 Len: 16 Enqueue: 0
 ID: 91 Len: 8 Enqueue: 0
 ID: 92 Len: 0 Enqueue: 0
-ID: 93 Len: 8 Enqueue: 6795
+ID: 93 Len: 8 Enqueue: 7650
 ID: 94 Len: 2 Enqueue: 0
 ID: 95 Len: 8 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
-ID: 97 Len: 8 Enqueue: 6693
-ID: 98 Len: 8 Enqueue: 6711
-ID: 99 Len: 8 Enqueue: 6699
-ID: 100 Len: 8 Enqueue: 6843
-ID: 101 Len: 8 Enqueue: 6681
-ID: 102 Len: 8 Enqueue: 6687
-ID: 103 Len: 8 Enqueue: 6825
-ID: 104 Len: 8 Enqueue: 6831
-ID: 105 Len: 24 Enqueue: 6957
+ID: 97 Len: 8 Enqueue: 7548
+ID: 98 Len: 8 Enqueue: 7566
+ID: 99 Len: 8 Enqueue: 7554
+ID: 100 Len: 8 Enqueue: 7698
+ID: 101 Len: 8 Enqueue: 7536
+ID: 102 Len: 8 Enqueue: 7542
+ID: 103 Len: 8 Enqueue: 7680
+ID: 104 Len: 8 Enqueue: 7686
+ID: 105 Len: 24 Enqueue: 7812
 ID: 106 Len: 24 Enqueue: 0
-ID: 107 Len: 24 Enqueue: 7003
-ID: 108 Len: 48 Enqueue: 6893
-ID: 109 Len: 8 Enqueue: 7206
+ID: 107 Len: 24 Enqueue: 7858
+ID: 108 Len: 48 Enqueue: 7748
+ID: 109 Len: 8 Enqueue: 8061
 ID: 110 Len: 8 Enqueue: 0
-ID: 111 Len: 48 Enqueue: 7164
+ID: 111 Len: 48 Enqueue: 8019
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 8 Enqueue: 6807
-ID: 114 Len: 8 Enqueue: 7212
+ID: 113 Len: 8 Enqueue: 7662
+ID: 114 Len: 8 Enqueue: 8067
 ID: 115 Len: 8 Enqueue: 0
-ID: 116 Len: 48 Enqueue: 7176
+ID: 116 Len: 48 Enqueue: 8031
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 8 Enqueue: 6813
-ID: 119 Len: 80 Enqueue: 7095
+ID: 118 Len: 8 Enqueue: 7668
+ID: 119 Len: 80 Enqueue: 7950
 ID: 120 Len: 6 Enqueue: 0
-ID: 121 Len: 8 Enqueue: 6723
-ID: 122 Len: 72 Enqueue: 7106
-ID: 123 Len: 8 Enqueue: 6663
-ID: 124 Len: 8 Enqueue: 6729
-ID: 125 Len: 8 Enqueue: 7218
+ID: 121 Len: 8 Enqueue: 7578
+ID: 122 Len: 72 Enqueue: 7961
+ID: 123 Len: 8 Enqueue: 7518
+ID: 124 Len: 8 Enqueue: 7584
+ID: 125 Len: 8 Enqueue: 8073
 ID: 126 Len: 8 Enqueue: 0
-ID: 127 Len: 48 Enqueue: 7188
+ID: 127 Len: 48 Enqueue: 8043
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 8 Enqueue: 6819
-ID: 130 Len: 8 Enqueue: 6639
-ID: 131 Len: 8 Enqueue: 6645
-ID: 132 Len: 8 Enqueue: 6657
+ID: 129 Len: 8 Enqueue: 7674
+ID: 130 Len: 8 Enqueue: 7494
+ID: 131 Len: 8 Enqueue: 7500
+ID: 132 Len: 8 Enqueue: 7512
 ID: 133 Len: 1 Enqueue: 0
 ID: 134 Len: 8 Enqueue: 0
 ID: 135 Len: 1 Enqueue: 0
@@ -2363,49 +2557,49 @@ ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
-ID: 141 Len: 16 Enqueue: 7013
+ID: 141 Len: 16 Enqueue: 7868
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 32 Enqueue: 7579
-ID: 144 Len: 16 Enqueue: 7059
+ID: 143 Len: 32 Enqueue: 8434
+ID: 144 Len: 16 Enqueue: 7914
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 200 Enqueue: 7272
-ID: 147 Len: 192 Enqueue: 7240
-ID: 148 Len: 24 Enqueue: 7321
-ID: 149 Len: 8 Enqueue: 6921
-ID: 150 Len: 200 Enqueue: 6967
-ID: 151 Len: 32 Enqueue: 7590
-ID: 152 Len: 16 Enqueue: 7071
+ID: 146 Len: 200 Enqueue: 8127
+ID: 147 Len: 192 Enqueue: 8095
+ID: 148 Len: 24 Enqueue: 8176
+ID: 149 Len: 8 Enqueue: 7776
+ID: 150 Len: 200 Enqueue: 7822
+ID: 151 Len: 32 Enqueue: 8445
+ID: 152 Len: 16 Enqueue: 7926
 ID: 153 Len: 8 Enqueue: 0
-ID: 154 Len: 200 Enqueue: 7283
-ID: 155 Len: 192 Enqueue: 7224
-ID: 156 Len: 24 Enqueue: 7305
-ID: 157 Len: 8 Enqueue: 6717
+ID: 154 Len: 200 Enqueue: 8138
+ID: 155 Len: 192 Enqueue: 8079
+ID: 156 Len: 24 Enqueue: 8160
+ID: 157 Len: 8 Enqueue: 7572
 ID: 158 Len: 184 Enqueue: 0
-ID: 159 Len: 8 Enqueue: 6933
-ID: 160 Len: 200 Enqueue: 6979
-ID: 161 Len: 32 Enqueue: 7601
-ID: 162 Len: 16 Enqueue: 7083
+ID: 159 Len: 8 Enqueue: 7788
+ID: 160 Len: 200 Enqueue: 7834
+ID: 161 Len: 32 Enqueue: 8456
+ID: 162 Len: 16 Enqueue: 7938
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 136 Enqueue: 7294
-ID: 165 Len: 128 Enqueue: 7256
-ID: 166 Len: 16 Enqueue: 7327
-ID: 167 Len: 8 Enqueue: 7200
+ID: 164 Len: 136 Enqueue: 8149
+ID: 165 Len: 128 Enqueue: 8111
+ID: 166 Len: 16 Enqueue: 8182
+ID: 167 Len: 8 Enqueue: 8055
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 48 Enqueue: 7152
+ID: 169 Len: 48 Enqueue: 8007
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 8 Enqueue: 6801
-ID: 172 Len: 8 Enqueue: 6945
-ID: 173 Len: 136 Enqueue: 6991
-ID: 174 Len: 32 Enqueue: 7568
-ID: 175 Len: 16 Enqueue: 7047
+ID: 171 Len: 8 Enqueue: 7656
+ID: 172 Len: 8 Enqueue: 7800
+ID: 173 Len: 136 Enqueue: 7846
+ID: 174 Len: 32 Enqueue: 8423
+ID: 175 Len: 16 Enqueue: 7902
 ID: 176 Len: 8 Enqueue: 0
 ID: 177 Len: 136 Enqueue: 0
 ID: 178 Len: 128 Enqueue: 0
 ID: 179 Len: 16 Enqueue: 0
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6909
+ID: 181 Len: 8 Enqueue: 7764
 ID: 182 Len: 136 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 6651
+ID: 183 Len: 8 Enqueue: 7506
 ID: 184 Len: 128 Enqueue: 0
 ID: 185 Len: 9 Enqueue: 0
 ID: 186 Len: 0 Enqueue: 0
@@ -2526,51 +2720,67 @@ ID: 300 Len: 9 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
 ID: 302 Len: 33 Enqueue: 0
 ID: 303 Len: 0 Enqueue: 0
-ID: 304 Len: 9 Enqueue: 0
+ID: 304 Len: 17 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 41 Enqueue: 0
+ID: 306 Len: 9 Enqueue: 0
 ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 0 Enqueue: 0
+ID: 308 Len: 17 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 25 Enqueue: 0
+ID: 310 Len: 9 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 9 Enqueue: 0
+ID: 312 Len: 41 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 25 Enqueue: 0
+ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 89 Enqueue: 0
+ID: 316 Len: 9 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 0 Enqueue: 0
+ID: 318 Len: 17 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
 ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 9 Enqueue: 0
+ID: 322 Len: 25 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
 ID: 324 Len: 9 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 9 Enqueue: 0
+ID: 326 Len: 25 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 17 Enqueue: 0
+ID: 328 Len: 89 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
-ID: 330 Len: 25 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 0 Enqueue: 0
+ID: 332 Len: 9 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
 ID: 336 Len: 9 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 25 Enqueue: 0
+ID: 338 Len: 9 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 0 Enqueue: 0
+ID: 340 Len: 17 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 97 Enqueue: 0
+ID: 342 Len: 17 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 0 Enqueue: 0
+ID: 344 Len: 17 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
-ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 9 Enqueue: 0
+ID: 346 Len: 25 Enqueue: 0
+ID: 347 Len: 0 Enqueue: 0
 ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 17 Enqueue: 0
-ID: 351 Len: 9 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 9 Enqueue: 0
+ID: 353 Len: 0 Enqueue: 0
+ID: 354 Len: 25 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 0 Enqueue: 0
+ID: 358 Len: 97 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 0 Enqueue: 0
+ID: 363 Len: 9 Enqueue: 0
+ID: 364 Len: 9 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 17 Enqueue: 0
+ID: 367 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7eb0]
-	PrepareEventRoot 73 01 00 00 11 00 00 00 
+	PrepareEventRoot 83 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7ee8]
-	PrepareEventRoot 74 01 00 00 09 00 00 00 
+	PrepareEventRoot 84 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7ee8.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call be 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call be 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b8cb0]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b9408]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b9408]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b9408]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b92c8]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b9368]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b8e68]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb8e68]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b8e68]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b8f08]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8fa8]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8dc8]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b9934]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9934]
-	PrepareEventRoot 29 01 00 00 11 00 00 00 
+	PrepareEventRoot 2d 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b9934]
-	PrepareEventRoot 2a 01 00 00 19 00 00 00 
+	PrepareEventRoot 2e 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
-	PrepareEventRoot 1d 01 00 00 11 00 00 00 
+	PrepareEventRoot 21 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
-	PrepareEventRoot 1f 01 00 00 19 00 00 00 
+	PrepareEventRoot 23 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb9888]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b9888]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
-	PrepareEventRoot 25 01 00 00 19 00 00 00 
+	PrepareEventRoot 29 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@b98e0]
-	PrepareEventRoot 26 01 00 00 00 00 00 00 
+	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b9888]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2b 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@b98e0]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
-	PrepareEventRoot 17 01 00 00 11 00 00 00 
+	PrepareEventRoot 1b 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	PrepareEventRoot 1d 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.condFields]
+	Call b9 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
-	PrepareEventRoot 1b 01 00 00 19 00 00 00 
+	PrepareEventRoot 1f 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	PrepareEventRoot 25 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
-	PrepareEventRoot 23 01 00 00 11 00 00 00 
+	PrepareEventRoot 27 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
-	PrepareEventRoot 24 01 00 00 09 00 00 00 
+	PrepareEventRoot 28 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b94a8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b94a8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@b94a8]
+	PrepareEventRoot 07 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@b9504]
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@b94a8]
+	PrepareEventRoot 09 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@b9504]
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 26 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@b94a8]
-	PrepareEventRoot 07 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@b94a8]
+	PrepareEventRoot 0b 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@b9504]
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0xb11: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@b94a8]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
-	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@b94a8]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
+	PrepareEventRoot 0d 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@b9504]
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[main.condFields]
+	Call 49 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b954c]
-	PrepareEventRoot 15 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@b954c]
+	PrepareEventRoot 19 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb90e8]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@b90e8]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@b90e8]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b9140]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@b90e8]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@b90e8]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b9140]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb9188]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0xb9188]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@b9188]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@b9188]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b91e0]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@b9188]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@b9188]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b91e0]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb9228]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0xb9228]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@b9228]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@b9228]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b9280]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@b9228]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@b9228]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b9280]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@b9048]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e7 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@b9048]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@b9048]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@b9048]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@b7cd0]
-	PrepareEventRoot 71 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@b7cd0]
+	PrepareEventRoot 81 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@b8b78]
-	PrepareEventRoot 71 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b8bac]
-	PrepareEventRoot 72 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@b88a8]
+// 0x111f: ProcessEvent[Probe[main.inlined]@b8b78]
+	PrepareEventRoot 81 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@b8bac]
+	PrepareEventRoot 82 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@b88a8]
 	PrepareEventRoot be 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b88dc]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@b88dc]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b8a08]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@b8a08]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 4a 1e 00 00 // ProcessType[[3]string]
+	Call 69 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b8988]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@b8988]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
-	PrepareEventRoot 67 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+	PrepareEventRoot 77 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
-	PrepareEventRoot 68 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+	PrepareEventRoot 78 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[main.condFields]
+	Call 49 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
-	PrepareEventRoot 6b 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+	PrepareEventRoot 7b 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
-	PrepareEventRoot 6c 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+	PrepareEventRoot 7c 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
-	PrepareEventRoot 6a 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+	PrepareEventRoot 7a 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
-	PrepareEventRoot 6e 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+	PrepareEventRoot 7e 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb9dac]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0xb9dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@b9dac]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
-	PrepareEventRoot 3f 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@b9dac]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 4f 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@b9dac]
-	PrepareEventRoot 41 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb9dac]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0xb9dac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@b9dac]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
-	PrepareEventRoot 43 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@b9dac]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	PrepareEventRoot 53 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@b9dac]
-	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@b9dac]
-	PrepareEventRoot 47 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
-	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 59 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*string]
+	Call 07 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
-	PrepareEventRoot 4b 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 5b 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.lenFields]
+	Call bf 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 5f 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 6f 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 60 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 70 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 63 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 73 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 75 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 66 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 76 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
-	PrepareEventRoot 35 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+	PrepareEventRoot 41 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 43 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	PrepareEventRoot 37 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
-	PrepareEventRoot 39 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+	PrepareEventRoot 47 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	PrepareEventRoot 3b 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	PrepareEventRoot 3d 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 4b 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 2f 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 31 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 33 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 35 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 37 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@b9bdc]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 39 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
-	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 3b 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@b9bdc]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 32 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@b9bdc]
-	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 3f 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 34 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 35 1f 00 00 // ProcessType[main.lenFields]
+	Call 54 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 4d 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 5d 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 4f 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 5f 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 51 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 63 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 57 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 67 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
-	PrepareEventRoot 59 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 69 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
-	PrepareEventRoot 5b 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 6b 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,484 +1812,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
-	PrepareEventRoot 5d 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 6d 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@b8c38]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@b8c38]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b8c64]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@b8c64]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@b8d58]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@b8d58]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 4a 1e 00 00 // ProcessType[[3]string]
+	Call 69 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ce 1e 00 00 // ProcessType[[]string]
+	Call ed 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
-	PrepareEventRoot 6f 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
+	PrepareEventRoot 7f 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call c4 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
-	PrepareEventRoot 70 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
+	PrepareEventRoot 80 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*main.bigStruct]
+// 0x1fb3: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.condFields]
+// 0x1fb9: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.lenFields]
+// 0x1fbf: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*runtime._defer]
+// 0x1fc5: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._panic]
+// 0x1fcb: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime.cgoCallers]
+// 0x1fd1: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.coro]
+// 0x1fd7: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.g]
+// 0x1fdd: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.m]
+// 0x1fe3: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.p]
+// 0x1fe9: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.sudog]
+// 0x1fef: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.synctestBubble]
+// 0x1ff5: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.timer]
+// 0x1ffb: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.traceBuf]
+// 0x2001: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*string]
+// 0x2007: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x200d: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*table<string,int>]
+// 0x2013: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<string,main.bigStruct>]
+// 0x2019: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x201f: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*uint]
+// 0x2025: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*uint16]
+// 0x202b: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint32]
+// 0x2031: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint64]
+// 0x2037: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint8]
+// 0x203d: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uintptr]
+// 0x2043: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
+// 0x2049: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 01 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e3a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2059: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 49 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e4a: ProcessType[[3]string]
+// 0x2069: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e5a: ProcessType[[]*runtime.p]
+// 0x2079: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1e64: ProcessType[[]*runtime.p.array]
+// 0x2083: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call ca 1d 00 00 // ProcessType[*runtime.p]
+	Call e9 1f 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e70: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x208f: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call ee 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 0d 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7c: ProcessType[[]*table<string,int>.array]
+// 0x209b: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call f4 1d 00 00 // ProcessType[*table<string,int>]
+	Call 13 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e88: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x20a7: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 19 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e94: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x20b3: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 00 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1f 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]int]
+// 0x20bf: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1eaa: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20c9: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call db 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call fa 21 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20d5: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call e6 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 05 22 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ec2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20e1: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call f1 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 10 22 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ece: ProcessType[[]string]
+// 0x20ed: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1ed8: ProcessType[[]string.array]
+// 0x20f7: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ee4: ProcessType[[]uint8]
+// 0x2103: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1eee: ProcessType[[]uintptr]
+// 0x210d: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1ef8: ProcessType[error]
+// 0x2117: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1efa: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x2119: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f06: ProcessType[groupReference<string,int>]
+// 0x2125: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f12: ProcessType[groupReference<string,main.bigStruct>]
+// 0x2131: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f1e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x213d: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f2a: ProcessType[main.condFields]
+// 0x2149: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f35: ProcessType[main.lenFields]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x2154: ProcessType[main.lenFields]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call a0 1e 00 00 // ProcessType[[]int]
+	Call bf 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 99 1f 00 00 // ProcessType[map[string]int]
+	Call b8 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*string]
+	Call 07 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f63: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x2182: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1f6f: ProcessType[map<string,int>]
+// 0x218e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1f7b: ProcessType[map<string,main.bigStruct>]
+// 0x219a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1f87: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x21a6: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1f93: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21b2: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1f99: ProcessType[map[string]int]
+// 0x21b8: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1f9f: ProcessType[map[string]main.bigStruct]
+// 0x21be: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1fa5: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21c4: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1fab: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21ca: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call fc 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 1b 22 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fbb: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21da: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 0c 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 2b 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1fcb: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21ea: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 12 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 31 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fdb: ProcessType[noalg.map.group[string]int]
+// 0x21fa: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call bb 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call da 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1fe6: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x2205: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call ab 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ca 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ff1: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x2210: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call cb 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call ea 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1ffc: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x221b: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b3 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x200c: ProcessType[noalg.struct { key string; elem int }]
-	Call 07 21 00 00 // ProcessType[string]
+// 0x222b: ProcessType[noalg.struct { key string; elem int }]
+	Call 26 23 00 00 // ProcessType[string]
 	Return 
-// 0x2012: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2231: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call b2 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x201d: ProcessType[runtime.g]
+// 0x223c: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._panic]
+	Call cb 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*runtime._defer]
+	Call c5 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call e4 1e 00 00 // ProcessType[[]uint8]
+	Call 03 21 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d0 1d 00 00 // ProcessType[*runtime.sudog]
+	Call ef 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.timer]
+	Call fb 1f 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.coro]
+	Call d7 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.synctestBubble]
+	Call f5 1f 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x2082: ProcessType[runtime.m]
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+// 0x22a1: ProcessType[runtime.m]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.g]
+	Call dd 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 07 21 00 00 // ProcessType[string]
+	Call 26 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 5a 1e 00 00 // ProcessType[[]*runtime.p]
+	Call 79 20 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d1 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call ec 20 00 00 // ProcessType[runtime.mLockProfile]
+	Call 0b 23 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call f7 20 00 00 // ProcessType[runtime.mTraceState]
+	Call 16 23 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x20ec: ProcessType[runtime.mLockProfile]
+// 0x230b: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call ee 1e 00 00 // ProcessType[[]uintptr]
+	Call 0d 21 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x20f7: ProcessType[runtime.mTraceState]
+// 0x2316: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3a 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call c4 1d 00 00 // ProcessType[*runtime.m]
+	Call 59 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e3 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x2107: ProcessType[string]
+// 0x2326: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x210d: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x232c: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call fa 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 21 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x2118: ProcessType[table<string,int>]
+// 0x2337: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 1f 00 00 // ProcessType[groupReference<string,int>]
+	Call 25 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x2123: ProcessType[table<string,main.bigStruct>]
+// 0x2342: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 12 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 31 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x212e: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x234d: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1e 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 3d 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2434,31 +2557,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7710
+ID: 5 Len: 8 Enqueue: 8253
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8455
+ID: 9 Len: 16 Enqueue: 8998
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 7530
+ID: 11 Len: 8 Enqueue: 8073
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7928
+ID: 14 Len: 16 Enqueue: 8471
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 7716
-ID: 20 Len: 8 Enqueue: 7560
-ID: 21 Len: 8 Enqueue: 7698
-ID: 22 Len: 440 Enqueue: 8221
+ID: 19 Len: 8 Enqueue: 8259
+ID: 20 Len: 8 Enqueue: 8103
+ID: 21 Len: 8 Enqueue: 8241
+ID: 22 Len: 440 Enqueue: 8764
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 7596
+ID: 24 Len: 8 Enqueue: 8139
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 7590
+ID: 26 Len: 8 Enqueue: 8133
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 7620
-ID: 29 Len: 1816 Enqueue: 8322
+ID: 28 Len: 8 Enqueue: 8163
+ID: 29 Len: 1816 Enqueue: 8865
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2467,48 +2590,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7908
-ID: 39 Len: 8 Enqueue: 7524
+ID: 38 Len: 24 Enqueue: 8451
+ID: 39 Len: 8 Enqueue: 8067
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 7632
+ID: 41 Len: 8 Enqueue: 8175
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7918
-ID: 44 Len: 8 Enqueue: 7644
+ID: 43 Len: 24 Enqueue: 8461
+ID: 44 Len: 8 Enqueue: 8187
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 7608
+ID: 47 Len: 8 Enqueue: 8151
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 7638
+ID: 49 Len: 8 Enqueue: 8181
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 7614
+ID: 55 Len: 8 Enqueue: 8157
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 7770
+ID: 62 Len: 24 Enqueue: 8313
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 7626
-ID: 65 Len: 8 Enqueue: 7602
+ID: 64 Len: 8 Enqueue: 8169
+ID: 65 Len: 8 Enqueue: 8145
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 8428
+ID: 70 Len: 56 Enqueue: 8971
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 8439
+ID: 75 Len: 56 Enqueue: 8982
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 7738
-ID: 78 Len: 16 Enqueue: 7722
-ID: 79 Len: 8 Enqueue: 7650
+ID: 77 Len: 32 Enqueue: 8281
+ID: 78 Len: 16 Enqueue: 8265
+ID: 79 Len: 8 Enqueue: 8193
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2524,46 +2647,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 7656
+ID: 95 Len: 8 Enqueue: 8199
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 7548
-ID: 100 Len: 8 Enqueue: 7554
-ID: 101 Len: 8 Enqueue: 7704
-ID: 102 Len: 8 Enqueue: 7566
-ID: 103 Len: 8 Enqueue: 7536
-ID: 104 Len: 8 Enqueue: 7542
-ID: 105 Len: 8 Enqueue: 7686
-ID: 106 Len: 8 Enqueue: 7692
-ID: 107 Len: 24 Enqueue: 7840
+ID: 99 Len: 8 Enqueue: 8091
+ID: 100 Len: 8 Enqueue: 8097
+ID: 101 Len: 8 Enqueue: 8247
+ID: 102 Len: 8 Enqueue: 8109
+ID: 103 Len: 8 Enqueue: 8079
+ID: 104 Len: 8 Enqueue: 8085
+ID: 105 Len: 8 Enqueue: 8229
+ID: 106 Len: 8 Enqueue: 8235
+ID: 107 Len: 24 Enqueue: 8383
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 7886
-ID: 110 Len: 48 Enqueue: 7754
-ID: 111 Len: 8 Enqueue: 8089
+ID: 109 Len: 24 Enqueue: 8429
+ID: 110 Len: 48 Enqueue: 8297
+ID: 111 Len: 8 Enqueue: 8632
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 8047
+ID: 113 Len: 48 Enqueue: 8590
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 7668
-ID: 116 Len: 8 Enqueue: 8095
+ID: 115 Len: 8 Enqueue: 8211
+ID: 116 Len: 8 Enqueue: 8638
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 8059
+ID: 118 Len: 48 Enqueue: 8602
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 7674
-ID: 121 Len: 80 Enqueue: 7978
+ID: 120 Len: 8 Enqueue: 8217
+ID: 121 Len: 80 Enqueue: 8521
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 7578
-ID: 124 Len: 72 Enqueue: 7989
-ID: 125 Len: 8 Enqueue: 7518
-ID: 126 Len: 8 Enqueue: 7584
-ID: 127 Len: 8 Enqueue: 8101
+ID: 123 Len: 8 Enqueue: 8121
+ID: 124 Len: 72 Enqueue: 8532
+ID: 125 Len: 8 Enqueue: 8061
+ID: 126 Len: 8 Enqueue: 8127
+ID: 127 Len: 8 Enqueue: 8644
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 8071
+ID: 129 Len: 48 Enqueue: 8614
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 7680
-ID: 132 Len: 8 Enqueue: 7494
-ID: 133 Len: 8 Enqueue: 7500
-ID: 134 Len: 8 Enqueue: 7512
+ID: 131 Len: 8 Enqueue: 8223
+ID: 132 Len: 8 Enqueue: 8037
+ID: 133 Len: 8 Enqueue: 8043
+ID: 134 Len: 8 Enqueue: 8055
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2571,53 +2694,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 7780
+ID: 142 Len: 8 Enqueue: 8323
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7896
+ID: 146 Len: 16 Enqueue: 8439
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 8472
-ID: 149 Len: 16 Enqueue: 7942
+ID: 148 Len: 32 Enqueue: 9015
+ID: 149 Len: 16 Enqueue: 8485
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 8155
-ID: 152 Len: 192 Enqueue: 8123
-ID: 153 Len: 24 Enqueue: 8204
-ID: 154 Len: 8 Enqueue: 7804
-ID: 155 Len: 200 Enqueue: 7850
-ID: 156 Len: 32 Enqueue: 8483
-ID: 157 Len: 16 Enqueue: 7954
+ID: 151 Len: 200 Enqueue: 8698
+ID: 152 Len: 192 Enqueue: 8666
+ID: 153 Len: 24 Enqueue: 8747
+ID: 154 Len: 8 Enqueue: 8347
+ID: 155 Len: 200 Enqueue: 8393
+ID: 156 Len: 32 Enqueue: 9026
+ID: 157 Len: 16 Enqueue: 8497
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 8166
-ID: 160 Len: 192 Enqueue: 8107
-ID: 161 Len: 24 Enqueue: 8188
-ID: 162 Len: 8 Enqueue: 7572
+ID: 159 Len: 200 Enqueue: 8709
+ID: 160 Len: 192 Enqueue: 8650
+ID: 161 Len: 24 Enqueue: 8731
+ID: 162 Len: 8 Enqueue: 8115
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 7816
-ID: 165 Len: 200 Enqueue: 7862
-ID: 166 Len: 32 Enqueue: 8494
-ID: 167 Len: 16 Enqueue: 7966
+ID: 164 Len: 8 Enqueue: 8359
+ID: 165 Len: 200 Enqueue: 8405
+ID: 166 Len: 32 Enqueue: 9037
+ID: 167 Len: 16 Enqueue: 8509
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 8177
-ID: 170 Len: 128 Enqueue: 8139
-ID: 171 Len: 16 Enqueue: 8210
-ID: 172 Len: 8 Enqueue: 8083
+ID: 169 Len: 136 Enqueue: 8720
+ID: 170 Len: 128 Enqueue: 8682
+ID: 171 Len: 16 Enqueue: 8753
+ID: 172 Len: 8 Enqueue: 8626
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 8035
+ID: 174 Len: 48 Enqueue: 8578
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 7662
-ID: 177 Len: 8 Enqueue: 7828
-ID: 178 Len: 136 Enqueue: 7874
-ID: 179 Len: 32 Enqueue: 8461
-ID: 180 Len: 16 Enqueue: 7930
+ID: 176 Len: 8 Enqueue: 8205
+ID: 177 Len: 8 Enqueue: 8371
+ID: 178 Len: 136 Enqueue: 8417
+ID: 179 Len: 32 Enqueue: 9004
+ID: 180 Len: 16 Enqueue: 8473
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 7792
+ID: 186 Len: 8 Enqueue: 8335
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 7506
+ID: 188 Len: 8 Enqueue: 8049
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
@@ -2692,13 +2815,13 @@ ID: 259 Len: 17 Enqueue: 0
 ID: 260 Len: 0 Enqueue: 0
 ID: 261 Len: 17 Enqueue: 0
 ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 33 Enqueue: 0
+ID: 263 Len: 2 Enqueue: 0
 ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 33 Enqueue: 0
+ID: 265 Len: 2 Enqueue: 0
 ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 17 Enqueue: 0
+ID: 267 Len: 33 Enqueue: 0
 ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
+ID: 269 Len: 33 Enqueue: 0
 ID: 270 Len: 0 Enqueue: 0
 ID: 271 Len: 17 Enqueue: 0
 ID: 272 Len: 0 Enqueue: 0
@@ -2706,81 +2829,81 @@ ID: 273 Len: 17 Enqueue: 0
 ID: 274 Len: 0 Enqueue: 0
 ID: 275 Len: 17 Enqueue: 0
 ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 97 Enqueue: 0
+ID: 277 Len: 17 Enqueue: 0
 ID: 278 Len: 0 Enqueue: 0
 ID: 279 Len: 17 Enqueue: 0
 ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
+ID: 281 Len: 97 Enqueue: 0
 ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 25 Enqueue: 0
+ID: 283 Len: 17 Enqueue: 0
 ID: 284 Len: 0 Enqueue: 0
 ID: 285 Len: 17 Enqueue: 0
 ID: 286 Len: 0 Enqueue: 0
 ID: 287 Len: 25 Enqueue: 0
 ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 9 Enqueue: 0
+ID: 289 Len: 17 Enqueue: 0
 ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 17 Enqueue: 0
-ID: 292 Len: 9 Enqueue: 0
-ID: 293 Len: 25 Enqueue: 0
+ID: 291 Len: 25 Enqueue: 0
+ID: 292 Len: 0 Enqueue: 0
+ID: 293 Len: 9 Enqueue: 0
 ID: 294 Len: 0 Enqueue: 0
-ID: 295 Len: 25 Enqueue: 0
-ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 17 Enqueue: 0
-ID: 298 Len: 25 Enqueue: 0
-ID: 299 Len: 17 Enqueue: 0
+ID: 295 Len: 17 Enqueue: 0
+ID: 296 Len: 9 Enqueue: 0
+ID: 297 Len: 25 Enqueue: 0
+ID: 298 Len: 0 Enqueue: 0
+ID: 299 Len: 25 Enqueue: 0
 ID: 300 Len: 0 Enqueue: 0
-ID: 301 Len: 9 Enqueue: 0
-ID: 302 Len: 0 Enqueue: 0
-ID: 303 Len: 17 Enqueue: 0
+ID: 301 Len: 17 Enqueue: 0
+ID: 302 Len: 25 Enqueue: 0
+ID: 303 Len: 2 Enqueue: 0
 ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 9 Enqueue: 0
+ID: 305 Len: 2 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
-ID: 307 Len: 33 Enqueue: 0
+ID: 307 Len: 2 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
 ID: 309 Len: 17 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 9 Enqueue: 0
+ID: 311 Len: 2 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 17 Enqueue: 0
+ID: 313 Len: 9 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 9 Enqueue: 0
+ID: 315 Len: 17 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 41 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
-ID: 319 Len: 17 Enqueue: 0
+ID: 319 Len: 33 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 9 Enqueue: 0
+ID: 321 Len: 17 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 17 Enqueue: 0
+ID: 323 Len: 2 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
 ID: 325 Len: 9 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 25 Enqueue: 0
+ID: 327 Len: 17 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
 ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
-ID: 331 Len: 25 Enqueue: 0
+ID: 331 Len: 41 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 89 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
-ID: 335 Len: 9 Enqueue: 0
+ID: 335 Len: 2 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
 ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
-ID: 339 Len: 9 Enqueue: 0
+ID: 339 Len: 17 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
 ID: 341 Len: 9 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 9 Enqueue: 0
+ID: 343 Len: 25 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 17 Enqueue: 0
+ID: 345 Len: 9 Enqueue: 0
 ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 17 Enqueue: 0
+ID: 347 Len: 25 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 17 Enqueue: 0
+ID: 349 Len: 89 Enqueue: 0
 ID: 350 Len: 0 Enqueue: 0
-ID: 351 Len: 25 Enqueue: 0
+ID: 351 Len: 9 Enqueue: 0
 ID: 352 Len: 0 Enqueue: 0
 ID: 353 Len: 9 Enqueue: 0
 ID: 354 Len: 0 Enqueue: 0
@@ -2788,17 +2911,33 @@ ID: 355 Len: 9 Enqueue: 0
 ID: 356 Len: 0 Enqueue: 0
 ID: 357 Len: 9 Enqueue: 0
 ID: 358 Len: 0 Enqueue: 0
-ID: 359 Len: 25 Enqueue: 0
+ID: 359 Len: 9 Enqueue: 0
 ID: 360 Len: 0 Enqueue: 0
-ID: 361 Len: 0 Enqueue: 0
+ID: 361 Len: 17 Enqueue: 0
 ID: 362 Len: 0 Enqueue: 0
-ID: 363 Len: 97 Enqueue: 0
+ID: 363 Len: 17 Enqueue: 0
 ID: 364 Len: 0 Enqueue: 0
-ID: 365 Len: 0 Enqueue: 0
+ID: 365 Len: 17 Enqueue: 0
 ID: 366 Len: 0 Enqueue: 0
-ID: 367 Len: 0 Enqueue: 0
-ID: 368 Len: 9 Enqueue: 0
+ID: 367 Len: 25 Enqueue: 0
+ID: 368 Len: 0 Enqueue: 0
 ID: 369 Len: 9 Enqueue: 0
 ID: 370 Len: 0 Enqueue: 0
-ID: 371 Len: 17 Enqueue: 0
-ID: 372 Len: 9 Enqueue: 0
+ID: 371 Len: 9 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 9 Enqueue: 0
+ID: 374 Len: 0 Enqueue: 0
+ID: 375 Len: 25 Enqueue: 0
+ID: 376 Len: 0 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 0 Enqueue: 0
+ID: 379 Len: 97 Enqueue: 0
+ID: 380 Len: 0 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 0 Enqueue: 0
+ID: 383 Len: 0 Enqueue: 0
+ID: 384 Len: 9 Enqueue: 0
+ID: 385 Len: 9 Enqueue: 0
+ID: 386 Len: 0 Enqueue: 0
+ID: 387 Len: 17 Enqueue: 0
+ID: 388 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7eb0]
-	PrepareEventRoot 2c 01 00 00 11 00 00 00 
+	PrepareEventRoot 63 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7ee8]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	PrepareEventRoot 64 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7ee8.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b8cb0]
-	PrepareEventRoot ce 00 00 00 11 00 00 00 
+	PrepareEventRoot d1 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b8d20]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0xb9408]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b9408]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
-	PrepareEventRoot fa 00 00 00 11 00 00 00 
+	PrepareEventRoot fd 00 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@b9468]
-	PrepareEventRoot fb 00 00 00 00 00 00 00 
+	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0xb9408]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b9408]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
-	PrepareEventRoot fc 00 00 00 11 00 00 00 
+	PrepareEventRoot ff 00 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@b9468]
-	PrepareEventRoot fd 00 00 00 00 00 00 00 
+	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b9408]
-	PrepareEventRoot fe 00 00 00 12 00 00 00 
+	PrepareEventRoot 01 01 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@b9468]
-	PrepareEventRoot ff 00 00 00 00 00 00 00 
+	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb92c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b92c8]
-	PrepareEventRoot f6 00 00 00 11 00 00 00 
+	PrepareEventRoot f9 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb92c8.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b9324]
-	PrepareEventRoot f7 00 00 00 00 00 00 00 
+	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0xb9368.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b9368]
-	PrepareEventRoot f8 00 00 00 11 00 00 00 
+	PrepareEventRoot fb 00 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb9368.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@b93c4]
-	PrepareEventRoot f9 00 00 00 00 00 00 00 
+	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0xb8e68]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b8e68]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb8e68]
-	PrepareEventRoot d6 00 00 00 11 00 00 00 
+	PrepareEventRoot d9 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@b8ec0]
-	PrepareEventRoot d7 00 00 00 00 00 00 00 
+	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b8e68]
-	PrepareEventRoot d8 00 00 00 13 00 00 00 
+	PrepareEventRoot db 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b8ec0]
-	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
-	PrepareEventRoot da 00 00 00 11 00 00 00 
+	PrepareEventRoot dd 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@b8f60]
-	PrepareEventRoot db 00 00 00 00 00 00 00 
+	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
-	PrepareEventRoot dc 00 00 00 11 00 00 00 
+	PrepareEventRoot df 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@b8f60]
-	PrepareEventRoot dd 00 00 00 00 00 00 00 
+	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b8f08]
-	PrepareEventRoot de 00 00 00 15 00 00 00 
+	PrepareEventRoot e1 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b8f60]
-	PrepareEventRoot df 00 00 00 00 00 00 00 
+	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb8fa8]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8fa8]
-	PrepareEventRoot e0 00 00 00 11 00 00 00 
+	PrepareEventRoot e3 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@b9000]
-	PrepareEventRoot e1 00 00 00 00 00 00 00 
+	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b8fa8]
-	PrepareEventRoot e2 00 00 00 19 00 00 00 
+	PrepareEventRoot e5 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b9000]
-	PrepareEventRoot e3 00 00 00 00 00 00 00 
+	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb8dc8]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8dc8]
-	PrepareEventRoot d2 00 00 00 11 00 00 00 
+	PrepareEventRoot d5 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b8e28]
-	PrepareEventRoot d3 00 00 00 00 00 00 00 
+	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b8dc8]
-	PrepareEventRoot d4 00 00 00 12 00 00 00 
+	PrepareEventRoot d7 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@b8e28]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0xb9934]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b9934]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9934]
-	PrepareEventRoot 26 01 00 00 11 00 00 00 
+	PrepareEventRoot 29 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b9934]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2a 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
-	PrepareEventRoot 1a 01 00 00 11 00 00 00 
+	PrepareEventRoot 1d 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
-	PrepareEventRoot 1c 01 00 00 19 00 00 00 
+	PrepareEventRoot 1f 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb9888]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@b9888]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
-	PrepareEventRoot 22 01 00 00 19 00 00 00 
+	PrepareEventRoot 25 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@b98e0]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@b9888]
-	PrepareEventRoot 24 01 00 00 19 00 00 00 
+	PrepareEventRoot 27 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@b98e0]
-	PrepareEventRoot 25 01 00 00 00 00 00 00 
+	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	PrepareEventRoot 17 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	PrepareEventRoot 19 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.condFields]
+	Call 23 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
-	PrepareEventRoot 18 01 00 00 19 00 00 00 
+	PrepareEventRoot 1b 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
-	PrepareEventRoot 1e 01 00 00 09 00 00 00 
+	PrepareEventRoot 21 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
-	PrepareEventRoot 1f 01 00 00 00 00 00 00 
+	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
-	PrepareEventRoot 20 01 00 00 11 00 00 00 
+	PrepareEventRoot 23 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
-	PrepareEventRoot 21 01 00 00 09 00 00 00 
+	PrepareEventRoot 24 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@b94a8]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
-	PrepareEventRoot 00 01 00 00 11 00 00 00 
+	PrepareEventRoot 03 01 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 01 01 00 00 00 00 00 00 
+	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@b94a8]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
-	PrepareEventRoot 02 01 00 00 11 00 00 00 
+	PrepareEventRoot 05 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 03 01 00 00 00 00 00 00 
+	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@b94a8]
-	PrepareEventRoot 04 01 00 00 21 00 00 00 
+	PrepareEventRoot 07 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 05 01 00 00 00 00 00 00 
+	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@b94a8]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
-	PrepareEventRoot 06 01 00 00 21 00 00 00 
+	PrepareEventRoot 09 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@b9504]
-	PrepareEventRoot 07 01 00 00 00 00 00 00 
+	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 08 01 00 00 11 00 00 00 
+	PrepareEventRoot 0b 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 09 01 00 00 00 00 00 00 
+	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0a 01 00 00 11 00 00 00 
+	PrepareEventRoot 0d 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 0b 01 00 00 00 00 00 00 
+	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0c 01 00 00 11 00 00 00 
+	PrepareEventRoot 0f 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 0e 01 00 00 11 00 00 00 
+	PrepareEventRoot 11 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
+	PrepareEventRoot 13 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 17 15 00 00 // ProcessType[main.condFields]
+	Call b3 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@b954c]
-	PrepareEventRoot 12 01 00 00 61 00 00 00 
+	PrepareEventRoot 15 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b9600]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@b90e8]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
-	PrepareEventRoot ea 00 00 00 11 00 00 00 
+	PrepareEventRoot ed 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b9140]
-	PrepareEventRoot eb 00 00 00 00 00 00 00 
+	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@b90e8]
-	PrepareEventRoot ec 00 00 00 13 00 00 00 
+	PrepareEventRoot ef 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@b9140]
-	PrepareEventRoot ed 00 00 00 00 00 00 00 
+	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0xb9188]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@b9188]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
-	PrepareEventRoot ee 00 00 00 11 00 00 00 
+	PrepareEventRoot f1 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b91e0]
-	PrepareEventRoot ef 00 00 00 00 00 00 00 
+	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@b9188]
-	PrepareEventRoot f0 00 00 00 15 00 00 00 
+	PrepareEventRoot f3 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@b91e0]
-	PrepareEventRoot f1 00 00 00 00 00 00 00 
+	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb9228]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@b9228]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
-	PrepareEventRoot f2 00 00 00 11 00 00 00 
+	PrepareEventRoot f5 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@b9280]
-	PrepareEventRoot f3 00 00 00 00 00 00 00 
+	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@b9228]
-	PrepareEventRoot f4 00 00 00 19 00 00 00 
+	PrepareEventRoot f7 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@b9280]
-	PrepareEventRoot f5 00 00 00 00 00 00 00 
+	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@b9048]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
-	PrepareEventRoot e4 00 00 00 11 00 00 00 
+	PrepareEventRoot e7 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b90a8]
-	PrepareEventRoot e5 00 00 00 00 00 00 00 
+	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@b9048]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
-	PrepareEventRoot e6 00 00 00 11 00 00 00 
+	PrepareEventRoot e9 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@b90a8]
-	PrepareEventRoot e7 00 00 00 00 00 00 00 
+	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@b9048]
-	PrepareEventRoot e8 00 00 00 12 00 00 00 
+	PrepareEventRoot eb 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@b90a8]
-	PrepareEventRoot e9 00 00 00 00 00 00 00 
+	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@b7cd0]
-	PrepareEventRoot 2a 01 00 00 09 00 00 00 
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@b8b78]
-	PrepareEventRoot 2a 01 00 00 09 00 00 00 
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@b8bac]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@b88a8]
-	PrepareEventRoot bb 00 00 00 09 00 00 00 
+	PrepareEventRoot be 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@b88dc]
-	PrepareEventRoot bc 00 00 00 00 00 00 00 
+	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b8a08]
-	PrepareEventRoot c5 00 00 00 19 00 00 00 
+	PrepareEventRoot c8 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
-	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 37 14 00 00 // ProcessType[[3]string]
+	Call d3 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
-	PrepareEventRoot cb 00 00 00 31 00 00 00 
+	PrepareEventRoot ce 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
@@ -1104,461 +1104,875 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 8d 14 00 00 // ProcessType[[]int]
+	Call 29 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@b8988]
-	PrepareEventRoot c3 00 00 00 19 00 00 00 
+	PrepareEventRoot c6 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@b8918]
-	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b8950]
-	PrepareEventRoot be 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@b8918]
-	PrepareEventRoot bf 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b8950]
-	PrepareEventRoot c0 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 58 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@b8c38]
-	PrepareEventRoot cc 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b8c64]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@b8d58]
-	PrepareEventRoot d0 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
-	PrepareEventRoot d1 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call b3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@b8918]
-	PrepareEventRoot c1 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+	PrepareEventRoot 5b 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b8950]
-	PrepareEventRoot c2 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 37 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
-	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
-	PrepareEventRoot ca 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 3b 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 3d 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 71 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 3f 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 4f 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 53 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 35 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call bb 14 00 00 // ProcessType[[]string]
+	Call 29 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
-	PrepareEventRoot c7 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
-	PrepareEventRoot c8 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 37 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 2f 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 32 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 33 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 34 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call be 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 41 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 47 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 4b 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 4d 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@b8918]
+	PrepareEventRoot c0 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b8950]
+	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@b8918]
+	PrepareEventRoot c2 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b8950]
+	PrepareEventRoot c3 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
-	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 82 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@b8c38]
+	PrepareEventRoot cf 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer b9 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b8c64]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 83 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@b8d58]
+	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
+	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call 90 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@b8918]
+	PrepareEventRoot c4 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b8950]
+	PrepareEventRoot c5 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call d3 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
+	PrepareEventRoot cc 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
+	PrepareEventRoot cd 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 57 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
+	PrepareEventRoot ca 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
+	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
+	PrepareEventRoot 60 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 85 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer bc 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 86 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 6b 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1387: ProcessType[*main.bigStruct]
-	ProcessPointer a0 00 00 00 
-	Return 
-// 0x138d: ProcessType[*main.condFields]
-	ProcessPointer 79 00 00 00 
-	Return 
-// 0x1393: ProcessType[*runtime._defer]
-	ProcessPointer 1b 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._panic]
-	ProcessPointer 19 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 42 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.coro]
-	ProcessPointer 30 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.g]
-	ProcessPointer 16 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.m]
-	ProcessPointer 1d 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.p]
-	ProcessPointer 8a 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.sudog]
-	ProcessPointer 2a 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.synctestBubble]
-	ProcessPointer 32 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.timer]
-	ProcessPointer 2d 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.traceBuf]
-	ProcessPointer 50 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13db: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer b0 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*table<string,int>]
-	ProcessPointer 91 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 99 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a1d: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x13f3: ProcessType[*uint]
+// 0x1a23: ProcessType[*main.condFields]
+	ProcessPointer 79 00 00 00 
+	Return 
+// 0x1a29: ProcessType[*main.lenFields]
+	ProcessPointer 7c 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*runtime._defer]
+	ProcessPointer 1b 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._panic]
+	ProcessPointer 19 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 42 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.coro]
+	ProcessPointer 30 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.g]
+	ProcessPointer 16 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.m]
+	ProcessPointer 1d 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.p]
+	ProcessPointer 8d 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.sudog]
+	ProcessPointer 2a 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.synctestBubble]
+	ProcessPointer 32 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.timer]
+	ProcessPointer 2d 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.traceBuf]
+	ProcessPointer 50 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer b3 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*table<string,int>]
+	ProcessPointer 94 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer 9c 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer a6 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x13f9: ProcessType[*uint16]
+// 0x1a95: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint32]
+// 0x1a9b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint64]
+// 0x1aa1: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uint8]
+// 0x1aa7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1411: ProcessType[*uintptr]
+// 0x1aad: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1417: ProcessType[[2]*runtime.traceBuf]
+// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 6b 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1427: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1ac3: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1437: ProcessType[[3]string]
+// 0x1ad3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1447: ProcessType[[]*runtime.p]
+// 0x1ae3: ProcessType[[]*runtime.p]
+	ProcessSlice 8e 00 00 00 08 00 00 00 
+	Return 
+// 0x1aed: ProcessType[[]*runtime.p.array]
+	ProcessSliceDataPrep 
+	Call 53 1a 00 00 // ProcessType[*runtime.p]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1af9: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 77 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b05: ProcessType[[]*table<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 7d 1a 00 00 // ProcessType[*table<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b11: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 83 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b1d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 89 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]int]
+	ProcessSlice 90 00 00 00 08 00 00 00 
+	Return 
+// 0x1b33: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 64 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 6f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b4b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+	ProcessSliceDataPrep 
+	Call 7a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b57: ProcessType[[]string]
+	ProcessSlice 92 00 00 00 10 00 00 00 
+	Return 
+// 0x1b61: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call 90 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b6d: ProcessType[[]uint8]
+	ProcessSlice 89 00 00 00 01 00 00 00 
+	Return 
+// 0x1b77: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1451: ProcessType[[]*runtime.p.array]
-	ProcessSliceDataPrep 
-	Call b7 13 00 00 // ProcessType[*runtime.p]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x145d: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call db 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1469: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call e1 13 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1475: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1481: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call ed 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]int]
-	ProcessSlice 8d 00 00 00 08 00 00 00 
-	Return 
-// 0x1497: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call 9a 15 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call a5 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14af: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
-	ProcessSliceDataPrep 
-	Call b0 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14bb: ProcessType[[]string]
-	ProcessSlice 8f 00 00 00 10 00 00 00 
-	Return 
-// 0x14c5: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call c6 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14d1: ProcessType[[]uint8]
-	ProcessSlice 86 00 00 00 01 00 00 00 
-	Return 
-// 0x14db: ProcessType[[]uintptr]
-	ProcessSlice 88 00 00 00 08 00 00 00 
-	Return 
-// 0x14e5: ProcessType[error]
+// 0x1b81: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14e7: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b8 00 00 00 88 00 00 00 00 08 
+// 0x1b83: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14f3: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 98 00 00 00 c8 00 00 00 00 08 
+// 0x1b8f: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x14ff: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups a2 00 00 00 c8 00 00 00 00 08 
+// 0x1b9b: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x150b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
+// 0x1ba7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1517: ProcessType[main.condFields]
+// 0x1bb3: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1522: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b7 00 00 00 b3 00 00 00 10 18 
+// 0x1bbe: ProcessType[main.lenFields]
+	Call 90 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 29 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 22 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 71 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x152e: ProcessType[map<string,int>]
-	ProcessGoSwissMap 97 00 00 00 94 00 00 00 10 18 
+// 0x1bec: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x153a: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap a1 00 00 00 9c 00 00 00 10 18 
+// 0x1bf8: ProcessType[map<string,int>]
+	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1546: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap ae 00 00 00 a6 00 00 00 10 18 
+// 0x1c04: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1552: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer ab 00 00 00 
+// 0x1c10: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1558: ProcessType[map[string]int]
+// 0x1c1c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer ae 00 00 00 
+	Return 
+// 0x1c22: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x155e: ProcessType[map[string]main.bigStruct]
+// 0x1c28: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1564: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 7e 00 00 00 
+// 0x1c2e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 81 00 00 00 
 	Return 
-// 0x156a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c34: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call bb 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 85 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x157a: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c44: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call cb 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 95 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x158a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c54: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call d1 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 9b 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x159a: ProcessType[noalg.map.group[string]int]
+// 0x1c64: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 44 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15a5: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c6f: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 34 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15b0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c7a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 8a 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15bb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call c6 16 00 00 // ProcessType[string]
+// 0x1c85: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 90 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 87 13 00 00 // ProcessType[*main.bigStruct]
+	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15cb: ProcessType[noalg.struct { key string; elem int }]
-	Call c6 16 00 00 // ProcessType[string]
+// 0x1c95: ProcessType[noalg.struct { key string; elem int }]
+	Call 90 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15d1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c9b: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 52 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 1c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15dc: ProcessType[runtime.g]
+// 0x1ca6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._panic]
+	Call 35 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 93 13 00 00 // ProcessType[*runtime._defer]
+	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call d1 14 00 00 // ProcessType[[]uint8]
+	Call 6d 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call bd 13 00 00 // ProcessType[*runtime.sudog]
+	Call 59 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.timer]
+	Call 65 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.coro]
+	Call 41 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 5f 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1641: ProcessType[runtime.m]
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+// 0x1d0b: ProcessType[runtime.m]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.g]
+	Call 47 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call c6 16 00 00 // ProcessType[string]
+	Call 90 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 47 14 00 00 // ProcessType[[]*runtime.p]
+	Call e3 1a 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call ab 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 75 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 16 00 00 // ProcessType[runtime.mTraceState]
+	Call 80 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16ab: ProcessType[runtime.mLockProfile]
+// 0x1d75: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call db 14 00 00 // ProcessType[[]uintptr]
+	Call 77 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16b6: ProcessType[runtime.mTraceState]
+// 0x1d80: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 27 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b1 13 00 00 // ProcessType[*runtime.m]
+	Call c3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 4d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16c6: ProcessType[string]
-	ProcessString 84 00 00 00 
+// 0x1d90: ProcessType[string]
+	ProcessString 87 00 00 00 
 	Return 
-// 0x16cc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1d96: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call e7 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 83 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16d7: ProcessType[table<string,int>]
+// 0x1da1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f3 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 8f 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x16e2: ProcessType[table<string,main.bigStruct>]
+// 0x1dac: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ff 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 9b 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x16ed: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1db7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0b 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1826,31 +2240,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5131
+ID: 5 Len: 8 Enqueue: 6823
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5830
+ID: 9 Len: 16 Enqueue: 7568
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4957
+ID: 11 Len: 8 Enqueue: 6643
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 5349
+ID: 14 Len: 16 Enqueue: 7041
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5137
-ID: 20 Len: 8 Enqueue: 4987
-ID: 21 Len: 8 Enqueue: 5119
-ID: 22 Len: 440 Enqueue: 5596
+ID: 19 Len: 8 Enqueue: 6829
+ID: 20 Len: 8 Enqueue: 6673
+ID: 21 Len: 8 Enqueue: 6811
+ID: 22 Len: 440 Enqueue: 7334
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5017
+ID: 24 Len: 8 Enqueue: 6709
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5011
+ID: 26 Len: 8 Enqueue: 6703
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5041
-ID: 29 Len: 1816 Enqueue: 5697
+ID: 28 Len: 8 Enqueue: 6733
+ID: 29 Len: 1816 Enqueue: 7435
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1859,48 +2273,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5329
-ID: 39 Len: 8 Enqueue: 4951
+ID: 38 Len: 24 Enqueue: 7021
+ID: 39 Len: 8 Enqueue: 6637
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5053
+ID: 41 Len: 8 Enqueue: 6745
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5339
-ID: 44 Len: 8 Enqueue: 5065
+ID: 43 Len: 24 Enqueue: 7031
+ID: 44 Len: 8 Enqueue: 6757
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5029
+ID: 47 Len: 8 Enqueue: 6721
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5059
+ID: 49 Len: 8 Enqueue: 6751
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5035
+ID: 55 Len: 8 Enqueue: 6727
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 5191
+ID: 62 Len: 24 Enqueue: 6883
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 5047
-ID: 65 Len: 8 Enqueue: 5023
+ID: 64 Len: 8 Enqueue: 6739
+ID: 65 Len: 8 Enqueue: 6715
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 5803
+ID: 70 Len: 56 Enqueue: 7541
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5814
+ID: 75 Len: 56 Enqueue: 7552
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 5159
-ID: 78 Len: 16 Enqueue: 5143
-ID: 79 Len: 8 Enqueue: 5071
+ID: 77 Len: 32 Enqueue: 6851
+ID: 78 Len: 16 Enqueue: 6835
+ID: 79 Len: 8 Enqueue: 6763
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -1916,210 +2330,265 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 5077
+ID: 95 Len: 8 Enqueue: 6769
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 4975
-ID: 100 Len: 8 Enqueue: 4981
-ID: 101 Len: 8 Enqueue: 5125
-ID: 102 Len: 8 Enqueue: 4993
-ID: 103 Len: 8 Enqueue: 4963
-ID: 104 Len: 8 Enqueue: 4969
-ID: 105 Len: 8 Enqueue: 5107
-ID: 106 Len: 8 Enqueue: 5113
-ID: 107 Len: 24 Enqueue: 5261
+ID: 99 Len: 8 Enqueue: 6661
+ID: 100 Len: 8 Enqueue: 6667
+ID: 101 Len: 8 Enqueue: 6817
+ID: 102 Len: 8 Enqueue: 6679
+ID: 103 Len: 8 Enqueue: 6649
+ID: 104 Len: 8 Enqueue: 6655
+ID: 105 Len: 8 Enqueue: 6799
+ID: 106 Len: 8 Enqueue: 6805
+ID: 107 Len: 24 Enqueue: 6953
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 5307
-ID: 110 Len: 48 Enqueue: 5175
-ID: 111 Len: 8 Enqueue: 5464
+ID: 109 Len: 24 Enqueue: 6999
+ID: 110 Len: 48 Enqueue: 6867
+ID: 111 Len: 8 Enqueue: 7202
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5422
+ID: 113 Len: 48 Enqueue: 7160
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 5089
-ID: 116 Len: 8 Enqueue: 5470
+ID: 115 Len: 8 Enqueue: 6781
+ID: 116 Len: 8 Enqueue: 7208
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5434
+ID: 118 Len: 48 Enqueue: 7172
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5095
-ID: 121 Len: 80 Enqueue: 5399
+ID: 120 Len: 8 Enqueue: 6787
+ID: 121 Len: 80 Enqueue: 7091
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 5005
-ID: 124 Len: 8 Enqueue: 5476
-ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5446
-ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5101
-ID: 129 Len: 8 Enqueue: 4927
-ID: 130 Len: 8 Enqueue: 4933
-ID: 131 Len: 8 Enqueue: 4945
-ID: 132 Len: 1 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 1 Enqueue: 0
-ID: 135 Len: 8 Enqueue: 0
+ID: 123 Len: 8 Enqueue: 6691
+ID: 124 Len: 72 Enqueue: 7102
+ID: 125 Len: 8 Enqueue: 6631
+ID: 126 Len: 8 Enqueue: 6697
+ID: 127 Len: 8 Enqueue: 7214
+ID: 128 Len: 8 Enqueue: 0
+ID: 129 Len: 48 Enqueue: 7184
+ID: 130 Len: 8 Enqueue: 0
+ID: 131 Len: 8 Enqueue: 6793
+ID: 132 Len: 8 Enqueue: 6607
+ID: 133 Len: 8 Enqueue: 6613
+ID: 134 Len: 8 Enqueue: 6625
+ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
-ID: 137 Len: 8 Enqueue: 0
+ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 8 Enqueue: 5201
+ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 5317
+ID: 142 Len: 8 Enqueue: 6893
+ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 32 Enqueue: 5847
-ID: 146 Len: 16 Enqueue: 5363
+ID: 145 Len: 8 Enqueue: 0
+ID: 146 Len: 16 Enqueue: 7009
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 5530
-ID: 149 Len: 192 Enqueue: 5498
-ID: 150 Len: 24 Enqueue: 5579
-ID: 151 Len: 8 Enqueue: 5225
-ID: 152 Len: 200 Enqueue: 5271
-ID: 153 Len: 32 Enqueue: 5858
-ID: 154 Len: 16 Enqueue: 5375
-ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 5541
-ID: 157 Len: 192 Enqueue: 5482
-ID: 158 Len: 24 Enqueue: 5563
-ID: 159 Len: 8 Enqueue: 4999
-ID: 160 Len: 184 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 5237
-ID: 162 Len: 200 Enqueue: 5283
-ID: 163 Len: 32 Enqueue: 5869
-ID: 164 Len: 16 Enqueue: 5387
-ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 136 Enqueue: 5552
-ID: 167 Len: 128 Enqueue: 5514
-ID: 168 Len: 16 Enqueue: 5585
-ID: 169 Len: 8 Enqueue: 5458
-ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 48 Enqueue: 5410
-ID: 172 Len: 8 Enqueue: 0
-ID: 173 Len: 8 Enqueue: 5083
-ID: 174 Len: 8 Enqueue: 5249
-ID: 175 Len: 136 Enqueue: 5295
-ID: 176 Len: 32 Enqueue: 5836
-ID: 177 Len: 16 Enqueue: 5351
-ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 136 Enqueue: 0
-ID: 180 Len: 128 Enqueue: 0
-ID: 181 Len: 16 Enqueue: 0
-ID: 182 Len: 8 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 5213
-ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 8 Enqueue: 4939
-ID: 186 Len: 128 Enqueue: 0
-ID: 187 Len: 9 Enqueue: 0
-ID: 188 Len: 0 Enqueue: 0
-ID: 189 Len: 17 Enqueue: 0
-ID: 190 Len: 0 Enqueue: 0
+ID: 148 Len: 32 Enqueue: 7585
+ID: 149 Len: 16 Enqueue: 7055
+ID: 150 Len: 8 Enqueue: 0
+ID: 151 Len: 200 Enqueue: 7268
+ID: 152 Len: 192 Enqueue: 7236
+ID: 153 Len: 24 Enqueue: 7317
+ID: 154 Len: 8 Enqueue: 6917
+ID: 155 Len: 200 Enqueue: 6963
+ID: 156 Len: 32 Enqueue: 7596
+ID: 157 Len: 16 Enqueue: 7067
+ID: 158 Len: 8 Enqueue: 0
+ID: 159 Len: 200 Enqueue: 7279
+ID: 160 Len: 192 Enqueue: 7220
+ID: 161 Len: 24 Enqueue: 7301
+ID: 162 Len: 8 Enqueue: 6685
+ID: 163 Len: 184 Enqueue: 0
+ID: 164 Len: 8 Enqueue: 6929
+ID: 165 Len: 200 Enqueue: 6975
+ID: 166 Len: 32 Enqueue: 7607
+ID: 167 Len: 16 Enqueue: 7079
+ID: 168 Len: 8 Enqueue: 0
+ID: 169 Len: 136 Enqueue: 7290
+ID: 170 Len: 128 Enqueue: 7252
+ID: 171 Len: 16 Enqueue: 7323
+ID: 172 Len: 8 Enqueue: 7196
+ID: 173 Len: 8 Enqueue: 0
+ID: 174 Len: 48 Enqueue: 7148
+ID: 175 Len: 8 Enqueue: 0
+ID: 176 Len: 8 Enqueue: 6775
+ID: 177 Len: 8 Enqueue: 6941
+ID: 178 Len: 136 Enqueue: 6987
+ID: 179 Len: 32 Enqueue: 7574
+ID: 180 Len: 16 Enqueue: 7043
+ID: 181 Len: 8 Enqueue: 0
+ID: 182 Len: 136 Enqueue: 0
+ID: 183 Len: 128 Enqueue: 0
+ID: 184 Len: 16 Enqueue: 0
+ID: 185 Len: 8 Enqueue: 0
+ID: 186 Len: 8 Enqueue: 6905
+ID: 187 Len: 136 Enqueue: 0
+ID: 188 Len: 8 Enqueue: 6619
+ID: 189 Len: 128 Enqueue: 0
+ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
-ID: 192 Len: 0 Enqueue: 0
-ID: 193 Len: 33 Enqueue: 0
+ID: 192 Len: 17 Enqueue: 0
+ID: 193 Len: 0 Enqueue: 0
 ID: 194 Len: 0 Enqueue: 0
-ID: 195 Len: 25 Enqueue: 0
-ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 25 Enqueue: 0
-ID: 198 Len: 0 Enqueue: 0
-ID: 199 Len: 25 Enqueue: 0
-ID: 200 Len: 0 Enqueue: 0
-ID: 201 Len: 49 Enqueue: 0
-ID: 202 Len: 0 Enqueue: 0
-ID: 203 Len: 49 Enqueue: 0
-ID: 204 Len: 17 Enqueue: 0
+ID: 195 Len: 0 Enqueue: 0
+ID: 196 Len: 33 Enqueue: 0
+ID: 197 Len: 0 Enqueue: 0
+ID: 198 Len: 25 Enqueue: 0
+ID: 199 Len: 0 Enqueue: 0
+ID: 200 Len: 25 Enqueue: 0
+ID: 201 Len: 0 Enqueue: 0
+ID: 202 Len: 25 Enqueue: 0
+ID: 203 Len: 0 Enqueue: 0
+ID: 204 Len: 49 Enqueue: 0
 ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 17 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
+ID: 206 Len: 49 Enqueue: 0
+ID: 207 Len: 17 Enqueue: 0
 ID: 208 Len: 0 Enqueue: 0
-ID: 209 Len: 0 Enqueue: 0
-ID: 210 Len: 17 Enqueue: 0
+ID: 209 Len: 17 Enqueue: 0
+ID: 210 Len: 0 Enqueue: 0
 ID: 211 Len: 0 Enqueue: 0
-ID: 212 Len: 18 Enqueue: 0
-ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 17 Enqueue: 0
-ID: 215 Len: 0 Enqueue: 0
-ID: 216 Len: 19 Enqueue: 0
-ID: 217 Len: 0 Enqueue: 0
-ID: 218 Len: 17 Enqueue: 0
-ID: 219 Len: 0 Enqueue: 0
-ID: 220 Len: 17 Enqueue: 0
-ID: 221 Len: 0 Enqueue: 0
-ID: 222 Len: 21 Enqueue: 0
-ID: 223 Len: 0 Enqueue: 0
-ID: 224 Len: 17 Enqueue: 0
-ID: 225 Len: 0 Enqueue: 0
-ID: 226 Len: 25 Enqueue: 0
-ID: 227 Len: 0 Enqueue: 0
-ID: 228 Len: 17 Enqueue: 0
-ID: 229 Len: 0 Enqueue: 0
-ID: 230 Len: 17 Enqueue: 0
-ID: 231 Len: 0 Enqueue: 0
-ID: 232 Len: 18 Enqueue: 0
-ID: 233 Len: 0 Enqueue: 0
-ID: 234 Len: 17 Enqueue: 0
-ID: 235 Len: 0 Enqueue: 0
-ID: 236 Len: 19 Enqueue: 0
-ID: 237 Len: 0 Enqueue: 0
-ID: 238 Len: 17 Enqueue: 0
-ID: 239 Len: 0 Enqueue: 0
-ID: 240 Len: 21 Enqueue: 0
-ID: 241 Len: 0 Enqueue: 0
-ID: 242 Len: 17 Enqueue: 0
-ID: 243 Len: 0 Enqueue: 0
-ID: 244 Len: 25 Enqueue: 0
-ID: 245 Len: 0 Enqueue: 0
-ID: 246 Len: 17 Enqueue: 0
-ID: 247 Len: 0 Enqueue: 0
-ID: 248 Len: 17 Enqueue: 0
-ID: 249 Len: 0 Enqueue: 0
-ID: 250 Len: 17 Enqueue: 0
-ID: 251 Len: 0 Enqueue: 0
-ID: 252 Len: 17 Enqueue: 0
-ID: 253 Len: 0 Enqueue: 0
-ID: 254 Len: 18 Enqueue: 0
-ID: 255 Len: 0 Enqueue: 0
-ID: 256 Len: 17 Enqueue: 0
-ID: 257 Len: 0 Enqueue: 0
-ID: 258 Len: 17 Enqueue: 0
-ID: 259 Len: 0 Enqueue: 0
-ID: 260 Len: 33 Enqueue: 0
-ID: 261 Len: 0 Enqueue: 0
-ID: 262 Len: 33 Enqueue: 0
-ID: 263 Len: 0 Enqueue: 0
-ID: 264 Len: 17 Enqueue: 0
-ID: 265 Len: 0 Enqueue: 0
-ID: 266 Len: 17 Enqueue: 0
-ID: 267 Len: 0 Enqueue: 0
-ID: 268 Len: 17 Enqueue: 0
-ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 17 Enqueue: 0
-ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
-ID: 273 Len: 0 Enqueue: 0
-ID: 274 Len: 97 Enqueue: 0
-ID: 275 Len: 0 Enqueue: 0
-ID: 276 Len: 17 Enqueue: 0
-ID: 277 Len: 0 Enqueue: 0
-ID: 278 Len: 17 Enqueue: 0
-ID: 279 Len: 0 Enqueue: 0
-ID: 280 Len: 25 Enqueue: 0
-ID: 281 Len: 0 Enqueue: 0
-ID: 282 Len: 17 Enqueue: 0
-ID: 283 Len: 0 Enqueue: 0
-ID: 284 Len: 25 Enqueue: 0
-ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 9 Enqueue: 0
-ID: 287 Len: 0 Enqueue: 0
-ID: 288 Len: 17 Enqueue: 0
+ID: 212 Len: 0 Enqueue: 0
+ID: 213 Len: 17 Enqueue: 0
+ID: 214 Len: 0 Enqueue: 0
+ID: 215 Len: 18 Enqueue: 0
+ID: 216 Len: 0 Enqueue: 0
+ID: 217 Len: 17 Enqueue: 0
+ID: 218 Len: 0 Enqueue: 0
+ID: 219 Len: 19 Enqueue: 0
+ID: 220 Len: 0 Enqueue: 0
+ID: 221 Len: 17 Enqueue: 0
+ID: 222 Len: 0 Enqueue: 0
+ID: 223 Len: 17 Enqueue: 0
+ID: 224 Len: 0 Enqueue: 0
+ID: 225 Len: 21 Enqueue: 0
+ID: 226 Len: 0 Enqueue: 0
+ID: 227 Len: 17 Enqueue: 0
+ID: 228 Len: 0 Enqueue: 0
+ID: 229 Len: 25 Enqueue: 0
+ID: 230 Len: 0 Enqueue: 0
+ID: 231 Len: 17 Enqueue: 0
+ID: 232 Len: 0 Enqueue: 0
+ID: 233 Len: 17 Enqueue: 0
+ID: 234 Len: 0 Enqueue: 0
+ID: 235 Len: 18 Enqueue: 0
+ID: 236 Len: 0 Enqueue: 0
+ID: 237 Len: 17 Enqueue: 0
+ID: 238 Len: 0 Enqueue: 0
+ID: 239 Len: 19 Enqueue: 0
+ID: 240 Len: 0 Enqueue: 0
+ID: 241 Len: 17 Enqueue: 0
+ID: 242 Len: 0 Enqueue: 0
+ID: 243 Len: 21 Enqueue: 0
+ID: 244 Len: 0 Enqueue: 0
+ID: 245 Len: 17 Enqueue: 0
+ID: 246 Len: 0 Enqueue: 0
+ID: 247 Len: 25 Enqueue: 0
+ID: 248 Len: 0 Enqueue: 0
+ID: 249 Len: 17 Enqueue: 0
+ID: 250 Len: 0 Enqueue: 0
+ID: 251 Len: 17 Enqueue: 0
+ID: 252 Len: 0 Enqueue: 0
+ID: 253 Len: 17 Enqueue: 0
+ID: 254 Len: 0 Enqueue: 0
+ID: 255 Len: 17 Enqueue: 0
+ID: 256 Len: 0 Enqueue: 0
+ID: 257 Len: 18 Enqueue: 0
+ID: 258 Len: 0 Enqueue: 0
+ID: 259 Len: 17 Enqueue: 0
+ID: 260 Len: 0 Enqueue: 0
+ID: 261 Len: 17 Enqueue: 0
+ID: 262 Len: 0 Enqueue: 0
+ID: 263 Len: 33 Enqueue: 0
+ID: 264 Len: 0 Enqueue: 0
+ID: 265 Len: 33 Enqueue: 0
+ID: 266 Len: 0 Enqueue: 0
+ID: 267 Len: 17 Enqueue: 0
+ID: 268 Len: 0 Enqueue: 0
+ID: 269 Len: 17 Enqueue: 0
+ID: 270 Len: 0 Enqueue: 0
+ID: 271 Len: 17 Enqueue: 0
+ID: 272 Len: 0 Enqueue: 0
+ID: 273 Len: 17 Enqueue: 0
+ID: 274 Len: 0 Enqueue: 0
+ID: 275 Len: 17 Enqueue: 0
+ID: 276 Len: 0 Enqueue: 0
+ID: 277 Len: 97 Enqueue: 0
+ID: 278 Len: 0 Enqueue: 0
+ID: 279 Len: 17 Enqueue: 0
+ID: 280 Len: 0 Enqueue: 0
+ID: 281 Len: 17 Enqueue: 0
+ID: 282 Len: 0 Enqueue: 0
+ID: 283 Len: 25 Enqueue: 0
+ID: 284 Len: 0 Enqueue: 0
+ID: 285 Len: 17 Enqueue: 0
+ID: 286 Len: 0 Enqueue: 0
+ID: 287 Len: 25 Enqueue: 0
+ID: 288 Len: 0 Enqueue: 0
 ID: 289 Len: 9 Enqueue: 0
-ID: 290 Len: 25 Enqueue: 0
-ID: 291 Len: 0 Enqueue: 0
-ID: 292 Len: 25 Enqueue: 0
-ID: 293 Len: 0 Enqueue: 0
-ID: 294 Len: 17 Enqueue: 0
+ID: 290 Len: 0 Enqueue: 0
+ID: 291 Len: 17 Enqueue: 0
+ID: 292 Len: 9 Enqueue: 0
+ID: 293 Len: 25 Enqueue: 0
+ID: 294 Len: 0 Enqueue: 0
 ID: 295 Len: 25 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 9 Enqueue: 0
-ID: 298 Len: 9 Enqueue: 0
-ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 17 Enqueue: 0
+ID: 297 Len: 17 Enqueue: 0
+ID: 298 Len: 25 Enqueue: 0
+ID: 299 Len: 17 Enqueue: 0
+ID: 300 Len: 0 Enqueue: 0
 ID: 301 Len: 9 Enqueue: 0
+ID: 302 Len: 0 Enqueue: 0
+ID: 303 Len: 17 Enqueue: 0
+ID: 304 Len: 0 Enqueue: 0
+ID: 305 Len: 9 Enqueue: 0
+ID: 306 Len: 0 Enqueue: 0
+ID: 307 Len: 33 Enqueue: 0
+ID: 308 Len: 0 Enqueue: 0
+ID: 309 Len: 9 Enqueue: 0
+ID: 310 Len: 0 Enqueue: 0
+ID: 311 Len: 41 Enqueue: 0
+ID: 312 Len: 0 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 0 Enqueue: 0
+ID: 315 Len: 25 Enqueue: 0
+ID: 316 Len: 0 Enqueue: 0
+ID: 317 Len: 9 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 25 Enqueue: 0
+ID: 320 Len: 0 Enqueue: 0
+ID: 321 Len: 89 Enqueue: 0
+ID: 322 Len: 0 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 0 Enqueue: 0
+ID: 325 Len: 9 Enqueue: 0
+ID: 326 Len: 0 Enqueue: 0
+ID: 327 Len: 9 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 9 Enqueue: 0
+ID: 330 Len: 0 Enqueue: 0
+ID: 331 Len: 9 Enqueue: 0
+ID: 332 Len: 0 Enqueue: 0
+ID: 333 Len: 17 Enqueue: 0
+ID: 334 Len: 0 Enqueue: 0
+ID: 335 Len: 25 Enqueue: 0
+ID: 336 Len: 0 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 0 Enqueue: 0
+ID: 339 Len: 9 Enqueue: 0
+ID: 340 Len: 0 Enqueue: 0
+ID: 341 Len: 9 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 25 Enqueue: 0
+ID: 344 Len: 0 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 0 Enqueue: 0
+ID: 347 Len: 97 Enqueue: 0
+ID: 348 Len: 0 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 9 Enqueue: 0
+ID: 353 Len: 9 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 17 Enqueue: 0
+ID: 356 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7eb0]
-	PrepareEventRoot 63 01 00 00 11 00 00 00 
+	PrepareEventRoot 73 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7ee8]
-	PrepareEventRoot 64 01 00 00 09 00 00 00 
+	PrepareEventRoot 74 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7ee8.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 9f 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b8cb0]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b9408]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b9408]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b9408]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b92c8]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b9368]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b8e68]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb8e68]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b8e68]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b8f08]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8fa8]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8dc8]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b9934]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9934]
@@ -377,7 +377,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b9934]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@b9888]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
@@ -470,7 +470,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@b9888]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
@@ -520,7 +520,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.condFields]
+	Call 9a 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	PrepareEventRoot 1b 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@b94a8]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@b94a8]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@b94a8]
 	PrepareEventRoot 07 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@b94a8]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@b954c]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call d3 1b 00 00 // ProcessType[main.condFields]
+	Call 2a 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@b954c]
 	PrepareEventRoot 15 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@b90e8]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
@@ -877,7 +877,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@b90e8]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@b9188]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
@@ -921,7 +921,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@b9188]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@b9228]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
@@ -965,7 +965,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@b9228]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@b9048]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@b9048]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@b9048]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@b7cd0]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@b8b78]
-	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	PrepareEventRoot 71 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@b8bac]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call f3 1a 00 00 // ProcessType[[3]string]
+	Call 4a 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
+	Call a0 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@b8988]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
-	PrepareEventRoot 57 01 00 00 19 00 00 00 
+	PrepareEventRoot 67 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
-	PrepareEventRoot 58 01 00 00 00 00 00 00 
+	PrepareEventRoot 68 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call d3 1b 00 00 // ProcessType[main.condFields]
+	Call 2a 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
-	PrepareEventRoot 5b 01 00 00 61 00 00 00 
+	PrepareEventRoot 6b 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
-	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+	PrepareEventRoot 6c 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
-	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	PrepareEventRoot 6a 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@b9dac]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 3a 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@b9dac]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	PrepareEventRoot 3f 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 40 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 41 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 42 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@b9dac]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xb9dac]
+	PrepareEventRoot 43 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 44 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 45 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 46 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@b9dac]
-	PrepareEventRoot 3b 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@b9dac]
+	PrepareEventRoot 47 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b9e50]
-	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
-	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 49 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*string]
+	Call e8 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
-	PrepareEventRoot 3f 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+	PrepareEventRoot 4b 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
-	PrepareEventRoot 40 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.lenFields]
+	Call a0 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 4f 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 5f 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 50 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 60 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 52 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 61 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 63 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 54 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
-	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+	PrepareEventRoot 66 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 36 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b9cbc]
-	PrepareEventRoot 37 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
-	PrepareEventRoot 38 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+	PrepareEventRoot 35 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@b9bdc]
-	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 37 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
-	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xb9cbc]
+	PrepareEventRoot 39 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b9c70]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@b9bdc]
-	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 3b 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 3c 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call a0 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+	PrepareEventRoot 3d 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 2c 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 2e 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+	PrepareEventRoot 2f 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@b9c70]
+	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@b9bdc]
+	PrepareEventRoot 31 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@b9bdc]
+// 0x1898: ProcessEvent[Probe[main.lenString]@b9bdc]
 	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call de 1b 00 00 // ProcessType[main.lenFields]
+	Call 35 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 41 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 4d 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 42 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 44 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 4f 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 50 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 51 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 46 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 47 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 53 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 55 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 4a 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	PrepareEventRoot 57 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 4c 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 59 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 5a 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 07 21 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 5b 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 5c 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,484 +1689,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
-	PrepareEventRoot 4d 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+	PrepareEventRoot 5d 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
-	PrepareEventRoot 4e 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@b8c38]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@b8c38]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b8c64]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@b8c64]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@b8d58]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@b8d58]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call f3 1a 00 00 // ProcessType[[3]string]
+	Call 4a 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]string]
+	Call ce 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a5 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
-	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
+	PrepareEventRoot 70 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*main.bigStruct]
+// 0x1d94: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.condFields]
+// 0x1d9a: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.lenFields]
+// 0x1da0: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*runtime._defer]
+// 0x1da6: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._panic]
+// 0x1dac: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime.cgoCallers]
+// 0x1db2: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.coro]
+// 0x1db8: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.g]
+// 0x1dbe: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.m]
+// 0x1dc4: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.p]
+// 0x1dca: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.sudog]
+// 0x1dd0: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.synctestBubble]
+// 0x1dd6: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.timer]
+// 0x1ddc: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.traceBuf]
+// 0x1de2: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*string]
+// 0x1de8: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dee: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*table<string,int>]
+// 0x1df4: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<string,main.bigStruct>]
+// 0x1dfa: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e00: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*uint]
+// 0x1e06: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*uint16]
+// 0x1e0c: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint32]
+// 0x1e12: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint64]
+// 0x1e18: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint8]
+// 0x1e1e: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uintptr]
+// 0x1e24: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
+// 0x1e2a: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call e2 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e3a: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 2a 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1af3: ProcessType[[3]string]
+// 0x1e4a: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b03: ProcessType[[]*runtime.p]
+// 0x1e5a: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1b0d: ProcessType[[]*runtime.p.array]
+// 0x1e64: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 73 1a 00 00 // ProcessType[*runtime.p]
+	Call ca 1d 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e70: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 97 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call ee 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b25: ProcessType[[]*table<string,int>.array]
+// 0x1e7c: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 9d 1a 00 00 // ProcessType[*table<string,int>]
+	Call f4 1d 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b31: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e88: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call fa 1d 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b3d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1e94: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a9 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 00 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]int]
+// 0x1ea0: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b53: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1eaa: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 84 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call db 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1eb6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 8f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call e6 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b6b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ec2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 9a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call f1 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]string]
+// 0x1ece: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1b81: ProcessType[[]string.array]
+// 0x1ed8: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[[]uint8]
+// 0x1ee4: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b97: ProcessType[[]uintptr]
+// 0x1eee: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1ba1: ProcessType[error]
+// 0x1ef8: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1ba3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1efa: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1baf: ProcessType[groupReference<string,int>]
+// 0x1f06: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bbb: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1f12: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bc7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f1e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bd3: ProcessType[main.condFields]
+// 0x1f2a: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1bde: ProcessType[main.lenFields]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x1f35: ProcessType[main.lenFields]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 49 1b 00 00 // ProcessType[[]int]
+	Call a0 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 42 1c 00 00 // ProcessType[map[string]int]
+	Call 99 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*string]
+	Call e8 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c0c: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f63: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1c18: ProcessType[map<string,int>]
+// 0x1f6f: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1c24: ProcessType[map<string,main.bigStruct>]
+// 0x1f7b: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1c30: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f87: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1c3c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f93: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1c42: ProcessType[map[string]int]
+// 0x1f99: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c48: ProcessType[map[string]main.bigStruct]
+// 0x1f9f: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c4e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fa5: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c54: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1fab: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a5 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call fc 1f 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c64: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1fbb: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b5 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 0c 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c74: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1fcb: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call bb 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 12 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c84: ProcessType[noalg.map.group[string]int]
+// 0x1fdb: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 64 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call bb 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c8f: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1fe6: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call ab 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c9a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ff1: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 74 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call cb 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1ca5: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x1ffc: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 94 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1cb5: ProcessType[noalg.struct { key string; elem int }]
-	Call b0 1d 00 00 // ProcessType[string]
+// 0x200c: ProcessType[noalg.struct { key string; elem int }]
+	Call 07 21 00 00 // ProcessType[string]
 	Return 
-// 0x1cbb: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x2012: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 3c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 93 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cc6: ProcessType[runtime.g]
+// 0x201d: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._panic]
+	Call ac 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
+	Call a6 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 8d 1b 00 00 // ProcessType[[]uint8]
+	Call e4 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 79 1a 00 00 // ProcessType[*runtime.sudog]
+	Call d0 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.timer]
+	Call dc 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.coro]
+	Call b8 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call d6 1d 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1d2b: ProcessType[runtime.m]
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+// 0x2082: ProcessType[runtime.m]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.g]
+	Call be 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call b0 1d 00 00 // ProcessType[string]
+	Call 07 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 03 1b 00 00 // ProcessType[[]*runtime.p]
+	Call 5a 1e 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b2 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call ec 20 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call f7 20 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d95: ProcessType[runtime.mLockProfile]
+// 0x20ec: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 97 1b 00 00 // ProcessType[[]uintptr]
+	Call ee 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1da0: ProcessType[runtime.mTraceState]
+// 0x20f7: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 6d 1a 00 00 // ProcessType[*runtime.m]
+	Call 3a 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call c4 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1db0: ProcessType[string]
+// 0x2107: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x1db6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x210d: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a3 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call fa 1e 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1dc1: ProcessType[table<string,int>]
+// 0x2118: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call af 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 06 1f 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dcc: ProcessType[table<string,main.bigStruct>]
+// 0x2123: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bb 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 12 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1dd7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x212e: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 1e 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2240,31 +2434,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6855
+ID: 5 Len: 8 Enqueue: 7710
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7600
+ID: 9 Len: 16 Enqueue: 8455
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6675
+ID: 11 Len: 8 Enqueue: 7530
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7073
+ID: 14 Len: 16 Enqueue: 7928
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6861
-ID: 20 Len: 8 Enqueue: 6705
-ID: 21 Len: 8 Enqueue: 6843
-ID: 22 Len: 440 Enqueue: 7366
+ID: 19 Len: 8 Enqueue: 7716
+ID: 20 Len: 8 Enqueue: 7560
+ID: 21 Len: 8 Enqueue: 7698
+ID: 22 Len: 440 Enqueue: 8221
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6741
+ID: 24 Len: 8 Enqueue: 7596
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6735
+ID: 26 Len: 8 Enqueue: 7590
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6765
-ID: 29 Len: 1816 Enqueue: 7467
+ID: 28 Len: 8 Enqueue: 7620
+ID: 29 Len: 1816 Enqueue: 8322
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2273,48 +2467,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7053
-ID: 39 Len: 8 Enqueue: 6669
+ID: 38 Len: 24 Enqueue: 7908
+ID: 39 Len: 8 Enqueue: 7524
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6777
+ID: 41 Len: 8 Enqueue: 7632
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7063
-ID: 44 Len: 8 Enqueue: 6789
+ID: 43 Len: 24 Enqueue: 7918
+ID: 44 Len: 8 Enqueue: 7644
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6753
+ID: 47 Len: 8 Enqueue: 7608
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6783
+ID: 49 Len: 8 Enqueue: 7638
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6759
+ID: 55 Len: 8 Enqueue: 7614
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 6915
+ID: 62 Len: 24 Enqueue: 7770
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 6771
-ID: 65 Len: 8 Enqueue: 6747
+ID: 64 Len: 8 Enqueue: 7626
+ID: 65 Len: 8 Enqueue: 7602
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 7573
+ID: 70 Len: 56 Enqueue: 8428
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7584
+ID: 75 Len: 56 Enqueue: 8439
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 6883
-ID: 78 Len: 16 Enqueue: 6867
-ID: 79 Len: 8 Enqueue: 6795
+ID: 77 Len: 32 Enqueue: 7738
+ID: 78 Len: 16 Enqueue: 7722
+ID: 79 Len: 8 Enqueue: 7650
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2330,46 +2524,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 6801
+ID: 95 Len: 8 Enqueue: 7656
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 6693
-ID: 100 Len: 8 Enqueue: 6699
-ID: 101 Len: 8 Enqueue: 6849
-ID: 102 Len: 8 Enqueue: 6711
-ID: 103 Len: 8 Enqueue: 6681
-ID: 104 Len: 8 Enqueue: 6687
-ID: 105 Len: 8 Enqueue: 6831
-ID: 106 Len: 8 Enqueue: 6837
-ID: 107 Len: 24 Enqueue: 6985
+ID: 99 Len: 8 Enqueue: 7548
+ID: 100 Len: 8 Enqueue: 7554
+ID: 101 Len: 8 Enqueue: 7704
+ID: 102 Len: 8 Enqueue: 7566
+ID: 103 Len: 8 Enqueue: 7536
+ID: 104 Len: 8 Enqueue: 7542
+ID: 105 Len: 8 Enqueue: 7686
+ID: 106 Len: 8 Enqueue: 7692
+ID: 107 Len: 24 Enqueue: 7840
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 7031
-ID: 110 Len: 48 Enqueue: 6899
-ID: 111 Len: 8 Enqueue: 7234
+ID: 109 Len: 24 Enqueue: 7886
+ID: 110 Len: 48 Enqueue: 7754
+ID: 111 Len: 8 Enqueue: 8089
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7192
+ID: 113 Len: 48 Enqueue: 8047
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 6813
-ID: 116 Len: 8 Enqueue: 7240
+ID: 115 Len: 8 Enqueue: 7668
+ID: 116 Len: 8 Enqueue: 8095
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7204
+ID: 118 Len: 48 Enqueue: 8059
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6819
-ID: 121 Len: 80 Enqueue: 7123
+ID: 120 Len: 8 Enqueue: 7674
+ID: 121 Len: 80 Enqueue: 7978
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 6723
-ID: 124 Len: 72 Enqueue: 7134
-ID: 125 Len: 8 Enqueue: 6663
-ID: 126 Len: 8 Enqueue: 6729
-ID: 127 Len: 8 Enqueue: 7246
+ID: 123 Len: 8 Enqueue: 7578
+ID: 124 Len: 72 Enqueue: 7989
+ID: 125 Len: 8 Enqueue: 7518
+ID: 126 Len: 8 Enqueue: 7584
+ID: 127 Len: 8 Enqueue: 8101
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7216
+ID: 129 Len: 48 Enqueue: 8071
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 6825
-ID: 132 Len: 8 Enqueue: 6639
-ID: 133 Len: 8 Enqueue: 6645
-ID: 134 Len: 8 Enqueue: 6657
+ID: 131 Len: 8 Enqueue: 7680
+ID: 132 Len: 8 Enqueue: 7494
+ID: 133 Len: 8 Enqueue: 7500
+ID: 134 Len: 8 Enqueue: 7512
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2377,53 +2571,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 6925
+ID: 142 Len: 8 Enqueue: 7780
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7041
+ID: 146 Len: 16 Enqueue: 7896
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 7617
-ID: 149 Len: 16 Enqueue: 7087
+ID: 148 Len: 32 Enqueue: 8472
+ID: 149 Len: 16 Enqueue: 7942
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 7300
-ID: 152 Len: 192 Enqueue: 7268
-ID: 153 Len: 24 Enqueue: 7349
-ID: 154 Len: 8 Enqueue: 6949
-ID: 155 Len: 200 Enqueue: 6995
-ID: 156 Len: 32 Enqueue: 7628
-ID: 157 Len: 16 Enqueue: 7099
+ID: 151 Len: 200 Enqueue: 8155
+ID: 152 Len: 192 Enqueue: 8123
+ID: 153 Len: 24 Enqueue: 8204
+ID: 154 Len: 8 Enqueue: 7804
+ID: 155 Len: 200 Enqueue: 7850
+ID: 156 Len: 32 Enqueue: 8483
+ID: 157 Len: 16 Enqueue: 7954
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 7311
-ID: 160 Len: 192 Enqueue: 7252
-ID: 161 Len: 24 Enqueue: 7333
-ID: 162 Len: 8 Enqueue: 6717
+ID: 159 Len: 200 Enqueue: 8166
+ID: 160 Len: 192 Enqueue: 8107
+ID: 161 Len: 24 Enqueue: 8188
+ID: 162 Len: 8 Enqueue: 7572
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 6961
-ID: 165 Len: 200 Enqueue: 7007
-ID: 166 Len: 32 Enqueue: 7639
-ID: 167 Len: 16 Enqueue: 7111
+ID: 164 Len: 8 Enqueue: 7816
+ID: 165 Len: 200 Enqueue: 7862
+ID: 166 Len: 32 Enqueue: 8494
+ID: 167 Len: 16 Enqueue: 7966
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 7322
-ID: 170 Len: 128 Enqueue: 7284
-ID: 171 Len: 16 Enqueue: 7355
-ID: 172 Len: 8 Enqueue: 7228
+ID: 169 Len: 136 Enqueue: 8177
+ID: 170 Len: 128 Enqueue: 8139
+ID: 171 Len: 16 Enqueue: 8210
+ID: 172 Len: 8 Enqueue: 8083
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 7180
+ID: 174 Len: 48 Enqueue: 8035
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 6807
-ID: 177 Len: 8 Enqueue: 6973
-ID: 178 Len: 136 Enqueue: 7019
-ID: 179 Len: 32 Enqueue: 7606
-ID: 180 Len: 16 Enqueue: 7075
+ID: 176 Len: 8 Enqueue: 7662
+ID: 177 Len: 8 Enqueue: 7828
+ID: 178 Len: 136 Enqueue: 7874
+ID: 179 Len: 32 Enqueue: 8461
+ID: 180 Len: 16 Enqueue: 7930
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 6937
+ID: 186 Len: 8 Enqueue: 7792
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 6651
+ID: 188 Len: 8 Enqueue: 7506
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0
@@ -2544,51 +2738,67 @@ ID: 305 Len: 9 Enqueue: 0
 ID: 306 Len: 0 Enqueue: 0
 ID: 307 Len: 33 Enqueue: 0
 ID: 308 Len: 0 Enqueue: 0
-ID: 309 Len: 9 Enqueue: 0
+ID: 309 Len: 17 Enqueue: 0
 ID: 310 Len: 0 Enqueue: 0
-ID: 311 Len: 41 Enqueue: 0
+ID: 311 Len: 9 Enqueue: 0
 ID: 312 Len: 0 Enqueue: 0
-ID: 313 Len: 0 Enqueue: 0
+ID: 313 Len: 17 Enqueue: 0
 ID: 314 Len: 0 Enqueue: 0
-ID: 315 Len: 25 Enqueue: 0
+ID: 315 Len: 9 Enqueue: 0
 ID: 316 Len: 0 Enqueue: 0
-ID: 317 Len: 9 Enqueue: 0
+ID: 317 Len: 41 Enqueue: 0
 ID: 318 Len: 0 Enqueue: 0
-ID: 319 Len: 25 Enqueue: 0
+ID: 319 Len: 17 Enqueue: 0
 ID: 320 Len: 0 Enqueue: 0
-ID: 321 Len: 89 Enqueue: 0
+ID: 321 Len: 9 Enqueue: 0
 ID: 322 Len: 0 Enqueue: 0
-ID: 323 Len: 0 Enqueue: 0
+ID: 323 Len: 17 Enqueue: 0
 ID: 324 Len: 0 Enqueue: 0
 ID: 325 Len: 9 Enqueue: 0
 ID: 326 Len: 0 Enqueue: 0
-ID: 327 Len: 9 Enqueue: 0
+ID: 327 Len: 25 Enqueue: 0
 ID: 328 Len: 0 Enqueue: 0
 ID: 329 Len: 9 Enqueue: 0
 ID: 330 Len: 0 Enqueue: 0
-ID: 331 Len: 9 Enqueue: 0
+ID: 331 Len: 25 Enqueue: 0
 ID: 332 Len: 0 Enqueue: 0
-ID: 333 Len: 17 Enqueue: 0
+ID: 333 Len: 89 Enqueue: 0
 ID: 334 Len: 0 Enqueue: 0
-ID: 335 Len: 25 Enqueue: 0
+ID: 335 Len: 9 Enqueue: 0
 ID: 336 Len: 0 Enqueue: 0
-ID: 337 Len: 0 Enqueue: 0
+ID: 337 Len: 9 Enqueue: 0
 ID: 338 Len: 0 Enqueue: 0
 ID: 339 Len: 9 Enqueue: 0
 ID: 340 Len: 0 Enqueue: 0
 ID: 341 Len: 9 Enqueue: 0
 ID: 342 Len: 0 Enqueue: 0
-ID: 343 Len: 25 Enqueue: 0
+ID: 343 Len: 9 Enqueue: 0
 ID: 344 Len: 0 Enqueue: 0
-ID: 345 Len: 0 Enqueue: 0
+ID: 345 Len: 17 Enqueue: 0
 ID: 346 Len: 0 Enqueue: 0
-ID: 347 Len: 97 Enqueue: 0
+ID: 347 Len: 17 Enqueue: 0
 ID: 348 Len: 0 Enqueue: 0
-ID: 349 Len: 0 Enqueue: 0
+ID: 349 Len: 17 Enqueue: 0
 ID: 350 Len: 0 Enqueue: 0
-ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 9 Enqueue: 0
+ID: 351 Len: 25 Enqueue: 0
+ID: 352 Len: 0 Enqueue: 0
 ID: 353 Len: 9 Enqueue: 0
 ID: 354 Len: 0 Enqueue: 0
-ID: 355 Len: 17 Enqueue: 0
-ID: 356 Len: 9 Enqueue: 0
+ID: 355 Len: 9 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 9 Enqueue: 0
+ID: 358 Len: 0 Enqueue: 0
+ID: 359 Len: 25 Enqueue: 0
+ID: 360 Len: 0 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 0 Enqueue: 0
+ID: 363 Len: 97 Enqueue: 0
+ID: 364 Len: 0 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 0 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 9 Enqueue: 0
+ID: 369 Len: 9 Enqueue: 0
+ID: 370 Len: 0 Enqueue: 0
+ID: 371 Len: 17 Enqueue: 0
+ID: 372 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7eb0]
 	PrepareEventRoot 63 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7ee8]
 	PrepareEventRoot 64 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 48 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@b8cb0]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@b9408]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@b9408]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@b9408]
 	PrepareEventRoot 01 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@b92c8]
 	PrepareEventRoot f9 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@b9368]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@b8e68]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb8e68]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@b8e68]
 	PrepareEventRoot db 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@b8f08]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@b8f08]
 	PrepareEventRoot e1 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8fa8]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	PrepareEventRoot e5 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8dc8]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	PrepareEventRoot d7 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@b9934]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9934]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@b9934]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
 	PrepareEventRoot 1d 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	PrepareEventRoot 1f 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb9888]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0xb9888]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@b9888]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@b9888]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
 	PrepareEventRoot 25 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@b98e0]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@b98e0]
 	PrepareEventRoot 26 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@b9888]
+// 0x767: ProcessEvent[Probe[main.condOnly]@b9888]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@b98e0]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@b98e0]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	PrepareEventRoot 17 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.condFields]
+	Call 43 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	PrepareEventRoot 1b 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
 	PrepareEventRoot 23 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
 	PrepareEventRoot 24 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0x964: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@b94a8]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0x9a8: ProcessEvent[Probe[main.condString]@b94a8]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 03 01 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@b9504]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@b94a8]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0xa05: ProcessEvent[Probe[main.condString]@b94a8]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@b9504]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@b94a8]
+// 0xa67: ProcessEvent[Probe[main.condString]@b94a8]
 	PrepareEventRoot 07 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@b9504]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0xa85: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@b94a8]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
+// 0xaeb: ProcessEvent[Probe[main.condString]@b94a8]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@b9504]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0b 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b954c]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b3 1b 00 00 // ProcessType[main.condFields]
+	Call d3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@b954c]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@b954c]
 	PrepareEventRoot 15 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b9600]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb90e8]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@b90e8]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@b90e8]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	PrepareEventRoot ed 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b9140]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@b90e8]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@b90e8]
 	PrepareEventRoot ef 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b9140]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb9188]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xb9188]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@b9188]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@b9188]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
 	PrepareEventRoot f1 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b91e0]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@b9188]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@b9188]
 	PrepareEventRoot f3 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b91e0]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb9228]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0xb9228]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@b9228]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@b9228]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
 	PrepareEventRoot f5 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b9280]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@b9228]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@b9228]
 	PrepareEventRoot f7 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b9280]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@b9048]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e7 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@b9048]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@b9048]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@b9048]
 	PrepareEventRoot eb 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b90a8]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@b7cd0]
+// 0x106e: ProcessEvent[Probe[main.inlined]@b7cd0]
 	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@b8b78]
+// 0x1093: ProcessEvent[Probe[main.inlined]@b8b78]
 	PrepareEventRoot 61 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@b8bac]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@b8bac]
 	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@b88a8]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@b88a8]
 	PrepareEventRoot be 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b88dc]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@b88dc]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b8a08]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@b8a08]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[3]string]
+	Call f3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b8988]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@b8988]
 	PrepareEventRoot c6 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
 	PrepareEventRoot 57 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xba1ac.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
 	PrepareEventRoot 58 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call b3 1b 00 00 // ProcessType[main.condFields]
+	Call d3 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
 	PrepareEventRoot 5b 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xba28c.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
 	PrepareEventRoot 5c 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@ba1ac]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ba244]
 	PrepareEventRoot 5a 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ba28c]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ba348]
 	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@b9dac]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@b9dac]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@b9e50]
 	PrepareEventRoot 3a 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@b9dac]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@b9dac]
 	PrepareEventRoot 3b 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xb9dac.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@b9e50]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@b9e50]
 	PrepareEventRoot 3c 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
 	PrepareEventRoot 3d 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*string]
+	Call 91 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@b9e9c]
 	PrepareEventRoot 3f 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xb9e9c.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@b9f28]
 	PrepareEventRoot 40 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.lenFields]
+	Call 49 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
 	PrepareEventRoot 4f 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
 	PrepareEventRoot 50 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
 	PrepareEventRoot 52 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
 	PrepareEventRoot 53 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
 	PrepareEventRoot 54 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@ba09c]
 	PrepareEventRoot 55 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xba09c.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@ba168]
 	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@b9cbc]
 	PrepareEventRoot 35 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
 	PrepareEventRoot 36 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@b9cbc]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@b9cbc]
 	PrepareEventRoot 37 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xb9cbc.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@b9d5c]
 	PrepareEventRoot 38 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x1525: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 2c 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@b9bdc]
+// 0x1559: ProcessEvent[Probe[main.lenString]@b9bdc]
 	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 2e 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@b9bdc]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@b9bdc]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xb9bdc]
 	PrepareEventRoot 2f 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@b9bdc]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@b9bdc]
 	PrepareEventRoot 31 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 32 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@b9bdc]
+// 0x1642: ProcessEvent[Probe[main.lenString]@b9bdc]
 	PrepareEventRoot 33 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xb9bdc.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@b9c70]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@b9c70]
 	PrepareEventRoot 34 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call be 1b 00 00 // ProcessType[main.lenFields]
+	Call de 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 41 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 42 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 44 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 45 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 46 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 47 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 49 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 4a 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
 	PrepareEventRoot 4b 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 4c 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,484 +1495,484 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@b9f6c]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xb9f6c]
 	PrepareEventRoot 4d 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xb9f6c.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@ba05c]
 	PrepareEventRoot 4e 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c0 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@b8c38]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@b8c38]
 	PrepareEventRoot cf 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@b8c64]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@b8c64]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@b8d58]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@b8d58]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@b8918]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c4 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@b8950]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call d3 1a 00 00 // ProcessType[[3]string]
+	Call f3 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
 	PrepareEventRoot cc 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 57 1b 00 00 // ProcessType[[]string]
+	Call 77 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
 	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 4e 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
 	PrepareEventRoot 60 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 85 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer bc 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 6b 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*main.bigStruct]
+// 0x1a3d: ProcessType[*main.bigStruct]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.condFields]
+// 0x1a43: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.lenFields]
+// 0x1a49: ProcessType[*main.lenFields]
 	ProcessPointer 7c 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*runtime._defer]
+// 0x1a4f: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._panic]
+// 0x1a55: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime.cgoCallers]
+// 0x1a5b: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.coro]
+// 0x1a61: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.g]
+// 0x1a67: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.m]
+// 0x1a6d: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.p]
+// 0x1a73: ProcessType[*runtime.p]
 	ProcessPointer 8d 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.sudog]
+// 0x1a79: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.synctestBubble]
+// 0x1a7f: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.timer]
+// 0x1a85: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.traceBuf]
+// 0x1a8b: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*string]
+// 0x1a91: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1a97: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*table<string,int>]
+// 0x1a9d: ProcessType[*table<string,int>]
 	ProcessPointer 94 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<string,main.bigStruct>]
+// 0x1aa3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9c 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1aa9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a6 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*uint]
+// 0x1aaf: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*uint16]
+// 0x1ab5: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint32]
+// 0x1abb: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint64]
+// 0x1ac1: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint8]
+// 0x1ac7: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uintptr]
+// 0x1acd: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[[2]*runtime.traceBuf]
+// 0x1ad3: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 8b 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ac3: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1ae3: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call b3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call d3 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[[3]string]
+// 0x1af3: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ae3: ProcessType[[]*runtime.p]
+// 0x1b03: ProcessType[[]*runtime.p]
 	ProcessSlice 8e 00 00 00 08 00 00 00 
 	Return 
-// 0x1aed: ProcessType[[]*runtime.p.array]
+// 0x1b0d: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 53 1a 00 00 // ProcessType[*runtime.p]
+	Call 73 1a 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1af9: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1b19: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 77 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 97 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b05: ProcessType[[]*table<string,int>.array]
+// 0x1b25: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 7d 1a 00 00 // ProcessType[*table<string,int>]
+	Call 9d 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b11: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b31: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call a3 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b1d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b3d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 89 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call a9 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]int]
+// 0x1b49: ProcessType[[]int]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b33: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b53: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 64 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 84 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b5f: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 6f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 8f 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b6b: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 7a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 9a 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b57: ProcessType[[]string]
+// 0x1b77: ProcessType[[]string]
 	ProcessSlice 92 00 00 00 10 00 00 00 
 	Return 
-// 0x1b61: ProcessType[[]string.array]
+// 0x1b81: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b6d: ProcessType[[]uint8]
+// 0x1b8d: ProcessType[[]uint8]
 	ProcessSlice 89 00 00 00 01 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]uintptr]
+// 0x1b97: ProcessType[[]uintptr]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1b81: ProcessType[error]
+// 0x1ba1: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b83: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1ba3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bb 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b8f: ProcessType[groupReference<string,int>]
+// 0x1baf: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9b 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1b9b: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1bbb: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a5 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ba7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bc7: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b2 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bb3: ProcessType[main.condFields]
+// 0x1bd3: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1bbe: ProcessType[main.lenFields]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1bde: ProcessType[main.lenFields]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 29 1b 00 00 // ProcessType[[]int]
+	Call 49 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 22 1c 00 00 // ProcessType[map[string]int]
+	Call 42 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*string]
+	Call 91 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bec: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1c0c: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ba 00 00 00 b6 00 00 00 10 18 
 	Return 
-// 0x1bf8: ProcessType[map<string,int>]
+// 0x1c18: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9a 00 00 00 97 00 00 00 10 18 
 	Return 
-// 0x1c04: ProcessType[map<string,main.bigStruct>]
+// 0x1c24: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a4 00 00 00 9f 00 00 00 10 18 
 	Return 
-// 0x1c10: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c30: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b1 00 00 00 a9 00 00 00 10 18 
 	Return 
-// 0x1c1c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c3c: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ae 00 00 00 
 	Return 
-// 0x1c22: ProcessType[map[string]int]
+// 0x1c42: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1c28: ProcessType[map[string]main.bigStruct]
+// 0x1c48: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c2e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c4e: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1c34: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c54: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 85 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call a5 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c44: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c64: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 95 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call b5 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c54: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c74: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 9b 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call bb 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c64: ProcessType[noalg.map.group[string]int]
+// 0x1c84: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 44 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 64 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c6f: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c8f: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 34 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c7a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c9a: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 54 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 74 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c85: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1ca5: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1d 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 3d 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1c95: ProcessType[noalg.struct { key string; elem int }]
-	Call 90 1d 00 00 // ProcessType[string]
+// 0x1cb5: ProcessType[noalg.struct { key string; elem int }]
+	Call b0 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1c9b: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1cbb: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 1c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 3c 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1ca6: ProcessType[runtime.g]
+// 0x1cc6: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._panic]
+	Call 55 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*runtime._defer]
+	Call 4f 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call 6d 1b 00 00 // ProcessType[[]uint8]
+	Call 8d 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 59 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 79 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.timer]
+	Call 85 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.coro]
+	Call 61 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 7f 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1d0b: ProcessType[runtime.m]
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d2b: ProcessType[runtime.m]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.g]
+	Call 67 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call 90 1d 00 00 // ProcessType[string]
+	Call b0 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call e3 1a 00 00 // ProcessType[[]*runtime.p]
+	Call 03 1b 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 5b 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call 75 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 80 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x1d75: ProcessType[runtime.mLockProfile]
+// 0x1d95: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 77 1b 00 00 // ProcessType[[]uintptr]
+	Call 97 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1d80: ProcessType[runtime.mTraceState]
+// 0x1da0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call c3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 4d 1a 00 00 // ProcessType[*runtime.m]
+	Call e3 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 6d 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1d90: ProcessType[string]
+// 0x1db0: ProcessType[string]
 	ProcessString 87 00 00 00 
 	Return 
-// 0x1d96: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1db6: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 83 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call a3 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1da1: ProcessType[table<string,int>]
+// 0x1dc1: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8f 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call af 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dac: ProcessType[table<string,main.bigStruct>]
+// 0x1dcc: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9b 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call bb 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1db7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1dd7: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call c7 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2240,31 +2240,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6823
+ID: 5 Len: 8 Enqueue: 6855
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7568
+ID: 9 Len: 16 Enqueue: 7600
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 6643
+ID: 11 Len: 8 Enqueue: 6675
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 7041
+ID: 14 Len: 16 Enqueue: 7073
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 6829
-ID: 20 Len: 8 Enqueue: 6673
-ID: 21 Len: 8 Enqueue: 6811
-ID: 22 Len: 440 Enqueue: 7334
+ID: 19 Len: 8 Enqueue: 6861
+ID: 20 Len: 8 Enqueue: 6705
+ID: 21 Len: 8 Enqueue: 6843
+ID: 22 Len: 440 Enqueue: 7366
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 6709
+ID: 24 Len: 8 Enqueue: 6741
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 6703
+ID: 26 Len: 8 Enqueue: 6735
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 6733
-ID: 29 Len: 1816 Enqueue: 7435
+ID: 28 Len: 8 Enqueue: 6765
+ID: 29 Len: 1816 Enqueue: 7467
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -2273,48 +2273,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 7021
-ID: 39 Len: 8 Enqueue: 6637
+ID: 38 Len: 24 Enqueue: 7053
+ID: 39 Len: 8 Enqueue: 6669
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 6745
+ID: 41 Len: 8 Enqueue: 6777
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 7031
-ID: 44 Len: 8 Enqueue: 6757
+ID: 43 Len: 24 Enqueue: 7063
+ID: 44 Len: 8 Enqueue: 6789
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 6721
+ID: 47 Len: 8 Enqueue: 6753
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 6751
+ID: 49 Len: 8 Enqueue: 6783
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 6727
+ID: 55 Len: 8 Enqueue: 6759
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 6883
+ID: 62 Len: 24 Enqueue: 6915
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 6739
-ID: 65 Len: 8 Enqueue: 6715
+ID: 64 Len: 8 Enqueue: 6771
+ID: 65 Len: 8 Enqueue: 6747
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 7541
+ID: 70 Len: 56 Enqueue: 7573
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7552
+ID: 75 Len: 56 Enqueue: 7584
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 6851
-ID: 78 Len: 16 Enqueue: 6835
-ID: 79 Len: 8 Enqueue: 6763
+ID: 77 Len: 32 Enqueue: 6883
+ID: 78 Len: 16 Enqueue: 6867
+ID: 79 Len: 8 Enqueue: 6795
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -2330,46 +2330,46 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 6769
+ID: 95 Len: 8 Enqueue: 6801
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 6661
-ID: 100 Len: 8 Enqueue: 6667
-ID: 101 Len: 8 Enqueue: 6817
-ID: 102 Len: 8 Enqueue: 6679
-ID: 103 Len: 8 Enqueue: 6649
-ID: 104 Len: 8 Enqueue: 6655
-ID: 105 Len: 8 Enqueue: 6799
-ID: 106 Len: 8 Enqueue: 6805
-ID: 107 Len: 24 Enqueue: 6953
+ID: 99 Len: 8 Enqueue: 6693
+ID: 100 Len: 8 Enqueue: 6699
+ID: 101 Len: 8 Enqueue: 6849
+ID: 102 Len: 8 Enqueue: 6711
+ID: 103 Len: 8 Enqueue: 6681
+ID: 104 Len: 8 Enqueue: 6687
+ID: 105 Len: 8 Enqueue: 6831
+ID: 106 Len: 8 Enqueue: 6837
+ID: 107 Len: 24 Enqueue: 6985
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 6999
-ID: 110 Len: 48 Enqueue: 6867
-ID: 111 Len: 8 Enqueue: 7202
+ID: 109 Len: 24 Enqueue: 7031
+ID: 110 Len: 48 Enqueue: 6899
+ID: 111 Len: 8 Enqueue: 7234
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 7160
+ID: 113 Len: 48 Enqueue: 7192
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 6781
-ID: 116 Len: 8 Enqueue: 7208
+ID: 115 Len: 8 Enqueue: 6813
+ID: 116 Len: 8 Enqueue: 7240
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7172
+ID: 118 Len: 48 Enqueue: 7204
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6787
-ID: 121 Len: 80 Enqueue: 7091
+ID: 120 Len: 8 Enqueue: 6819
+ID: 121 Len: 80 Enqueue: 7123
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 6691
-ID: 124 Len: 72 Enqueue: 7102
-ID: 125 Len: 8 Enqueue: 6631
-ID: 126 Len: 8 Enqueue: 6697
-ID: 127 Len: 8 Enqueue: 7214
+ID: 123 Len: 8 Enqueue: 6723
+ID: 124 Len: 72 Enqueue: 7134
+ID: 125 Len: 8 Enqueue: 6663
+ID: 126 Len: 8 Enqueue: 6729
+ID: 127 Len: 8 Enqueue: 7246
 ID: 128 Len: 8 Enqueue: 0
-ID: 129 Len: 48 Enqueue: 7184
+ID: 129 Len: 48 Enqueue: 7216
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 8 Enqueue: 6793
-ID: 132 Len: 8 Enqueue: 6607
-ID: 133 Len: 8 Enqueue: 6613
-ID: 134 Len: 8 Enqueue: 6625
+ID: 131 Len: 8 Enqueue: 6825
+ID: 132 Len: 8 Enqueue: 6639
+ID: 133 Len: 8 Enqueue: 6645
+ID: 134 Len: 8 Enqueue: 6657
 ID: 135 Len: 1 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 1 Enqueue: 0
@@ -2377,53 +2377,53 @@ ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 8 Enqueue: 0
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 6893
+ID: 142 Len: 8 Enqueue: 6925
 ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
-ID: 146 Len: 16 Enqueue: 7009
+ID: 146 Len: 16 Enqueue: 7041
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 32 Enqueue: 7585
-ID: 149 Len: 16 Enqueue: 7055
+ID: 148 Len: 32 Enqueue: 7617
+ID: 149 Len: 16 Enqueue: 7087
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 200 Enqueue: 7268
-ID: 152 Len: 192 Enqueue: 7236
-ID: 153 Len: 24 Enqueue: 7317
-ID: 154 Len: 8 Enqueue: 6917
-ID: 155 Len: 200 Enqueue: 6963
-ID: 156 Len: 32 Enqueue: 7596
-ID: 157 Len: 16 Enqueue: 7067
+ID: 151 Len: 200 Enqueue: 7300
+ID: 152 Len: 192 Enqueue: 7268
+ID: 153 Len: 24 Enqueue: 7349
+ID: 154 Len: 8 Enqueue: 6949
+ID: 155 Len: 200 Enqueue: 6995
+ID: 156 Len: 32 Enqueue: 7628
+ID: 157 Len: 16 Enqueue: 7099
 ID: 158 Len: 8 Enqueue: 0
-ID: 159 Len: 200 Enqueue: 7279
-ID: 160 Len: 192 Enqueue: 7220
-ID: 161 Len: 24 Enqueue: 7301
-ID: 162 Len: 8 Enqueue: 6685
+ID: 159 Len: 200 Enqueue: 7311
+ID: 160 Len: 192 Enqueue: 7252
+ID: 161 Len: 24 Enqueue: 7333
+ID: 162 Len: 8 Enqueue: 6717
 ID: 163 Len: 184 Enqueue: 0
-ID: 164 Len: 8 Enqueue: 6929
-ID: 165 Len: 200 Enqueue: 6975
-ID: 166 Len: 32 Enqueue: 7607
-ID: 167 Len: 16 Enqueue: 7079
+ID: 164 Len: 8 Enqueue: 6961
+ID: 165 Len: 200 Enqueue: 7007
+ID: 166 Len: 32 Enqueue: 7639
+ID: 167 Len: 16 Enqueue: 7111
 ID: 168 Len: 8 Enqueue: 0
-ID: 169 Len: 136 Enqueue: 7290
-ID: 170 Len: 128 Enqueue: 7252
-ID: 171 Len: 16 Enqueue: 7323
-ID: 172 Len: 8 Enqueue: 7196
+ID: 169 Len: 136 Enqueue: 7322
+ID: 170 Len: 128 Enqueue: 7284
+ID: 171 Len: 16 Enqueue: 7355
+ID: 172 Len: 8 Enqueue: 7228
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 48 Enqueue: 7148
+ID: 174 Len: 48 Enqueue: 7180
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 8 Enqueue: 6775
-ID: 177 Len: 8 Enqueue: 6941
-ID: 178 Len: 136 Enqueue: 6987
-ID: 179 Len: 32 Enqueue: 7574
-ID: 180 Len: 16 Enqueue: 7043
+ID: 176 Len: 8 Enqueue: 6807
+ID: 177 Len: 8 Enqueue: 6973
+ID: 178 Len: 136 Enqueue: 7019
+ID: 179 Len: 32 Enqueue: 7606
+ID: 180 Len: 16 Enqueue: 7075
 ID: 181 Len: 8 Enqueue: 0
 ID: 182 Len: 136 Enqueue: 0
 ID: 183 Len: 128 Enqueue: 0
 ID: 184 Len: 16 Enqueue: 0
 ID: 185 Len: 8 Enqueue: 0
-ID: 186 Len: 8 Enqueue: 6905
+ID: 186 Len: 8 Enqueue: 6937
 ID: 187 Len: 136 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 6619
+ID: 188 Len: 8 Enqueue: 6651
 ID: 189 Len: 128 Enqueue: 0
 ID: 190 Len: 9 Enqueue: 0
 ID: 191 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.sm.txt
@@ -3,54 +3,54 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7ea8.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7ea8.expr[1]]
+// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7ea8]
+// 0x39: ProcessEvent[Probe[main.PointerChainArg]@b7eb0]
 	PrepareEventRoot 2c 01 00 00 11 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7ea8.expr[0]]
-	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7ea8.expr[1]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[0]]
+	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xb7eb0.expr[1]]
 	Return 
-// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7edc.expr[0]]
+// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7ee8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 78 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
-// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7edc]
+// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@b7ee8]
 	PrepareEventRoot 2d 01 00 00 09 00 00 00 
-	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7edc.expr[0]]
+	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xb7ee8.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb8810.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8810.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 5e 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@b8810]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@b8cb0]
 	PrepareEventRoot ce 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8810.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8810.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xb8cb0.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b8880]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@b8d20]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0xb8f68]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0xb9408]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@b8f68]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb8f68]
+// 0x103: ProcessEvent[Probe[main.condBool]@b9408]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@b8fc8]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@b9468]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0xb8f68]
+// 0x121: ProcessCondition[Probe[main.condBool]@0xb9408]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@b8f68]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb8f68]
+// 0x159: ProcessEvent[Probe[main.condBool]@b9408]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xb9408]
 	PrepareEventRoot fc 00 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@b8fc8]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@b9468]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0xb8f68.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0xb9408.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@b8f68]
+// 0x1af: ProcessEvent[Probe[main.condBool]@b9408]
 	PrepareEventRoot fe 00 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb8f68.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb8f68.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xb9408.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b8fc8]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@b9468]
 	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb8e28.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xb92c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b8e28]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@b92c8]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb8e28.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xb92c8.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b8e84]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@b9324]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb8ec8.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0xb9368.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@b8ec8]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@b9368]
 	PrepareEventRoot f8 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb8ec8.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xb9368.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b8f24]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@b93c4]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0xb89c8]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0xb8e68]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@b89c8]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb89c8]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@b8e68]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xb8e68]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@b8a20]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@b8ec0]
 	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@b89c8]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@b8e68]
 	PrepareEventRoot d8 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb89c8.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xb8e68.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b8a20]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@b8ec0]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb8a68]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@b8a68]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8a68]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@b8f08]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	PrepareEventRoot da 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b8ac0]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@b8f60]
 	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0xb8a68]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@b8a68]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8a68]
+// 0x384: ProcessEvent[Probe[main.condInt32]@b8f08]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xb8f08]
 	PrepareEventRoot dc 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@b8ac0]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@b8f60]
 	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@b8a68]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@b8f08]
 	PrepareEventRoot de 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8a68.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xb8f08.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b8ac0]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@b8f60]
 	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb8b08]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xb8fa8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@b8b08]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8b08]
+// 0x437: ProcessEvent[Probe[main.condInt64]@b8fa8]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xb8fa8]
 	PrepareEventRoot e0 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b8b60]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@b9000]
 	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@b8b08]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@b8fa8]
 	PrepareEventRoot e2 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8b08.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xb8fa8.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b8b60]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@b9000]
 	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb8928]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xb8dc8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,86 +311,80 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb8928.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@b8928]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8928]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@b8dc8]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xb8dc8]
 	PrepareEventRoot d2 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8928.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b8988]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@b8e28]
 	PrepareEventRoot d3 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0xb8928.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0xb8928.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@b8928]
+// 0x539: ProcessEvent[Probe[main.condInt8]@b8dc8]
 	PrepareEventRoot d4 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8928.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8928.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xb8dc8.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b8988]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@b8e28]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb9498]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0xb9934]
 	ConditionBegin 
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprPushOffset 08 00 00 00 
 	ExprLoadLiteral 08 00 07 00 00 00 00 00 00 00 
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x57a: ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x59c: ProcessEvent[Probe[main.condLine]Line@b9498]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9498]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@b9934]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xb9934]
 	PrepareEventRoot 26 01 00 00 11 00 00 00 
-	Call 7a 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	Return 
-// 0x5b0: ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x5ee: ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@b9934]
+	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9934.expr[1]]
 	Return 
-// 0x604: ProcessEvent[Probe[main.condLine]Line@b9498]
-	PrepareEventRoot 27 01 00 00 21 00 00 00 
-	Call b0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[1]]
-	Call ee 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xb9498.expr[2]]
-	Return 
-// 0x61d: ProcessCondition[Probe[main.condNilPtrStruct]@0xb92a8]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x63f: ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x661: ProcessEvent[Probe[main.condNilPtrStruct]@b92a8]
-	Call 1d 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb92a8]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xb9748]
 	PrepareEventRoot 1a 01 00 00 11 00 00 00 
-	Call 3f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	Return 
-// 0x675: ProcessEvent[Probe[main.condNilPtrStruct]Return@b9310]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0x67f: ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x69a: ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessEvent[Probe[main.condNilPtrStruct]@b92a8]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@b9748]
 	PrepareEventRoot 1c 01 00 00 19 00 00 00 
-	Call 7f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[0]]
-	Call 9a 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb92a8.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xb9748.expr[1]]
 	Return 
-// 0x6d0: ProcessEvent[Probe[main.condNilPtrStruct]Return@b9310]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@b97b0]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x6da: ProcessCondition[Probe[main.condOnly]@0xb93e8]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xb9888]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6f7: ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x70d: ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x72f: ProcessEvent[Probe[main.condOnly]@b93e8]
-	Call da 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb93e8]
+// 0x708: ProcessEvent[Probe[main.condOnly]@b9888]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xb9888]
 	PrepareEventRoot 22 01 00 00 19 00 00 00 
-	Call f7 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[0]]
-	Call 0d 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
-// 0x748: ProcessEvent[Probe[main.condOnly]Return@b9440]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@b98e0]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x752: ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x768: ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x78a: ProcessEvent[Probe[main.condOnly]@b93e8]
+// 0x763: ProcessEvent[Probe[main.condOnly]@b9888]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
-	Call 52 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[0]]
-	Call 68 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb93e8.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xb9888.expr[1]]
 	Return 
-// 0x79e: ProcessEvent[Probe[main.condOnly]Return@b9440]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@b98e0]
 	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
-// 0x7a8: ProcessCondition[Probe[main.condPtrStructArg]@0xb919c]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7ca: ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x7ec: ProcessEvent[Probe[main.condPtrStructArg]@b919c]
-	Call a8 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb919c]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call ca 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
-// 0x800: ProcessEvent[Probe[main.condPtrStructArg]Return@b925c]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0x80a: ProcessCondition[Probe[main.condPtrStructArg]@0xb919c]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x82e: ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x850: ProcessEvent[Probe[main.condPtrStructArg]@b919c]
-	Call 0a 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb919c]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xb963c]
 	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 2e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	Return 
-// 0x864: ProcessEvent[Probe[main.condPtrStructArg]Return@b925c]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.condFields]
+	Call 8d 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x889: ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x8ab: ProcessEvent[Probe[main.condPtrStructArg]@b919c]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@b963c]
 	PrepareEventRoot 18 01 00 00 19 00 00 00 
-	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[0]]
-	Call 89 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb919c.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xb963c.expr[1]]
 	Return 
-// 0x8bf: ProcessEvent[Probe[main.condPtrStructArg]Return@b925c]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@b96fc]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0x8c9: ProcessCondition[Probe[main.condReturnAndLocal]@0xb9358]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8e6: ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8fc: ProcessEvent[Probe[main.condReturnAndLocal]@b9358]
-	Call c9 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb9358]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xb97f8]
 	PrepareEventRoot 1e 01 00 00 09 00 00 00 
-	Call e6 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	Return 
-// 0x910: ProcessEvent[Probe[main.condReturnAndLocal]Return@b93b0]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
 	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0x91a: ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x930: ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x946: ProcessEvent[Probe[main.condReturnAndLocal]@b9358]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@b97f8]
 	PrepareEventRoot 20 01 00 00 11 00 00 00 
-	Call 1a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[0]]
-	Call 30 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb9358.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xb97f8.expr[1]]
 	Return 
-// 0x95a: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb93b0.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x970: ProcessEvent[Probe[main.condReturnAndLocal]Return@b93b0]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@b9850]
 	PrepareEventRoot 21 01 00 00 09 00 00 00 
-	Call 5a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb93b0.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xb9850.expr[0]]
 	Return 
-// 0x97f: ProcessCondition[Probe[main.condString]@0xb9008]
+// 0x958: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9a1: ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x9c3: ProcessEvent[Probe[main.condString]@b9008]
-	Call 7f 09 00 00 // ProcessCondition[Probe[main.condString]@0xb9008]
+// 0x99c: ProcessEvent[Probe[main.condString]@b94a8]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
-	Call a1 09 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
-// 0x9d7: ProcessEvent[Probe[main.condString]Return@b9064]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
-// 0x9e1: ProcessCondition[Probe[main.condString]@0xb9008]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9fe: ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa20: ProcessEvent[Probe[main.condString]@b9008]
-	Call e1 09 00 00 // ProcessCondition[Probe[main.condString]@0xb9008]
+// 0x9f9: ProcessEvent[Probe[main.condString]@b94a8]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 02 01 00 00 11 00 00 00 
-	Call fe 09 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	Return 
-// 0xa34: ProcessEvent[Probe[main.condString]Return@b9064]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
-// 0xa3e: ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa60: ProcessExpression[Probe[main.condString]@0xb9008.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xa82: ProcessEvent[Probe[main.condString]@b9008]
+// 0xa5b: ProcessEvent[Probe[main.condString]@b94a8]
 	PrepareEventRoot 04 01 00 00 21 00 00 00 
-	Call 3e 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
-	Call 60 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xa96: ProcessEvent[Probe[main.condString]Return@b9064]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
-// 0xaa0: ProcessCondition[Probe[main.condString]@0xb9008]
+// 0xa79: ProcessCondition[Probe[main.condString]@0xb94a8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xac2: ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xae4: ProcessExpression[Probe[main.condString]@0xb9008.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xb06: ProcessEvent[Probe[main.condString]@b9008]
-	Call a0 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb9008]
+// 0xadf: ProcessEvent[Probe[main.condString]@b94a8]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xb94a8]
 	PrepareEventRoot 06 01 00 00 21 00 00 00 
-	Call c2 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[0]]
-	Call e4 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb9008.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xb94a8.expr[1]]
 	Return 
-// 0xb1f: ProcessEvent[Probe[main.condString]Return@b9064]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@b9504]
 	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
-// 0xb29: ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb48: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xb6a: ProcessEvent[Probe[main.condStructArg]@b90ac]
-	Call 29 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 48 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xb7e: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0xb88: ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xba4: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xbc6: ProcessEvent[Probe[main.condStructArg]@b90ac]
-	Call 88 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call a4 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xbda: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xbe4: ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc07: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xc29: ProcessEvent[Probe[main.condStructArg]@b90ac]
-	Call e4 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0c 01 00 00 11 00 00 00 
-	Call 07 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc3d: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xc47: ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc66: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xc88: ProcessEvent[Probe[main.condStructArg]@b90ac]
-	Call 47 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 0e 01 00 00 11 00 00 00 
-	Call 66 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xc9c: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xca6: ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcc7: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xce9: ProcessEvent[Probe[main.condStructArg]@b90ac]
-	Call a6 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb90ac]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@b954c]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xb954c]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call c7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	Return 
-// 0xcfd: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xd07: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 3e 15 00 00 // ProcessType[main.condFields]
+	Call 17 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd28: ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xd4a: ProcessEvent[Probe[main.condStructArg]@b90ac]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@b954c]
 	PrepareEventRoot 12 01 00 00 61 00 00 00 
-	Call 07 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[0]]
-	Call 28 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb90ac.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xb954c.expr[1]]
 	Return 
-// 0xd5e: ProcessEvent[Probe[main.condStructArg]Return@b9160]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@b9600]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xd68: ProcessCondition[Probe[main.condUint16]@0xb8c48]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd7f: ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xda1: ProcessEvent[Probe[main.condUint16]@b8c48]
-	Call 68 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb8c48]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@b90e8]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xb90e8]
 	PrepareEventRoot ea 00 00 00 11 00 00 00 
-	Call 7f 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	Return 
-// 0xdb5: ProcessEvent[Probe[main.condUint16]Return@b8ca0]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
-// 0xdbf: ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdd5: ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xdf7: ProcessEvent[Probe[main.condUint16]@b8c48]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@b90e8]
 	PrepareEventRoot ec 00 00 00 13 00 00 00 
-	Call bf 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[0]]
-	Call d5 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb8c48.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xb90e8.expr[1]]
 	Return 
-// 0xe0b: ProcessEvent[Probe[main.condUint16]Return@b8ca0]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@b9140]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xe15: ProcessCondition[Probe[main.condUint32]@0xb8ce8]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0xb9188]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe2e: ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xe50: ProcessEvent[Probe[main.condUint32]@b8ce8]
-	Call 15 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xb8ce8]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@b9188]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xb9188]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call 2e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	Return 
-// 0xe64: ProcessEvent[Probe[main.condUint32]Return@b8d40]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xe6e: ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe84: ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xea6: ProcessEvent[Probe[main.condUint32]@b8ce8]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@b9188]
 	PrepareEventRoot f0 00 00 00 15 00 00 00 
-	Call 6e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[0]]
-	Call 84 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb8ce8.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xb9188.expr[1]]
 	Return 
-// 0xeba: ProcessEvent[Probe[main.condUint32]Return@b8d40]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@b91e0]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0xec4: ProcessCondition[Probe[main.condUint64]@0xb8d88]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xb9228]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xee1: ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xf03: ProcessEvent[Probe[main.condUint64]@b8d88]
-	Call c4 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb8d88]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@b9228]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xb9228]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call e1 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	Return 
-// 0xf17: ProcessEvent[Probe[main.condUint64]Return@b8de0]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xf21: ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf37: ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xf59: ProcessEvent[Probe[main.condUint64]@b8d88]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@b9228]
 	PrepareEventRoot f4 00 00 00 19 00 00 00 
-	Call 21 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[0]]
-	Call 37 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb8d88.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xb9228.expr[1]]
 	Return 
-// 0xf6d: ProcessEvent[Probe[main.condUint64]Return@b8de0]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@b9280]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xf77: ProcessCondition[Probe[main.condUint8]@0xb8ba8]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf8d: ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0xfaf: ProcessEvent[Probe[main.condUint8]@b8ba8]
-	Call 77 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb8ba8]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e4 00 00 00 11 00 00 00 
-	Call 8d 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0xfc3: ProcessEvent[Probe[main.condUint8]Return@b8c08]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
-// 0xfcd: ProcessCondition[Probe[main.condUint8]@0xb8ba8]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xb9048]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,557 +1008,557 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfe3: ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1005: ProcessEvent[Probe[main.condUint8]@b8ba8]
-	Call cd 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb8ba8]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@b9048]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xb9048]
 	PrepareEventRoot e6 00 00 00 11 00 00 00 
-	Call e3 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	Return 
-// 0x1019: ProcessEvent[Probe[main.condUint8]Return@b8c08]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
-// 0x1023: ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1039: ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x105b: ProcessEvent[Probe[main.condUint8]@b8ba8]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@b9048]
 	PrepareEventRoot e8 00 00 00 12 00 00 00 
-	Call 23 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[0]]
-	Call 39 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb8ba8.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xb9048.expr[1]]
 	Return 
-// 0x106f: ProcessEvent[Probe[main.condUint8]Return@b8c08]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@b90a8]
 	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
-// 0x1079: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1089: ProcessEvent[Probe[main.inlined]@b7cd0]
+// 0x1062: ProcessEvent[Probe[main.inlined]@b7cd0]
 	PrepareEventRoot 2a 01 00 00 09 00 00 00 
-	Call 79 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb7cd0.expr[0]]
 	Return 
-// 0x1098: ProcessExpression[Probe[main.inlined]@0xb86d8.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ae: ProcessEvent[Probe[main.inlined]@b86d8]
+// 0x1087: ProcessEvent[Probe[main.inlined]@b8b78]
 	PrepareEventRoot 2a 01 00 00 09 00 00 00 
-	Call 98 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb86d8.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xb8b78.expr[0]]
 	Return 
-// 0x10bd: ProcessEvent[Probe[main.inlined]Return@b870c]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@b8bac]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x10c7: ProcessExpression[Probe[main.intArg]@0xb8408.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10dd: ProcessEvent[Probe[main.intArg]@b8408]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@b88a8]
 	PrepareEventRoot bb 00 00 00 09 00 00 00 
-	Call c7 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb8408.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xb88a8.expr[0]]
 	Return 
-// 0x10ec: ProcessEvent[Probe[main.intArg]Return@b843c]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@b88dc]
 	PrepareEventRoot bc 00 00 00 00 00 00 00 
 	Return 
-// 0x10f6: ProcessExpression[Probe[main.intArrayArg]@0xb8568.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x1112: ProcessEvent[Probe[main.intArrayArg]@b8568]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@b8a08]
 	PrepareEventRoot c5 00 00 00 19 00 00 00 
-	Call f6 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8568.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xb8a08.expr[0]]
 	Return 
-// 0x1121: ProcessEvent[Probe[main.intArrayArg]Return@b85a8]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@b8a48]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x112b: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb86b0.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 5e 14 00 00 // ProcessType[[3]string]
+	Call 37 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x114c: ProcessEvent[Probe[main.stringArrayArgFrameless]@b86b0]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@b8b50]
 	PrepareEventRoot cb 00 00 00 31 00 00 00 
-	Call 2b 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb86b0.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xb8b50.expr[0]]
 	Return 
-// 0x115b: ProcessExpression[Probe[main.intSliceArg]@0xb84e8.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call b4 14 00 00 // ProcessType[[]int]
+	Call 8d 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1184: ProcessEvent[Probe[main.intSliceArg]@b84e8]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@b8988]
 	PrepareEventRoot c3 00 00 00 19 00 00 00 
-	Call 5b 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb84e8.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xb8988.expr[0]]
 	Return 
-// 0x1193: ProcessEvent[Probe[main.intSliceArg]Return@b8520]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@b89c0]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x119d: ProcessExpression[Probe[main.stringArg]@0xb8478.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x11bf: ProcessEvent[Probe[main.stringArg]@b8478]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot bd 00 00 00 11 00 00 00 
-	Call 9d 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8478.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.stringArg]Return@b84b0]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot be 00 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessEvent[Probe[main.stringArg]@b8478]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot bf 00 00 00 00 00 00 00 
 	Return 
-// 0x11e2: ProcessEvent[Probe[main.stringArg]Return@b84b0]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c0 00 00 00 00 00 00 00 
 	Return 
-// 0x11ec: ProcessExpression[Probe[main.mapArg]@0xb8798.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7f 15 00 00 // ProcessType[map[string]int]
+	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1207: ProcessExpression[Probe[main.mapArg]@0xb8798.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 7f 15 00 00 // ProcessType[map[string]int]
+	Call 58 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1222: ProcessEvent[Probe[main.mapArg]@b8798]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@b8c38]
 	PrepareEventRoot cc 00 00 00 11 00 00 00 
-	Call ec 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8798.expr[0]]
-	Call 07 12 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8798.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xb8c38.expr[1]]
 	Return 
-// 0x1236: ProcessEvent[Probe[main.mapArg]Return@b87c4]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@b8c64]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1240: ProcessEvent[Probe[main.noArgs]@b88b8]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@b8d58]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x124a: ProcessEvent[Probe[main.noArgs]Return@b88ec]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@b8d8c]
 	PrepareEventRoot d1 00 00 00 00 00 00 00 
 	Return 
-// 0x1254: ProcessExpression[Probe[main.stringArg]@0xb8478.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1276: ProcessExpression[Probe[main.stringArg]@0xb8478.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1298: ProcessEvent[Probe[main.stringArg]@b8478]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@b8918]
 	PrepareEventRoot c1 00 00 00 21 00 00 00 
-	Call 54 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8478.expr[0]]
-	Call 76 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8478.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xb8918.expr[1]]
 	Return 
-// 0x12ac: ProcessEvent[Probe[main.stringArg]Return@b84b0]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@b8950]
 	PrepareEventRoot c2 00 00 00 00 00 00 00 
 	Return 
-// 0x12b6: ProcessExpression[Probe[main.stringArrayArg]@0xb8658.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 5e 14 00 00 // ProcessType[[3]string]
+	Call 37 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12d7: ProcessEvent[Probe[main.stringArrayArg]@b8658]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@b8af8]
 	PrepareEventRoot c9 00 00 00 31 00 00 00 
-	Call b6 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8658.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xb8af8.expr[0]]
 	Return 
-// 0x12e6: ProcessEvent[Probe[main.stringArrayArg]Return@b8698]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@b8b38]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x12f0: ProcessExpression[Probe[main.stringSliceArg]@0xb85d8.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call e2 14 00 00 // ProcessType[[]string]
+	Call bb 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1319: ProcessEvent[Probe[main.stringSliceArg]@b85d8]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@b8a78]
 	PrepareEventRoot c7 00 00 00 19 00 00 00 
-	Call f0 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb85d8.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xb8a78.expr[0]]
 	Return 
-// 0x1328: ProcessEvent[Probe[main.stringSliceArg]Return@b8610]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@b8ab0]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1332: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@b9730]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ba390]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x133c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb98a8.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 64 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1357: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@b98a8]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ba508]
 	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 3c 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xb98a8.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xba508.expr[0]]
 	Return 
-// 0x1366: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 82 00 00 00 
 	Return 
-// 0x136c: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer b9 00 00 00 
 	Return 
-// 0x1372: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x1378: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x137e: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 28 00 00 00 
 	Return 
-// 0x1384: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x138a: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1390: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 12 00 00 00 
 	Return 
-// 0x1396: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 10 00 00 00 
 	Return 
-// 0x139c: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*main.bigStruct]
+// 0x1387: ProcessType[*main.bigStruct]
 	ProcessPointer a0 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*main.condFields]
+// 0x138d: ProcessType[*main.condFields]
 	ProcessPointer 79 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*runtime._defer]
+// 0x1393: ProcessType[*runtime._defer]
 	ProcessPointer 1b 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*runtime._panic]
+// 0x1399: ProcessType[*runtime._panic]
 	ProcessPointer 19 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime.cgoCallers]
+// 0x139f: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 42 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime.coro]
+// 0x13a5: ProcessType[*runtime.coro]
 	ProcessPointer 30 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.g]
+// 0x13ab: ProcessType[*runtime.g]
 	ProcessPointer 16 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.m]
+// 0x13b1: ProcessType[*runtime.m]
 	ProcessPointer 1d 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.p]
+// 0x13b7: ProcessType[*runtime.p]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.sudog]
+// 0x13bd: ProcessType[*runtime.sudog]
 	ProcessPointer 2a 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.synctestBubble]
+// 0x13c3: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 32 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.timer]
+// 0x13c9: ProcessType[*runtime.timer]
 	ProcessPointer 2d 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*runtime.traceBuf]
+// 0x13cf: ProcessType[*runtime.traceBuf]
 	ProcessPointer 50 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*string]
+// 0x13d5: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1402: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13db: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x1408: ProcessType[*table<string,int>]
+// 0x13e1: ProcessType[*table<string,int>]
 	ProcessPointer 91 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<string,main.bigStruct>]
+// 0x13e7: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1414: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13ed: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a3 00 00 00 
 	Return 
-// 0x141a: ProcessType[*uint]
+// 0x13f3: ProcessType[*uint]
 	ProcessPointer 0a 00 00 00 
 	Return 
-// 0x1420: ProcessType[*uint16]
+// 0x13f9: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint32]
+// 0x13ff: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint64]
+// 0x1405: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uint8]
+// 0x140b: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1438: ProcessType[*uintptr]
+// 0x1411: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x143e: ProcessType[[2]*runtime.traceBuf]
+// 0x1417: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call f6 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call cf 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x144e: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1427: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 3e 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 17 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x145e: ProcessType[[3]string]
+// 0x1437: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x146e: ProcessType[[]*runtime.p]
+// 0x1447: ProcessType[[]*runtime.p]
 	ProcessSlice 8b 00 00 00 08 00 00 00 
 	Return 
-// 0x1478: ProcessType[[]*runtime.p.array]
+// 0x1451: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call de 13 00 00 // ProcessType[*runtime.p]
+	Call b7 13 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1484: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x145d: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 02 14 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call db 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1490: ProcessType[[]*table<string,int>.array]
+// 0x1469: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 08 14 00 00 // ProcessType[*table<string,int>]
+	Call e1 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x149c: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1475: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call e7 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14a8: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1481: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 14 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call ed 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14b4: ProcessType[[]int]
+// 0x148d: ProcessType[[]int]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x14be: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1497: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call c1 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 9a 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ca: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x14a3: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call cc 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call a5 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14d6: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x14af: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call d7 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b0 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14e2: ProcessType[[]string]
+// 0x14bb: ProcessType[[]string]
 	ProcessSlice 8f 00 00 00 10 00 00 00 
 	Return 
-// 0x14ec: ProcessType[[]string.array]
+// 0x14c5: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x14f8: ProcessType[[]uint8]
+// 0x14d1: ProcessType[[]uint8]
 	ProcessSlice 86 00 00 00 01 00 00 00 
 	Return 
-// 0x1502: ProcessType[[]uintptr]
+// 0x14db: ProcessType[[]uintptr]
 	ProcessSlice 88 00 00 00 08 00 00 00 
 	Return 
-// 0x150c: ProcessType[error]
+// 0x14e5: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x150e: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14e7: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b8 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x151a: ProcessType[groupReference<string,int>]
+// 0x14f3: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 98 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1526: ProcessType[groupReference<string,main.bigStruct>]
+// 0x14ff: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a2 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1532: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x150b: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups af 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x153e: ProcessType[main.condFields]
+// 0x1517: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x1549: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1522: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b7 00 00 00 b3 00 00 00 10 18 
 	Return 
-// 0x1555: ProcessType[map<string,int>]
+// 0x152e: ProcessType[map<string,int>]
 	ProcessGoSwissMap 97 00 00 00 94 00 00 00 10 18 
 	Return 
-// 0x1561: ProcessType[map<string,main.bigStruct>]
+// 0x153a: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a1 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x156d: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1546: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap ae 00 00 00 a6 00 00 00 10 18 
 	Return 
-// 0x1579: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1552: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x157f: ProcessType[map[string]int]
+// 0x1558: ProcessType[map[string]int]
 	ProcessPointer 71 00 00 00 
 	Return 
-// 0x1585: ProcessType[map[string]main.bigStruct]
+// 0x155e: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x158b: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1564: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1591: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x156a: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call e2 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bb 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15a1: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x157a: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call f2 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call cb 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x15b1: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x158a: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call f8 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d1 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15c1: ProcessType[noalg.map.group[string]int]
+// 0x159a: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call a1 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 7a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15cc: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x15a5: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 91 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 6a 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15d7: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x15b0: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call b1 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 8a 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15e2: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call ed 16 00 00 // ProcessType[string]
+// 0x15bb: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c6 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ae 13 00 00 // ProcessType[*main.bigStruct]
+	Call 87 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15f2: ProcessType[noalg.struct { key string; elem int }]
-	Call ed 16 00 00 // ProcessType[string]
+// 0x15cb: ProcessType[noalg.struct { key string; elem int }]
+	Call c6 16 00 00 // ProcessType[string]
 	Return 
-// 0x15f8: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15d1: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 79 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 52 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1603: ProcessType[runtime.g]
+// 0x15dc: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c0 13 00 00 // ProcessType[*runtime._panic]
+	Call 99 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ba 13 00 00 // ProcessType[*runtime._defer]
+	Call 93 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b0 00 00 00 
-	Call f8 14 00 00 // ProcessType[[]uint8]
+	Call d1 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 7e 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call e4 13 00 00 // ProcessType[*runtime.sudog]
+	Call bd 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.timer]
+	Call c9 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime.coro]
+	Call a5 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call c3 13 00 00 // ProcessType[*runtime.synctestBubble]
 	Return 
-// 0x1668: ProcessType[runtime.m]
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+// 0x1641: ProcessType[runtime.m]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.g]
+	Call ab 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 38 00 00 00 
-	Call ed 16 00 00 // ProcessType[string]
+	Call c6 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 6e 14 00 00 // ProcessType[[]*runtime.p]
+	Call 47 14 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 9f 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 30 01 00 00 
-	Call d2 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call ab 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call dd 16 00 00 // ProcessType[runtime.mTraceState]
+	Call b6 16 00 00 // ProcessType[runtime.mTraceState]
 	Return 
-// 0x16d2: ProcessType[runtime.mLockProfile]
+// 0x16ab: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 02 15 00 00 // ProcessType[[]uintptr]
+	Call db 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16dd: ProcessType[runtime.mTraceState]
+// 0x16b6: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 4e 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call d8 13 00 00 // ProcessType[*runtime.m]
+	Call 27 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b1 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16ed: ProcessType[string]
+// 0x16c6: ProcessType[string]
 	ProcessString 84 00 00 00 
 	Return 
-// 0x16f3: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16cc: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0e 15 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x16fe: ProcessType[table<string,int>]
+// 0x16d7: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1a 15 00 00 // ProcessType[groupReference<string,int>]
+	Call f3 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1709: ProcessType[table<string,main.bigStruct>]
+// 0x16e2: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 26 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call ff 14 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1714: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x16ed: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 32 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0b 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1832,31 +1826,31 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5170
+ID: 5 Len: 8 Enqueue: 5131
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5869
+ID: 9 Len: 16 Enqueue: 5830
 ID: 10 Len: 8 Enqueue: 0
-ID: 11 Len: 8 Enqueue: 4996
+ID: 11 Len: 8 Enqueue: 4957
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
-ID: 14 Len: 16 Enqueue: 5388
+ID: 14 Len: 16 Enqueue: 5349
 ID: 15 Len: 8 Enqueue: 0
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 1 Enqueue: 0
 ID: 18 Len: 4 Enqueue: 0
-ID: 19 Len: 8 Enqueue: 5176
-ID: 20 Len: 8 Enqueue: 5026
-ID: 21 Len: 8 Enqueue: 5158
-ID: 22 Len: 440 Enqueue: 5635
+ID: 19 Len: 8 Enqueue: 5137
+ID: 20 Len: 8 Enqueue: 4987
+ID: 21 Len: 8 Enqueue: 5119
+ID: 22 Len: 440 Enqueue: 5596
 ID: 23 Len: 16 Enqueue: 0
-ID: 24 Len: 8 Enqueue: 5056
+ID: 24 Len: 8 Enqueue: 5017
 ID: 25 Len: 8 Enqueue: 0
-ID: 26 Len: 8 Enqueue: 5050
+ID: 26 Len: 8 Enqueue: 5011
 ID: 27 Len: 8 Enqueue: 0
-ID: 28 Len: 8 Enqueue: 5080
-ID: 29 Len: 1816 Enqueue: 5736
+ID: 28 Len: 8 Enqueue: 5041
+ID: 29 Len: 1816 Enqueue: 5697
 ID: 30 Len: 48 Enqueue: 0
 ID: 31 Len: 8 Enqueue: 0
 ID: 32 Len: 4 Enqueue: 0
@@ -1865,48 +1859,48 @@ ID: 34 Len: 1 Enqueue: 0
 ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 8 Enqueue: 0
-ID: 38 Len: 24 Enqueue: 5368
-ID: 39 Len: 8 Enqueue: 4990
+ID: 38 Len: 24 Enqueue: 5329
+ID: 39 Len: 8 Enqueue: 4951
 ID: 40 Len: 8 Enqueue: 0
-ID: 41 Len: 8 Enqueue: 5092
+ID: 41 Len: 8 Enqueue: 5053
 ID: 42 Len: 8 Enqueue: 0
-ID: 43 Len: 24 Enqueue: 5378
-ID: 44 Len: 8 Enqueue: 5104
+ID: 43 Len: 24 Enqueue: 5339
+ID: 44 Len: 8 Enqueue: 5065
 ID: 45 Len: 8 Enqueue: 0
 ID: 46 Len: 4 Enqueue: 0
-ID: 47 Len: 8 Enqueue: 5068
+ID: 47 Len: 8 Enqueue: 5029
 ID: 48 Len: 8 Enqueue: 0
-ID: 49 Len: 8 Enqueue: 5098
+ID: 49 Len: 8 Enqueue: 5059
 ID: 50 Len: 8 Enqueue: 0
 ID: 51 Len: 32 Enqueue: 0
 ID: 52 Len: 32 Enqueue: 0
 ID: 53 Len: 12 Enqueue: 0
 ID: 54 Len: 16 Enqueue: 0
-ID: 55 Len: 8 Enqueue: 5074
+ID: 55 Len: 8 Enqueue: 5035
 ID: 56 Len: 40 Enqueue: 0
 ID: 57 Len: 8 Enqueue: 0
 ID: 58 Len: 48 Enqueue: 0
 ID: 59 Len: 8 Enqueue: 0
 ID: 60 Len: 8 Enqueue: 0
 ID: 61 Len: 4 Enqueue: 0
-ID: 62 Len: 24 Enqueue: 5230
+ID: 62 Len: 24 Enqueue: 5191
 ID: 63 Len: 8 Enqueue: 0
-ID: 64 Len: 8 Enqueue: 5086
-ID: 65 Len: 8 Enqueue: 5062
+ID: 64 Len: 8 Enqueue: 5047
+ID: 65 Len: 8 Enqueue: 5023
 ID: 66 Len: 8 Enqueue: 0
 ID: 67 Len: 8 Enqueue: 0
 ID: 68 Len: 256 Enqueue: 0
 ID: 69 Len: 16 Enqueue: 0
-ID: 70 Len: 56 Enqueue: 5842
+ID: 70 Len: 56 Enqueue: 5803
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 0 Enqueue: 0
 ID: 73 Len: 8 Enqueue: 0
 ID: 74 Len: 1 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5853
+ID: 75 Len: 56 Enqueue: 5814
 ID: 76 Len: 8 Enqueue: 0
-ID: 77 Len: 32 Enqueue: 5198
-ID: 78 Len: 16 Enqueue: 5182
-ID: 79 Len: 8 Enqueue: 5110
+ID: 77 Len: 32 Enqueue: 5159
+ID: 78 Len: 16 Enqueue: 5143
+ID: 79 Len: 8 Enqueue: 5071
 ID: 80 Len: 8 Enqueue: 0
 ID: 81 Len: 48 Enqueue: 0
 ID: 82 Len: 0 Enqueue: 0
@@ -1922,43 +1916,43 @@ ID: 91 Len: 32 Enqueue: 0
 ID: 92 Len: 160 Enqueue: 0
 ID: 93 Len: 16 Enqueue: 0
 ID: 94 Len: 8 Enqueue: 0
-ID: 95 Len: 8 Enqueue: 5116
+ID: 95 Len: 8 Enqueue: 5077
 ID: 96 Len: 2 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
 ID: 98 Len: 16 Enqueue: 0
-ID: 99 Len: 8 Enqueue: 5014
-ID: 100 Len: 8 Enqueue: 5020
-ID: 101 Len: 8 Enqueue: 5164
-ID: 102 Len: 8 Enqueue: 5032
-ID: 103 Len: 8 Enqueue: 5002
-ID: 104 Len: 8 Enqueue: 5008
-ID: 105 Len: 8 Enqueue: 5146
-ID: 106 Len: 8 Enqueue: 5152
-ID: 107 Len: 24 Enqueue: 5300
+ID: 99 Len: 8 Enqueue: 4975
+ID: 100 Len: 8 Enqueue: 4981
+ID: 101 Len: 8 Enqueue: 5125
+ID: 102 Len: 8 Enqueue: 4993
+ID: 103 Len: 8 Enqueue: 4963
+ID: 104 Len: 8 Enqueue: 4969
+ID: 105 Len: 8 Enqueue: 5107
+ID: 106 Len: 8 Enqueue: 5113
+ID: 107 Len: 24 Enqueue: 5261
 ID: 108 Len: 24 Enqueue: 0
-ID: 109 Len: 24 Enqueue: 5346
-ID: 110 Len: 48 Enqueue: 5214
-ID: 111 Len: 8 Enqueue: 5503
+ID: 109 Len: 24 Enqueue: 5307
+ID: 110 Len: 48 Enqueue: 5175
+ID: 111 Len: 8 Enqueue: 5464
 ID: 112 Len: 8 Enqueue: 0
-ID: 113 Len: 48 Enqueue: 5461
+ID: 113 Len: 48 Enqueue: 5422
 ID: 114 Len: 8 Enqueue: 0
-ID: 115 Len: 8 Enqueue: 5128
-ID: 116 Len: 8 Enqueue: 5509
+ID: 115 Len: 8 Enqueue: 5089
+ID: 116 Len: 8 Enqueue: 5470
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5473
+ID: 118 Len: 48 Enqueue: 5434
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5134
-ID: 121 Len: 80 Enqueue: 5438
+ID: 120 Len: 8 Enqueue: 5095
+ID: 121 Len: 80 Enqueue: 5399
 ID: 122 Len: 6 Enqueue: 0
-ID: 123 Len: 8 Enqueue: 5044
-ID: 124 Len: 8 Enqueue: 5515
+ID: 123 Len: 8 Enqueue: 5005
+ID: 124 Len: 8 Enqueue: 5476
 ID: 125 Len: 8 Enqueue: 0
-ID: 126 Len: 48 Enqueue: 5485
+ID: 126 Len: 48 Enqueue: 5446
 ID: 127 Len: 8 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5140
-ID: 129 Len: 8 Enqueue: 4966
-ID: 130 Len: 8 Enqueue: 4972
-ID: 131 Len: 8 Enqueue: 4984
+ID: 128 Len: 8 Enqueue: 5101
+ID: 129 Len: 8 Enqueue: 4927
+ID: 130 Len: 8 Enqueue: 4933
+ID: 131 Len: 8 Enqueue: 4945
 ID: 132 Len: 1 Enqueue: 0
 ID: 133 Len: 8 Enqueue: 0
 ID: 134 Len: 1 Enqueue: 0
@@ -1966,53 +1960,53 @@ ID: 135 Len: 8 Enqueue: 0
 ID: 136 Len: 8 Enqueue: 0
 ID: 137 Len: 8 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 8 Enqueue: 5240
+ID: 139 Len: 8 Enqueue: 5201
 ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
-ID: 143 Len: 16 Enqueue: 5356
+ID: 143 Len: 16 Enqueue: 5317
 ID: 144 Len: 8 Enqueue: 0
-ID: 145 Len: 32 Enqueue: 5886
-ID: 146 Len: 16 Enqueue: 5402
+ID: 145 Len: 32 Enqueue: 5847
+ID: 146 Len: 16 Enqueue: 5363
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 200 Enqueue: 5569
-ID: 149 Len: 192 Enqueue: 5537
-ID: 150 Len: 24 Enqueue: 5618
-ID: 151 Len: 8 Enqueue: 5264
-ID: 152 Len: 200 Enqueue: 5310
-ID: 153 Len: 32 Enqueue: 5897
-ID: 154 Len: 16 Enqueue: 5414
+ID: 148 Len: 200 Enqueue: 5530
+ID: 149 Len: 192 Enqueue: 5498
+ID: 150 Len: 24 Enqueue: 5579
+ID: 151 Len: 8 Enqueue: 5225
+ID: 152 Len: 200 Enqueue: 5271
+ID: 153 Len: 32 Enqueue: 5858
+ID: 154 Len: 16 Enqueue: 5375
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 5580
-ID: 157 Len: 192 Enqueue: 5521
-ID: 158 Len: 24 Enqueue: 5602
-ID: 159 Len: 8 Enqueue: 5038
+ID: 156 Len: 200 Enqueue: 5541
+ID: 157 Len: 192 Enqueue: 5482
+ID: 158 Len: 24 Enqueue: 5563
+ID: 159 Len: 8 Enqueue: 4999
 ID: 160 Len: 184 Enqueue: 0
-ID: 161 Len: 8 Enqueue: 5276
-ID: 162 Len: 200 Enqueue: 5322
-ID: 163 Len: 32 Enqueue: 5908
-ID: 164 Len: 16 Enqueue: 5426
+ID: 161 Len: 8 Enqueue: 5237
+ID: 162 Len: 200 Enqueue: 5283
+ID: 163 Len: 32 Enqueue: 5869
+ID: 164 Len: 16 Enqueue: 5387
 ID: 165 Len: 8 Enqueue: 0
-ID: 166 Len: 136 Enqueue: 5591
-ID: 167 Len: 128 Enqueue: 5553
-ID: 168 Len: 16 Enqueue: 5624
-ID: 169 Len: 8 Enqueue: 5497
+ID: 166 Len: 136 Enqueue: 5552
+ID: 167 Len: 128 Enqueue: 5514
+ID: 168 Len: 16 Enqueue: 5585
+ID: 169 Len: 8 Enqueue: 5458
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 48 Enqueue: 5449
+ID: 171 Len: 48 Enqueue: 5410
 ID: 172 Len: 8 Enqueue: 0
-ID: 173 Len: 8 Enqueue: 5122
-ID: 174 Len: 8 Enqueue: 5288
-ID: 175 Len: 136 Enqueue: 5334
-ID: 176 Len: 32 Enqueue: 5875
-ID: 177 Len: 16 Enqueue: 5390
+ID: 173 Len: 8 Enqueue: 5083
+ID: 174 Len: 8 Enqueue: 5249
+ID: 175 Len: 136 Enqueue: 5295
+ID: 176 Len: 32 Enqueue: 5836
+ID: 177 Len: 16 Enqueue: 5351
 ID: 178 Len: 8 Enqueue: 0
 ID: 179 Len: 136 Enqueue: 0
 ID: 180 Len: 128 Enqueue: 0
 ID: 181 Len: 16 Enqueue: 0
 ID: 182 Len: 8 Enqueue: 0
-ID: 183 Len: 8 Enqueue: 5252
+ID: 183 Len: 8 Enqueue: 5213
 ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 8 Enqueue: 4978
+ID: 185 Len: 8 Enqueue: 4939
 ID: 186 Len: 128 Enqueue: 0
 ID: 187 Len: 9 Enqueue: 0
 ID: 188 Len: 0 Enqueue: 0
@@ -2122,7 +2116,7 @@ ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 25 Enqueue: 0
 ID: 293 Len: 0 Enqueue: 0
 ID: 294 Len: 17 Enqueue: 0
-ID: 295 Len: 33 Enqueue: 0
+ID: 295 Len: 25 Enqueue: 0
 ID: 296 Len: 0 Enqueue: 0
 ID: 297 Len: 9 Enqueue: 0
 ID: 298 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 3f 13 00 00 // ProcessType[*****int]
+	Call cf 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@c826c]
-	PrepareEventRoot 31 01 00 00 11 00 00 00 
+	PrepareEventRoot 68 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	Return 
@@ -24,31 +24,31 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 51 13 00 00 // ProcessType[**int]
+	Call e1 19 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c82a4]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	PrepareEventRoot 69 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xc82a4.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@c9008]
-	PrepareEventRoot d3 00 00 00 11 00 00 00 
+	PrepareEventRoot d6 00 00 00 11 00 00 00 
 	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
 	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	Return 
 // 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@c9054]
-	PrepareEventRoot d4 00 00 00 00 00 00 00 
+	PrepareEventRoot d7 00 00 00 00 00 00 00 
 	Return 
 // 0xcb: ProcessCondition[Probe[main.condBool]@0xc9768]
 	ConditionBegin 
@@ -64,15 +64,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@c9768]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
-	PrepareEventRoot ff 00 00 00 11 00 00 00 
+	PrepareEventRoot 02 01 00 00 11 00 00 00 
 	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	Return 
 // 0x117: ProcessEvent[Probe[main.condBool]Return@c97cc]
-	PrepareEventRoot 00 01 00 00 00 00 00 00 
+	PrepareEventRoot 03 01 00 00 00 00 00 00 
 	Return 
 // 0x121: ProcessCondition[Probe[main.condBool]@0xc9768]
 	ConditionBegin 
@@ -88,15 +88,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@c9768]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
-	PrepareEventRoot 01 01 00 00 11 00 00 00 
+	PrepareEventRoot 04 01 00 00 11 00 00 00 
 	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	Return 
 // 0x16d: ProcessEvent[Probe[main.condBool]Return@c97cc]
-	PrepareEventRoot 02 01 00 00 00 00 00 00 
+	PrepareEventRoot 05 01 00 00 00 00 00 00 
 	Return 
 // 0x177: ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	ExprPrepare 
@@ -108,43 +108,43 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@c9768]
-	PrepareEventRoot 03 01 00 00 12 00 00 00 
+	PrepareEventRoot 06 01 00 00 12 00 00 00 
 	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[1]]
 	Return 
 // 0x1c3: ProcessEvent[Probe[main.condBool]Return@c97cc]
-	PrepareEventRoot 04 01 00 00 00 00 00 00 
+	PrepareEventRoot 07 01 00 00 00 00 00 00 
 	Return 
 // 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xc9628.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@c9628]
-	PrepareEventRoot fb 00 00 00 11 00 00 00 
+	PrepareEventRoot fe 00 00 00 11 00 00 00 
 	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xc9628.expr[0]]
 	Return 
 // 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@c9688]
-	PrepareEventRoot fc 00 00 00 00 00 00 00 
+	PrepareEventRoot ff 00 00 00 00 00 00 00 
 	Return 
 // 0x208: ProcessExpression[Probe[main.condFloat64]@0xc96c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@c96c8]
-	PrepareEventRoot fd 00 00 00 11 00 00 00 
+	PrepareEventRoot 00 01 00 00 11 00 00 00 
 	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xc96c8.expr[0]]
 	Return 
 // 0x239: ProcessEvent[Probe[main.condFloat64]Return@c9728]
-	PrepareEventRoot fe 00 00 00 00 00 00 00 
+	PrepareEventRoot 01 01 00 00 00 00 00 00 
 	Return 
 // 0x243: ProcessCondition[Probe[main.condInt16]@0xc91b8]
 	ConditionBegin 
@@ -160,15 +160,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@c91b8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc91b8]
-	PrepareEventRoot db 00 00 00 11 00 00 00 
+	PrepareEventRoot de 00 00 00 11 00 00 00 
 	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	Return 
 // 0x290: ProcessEvent[Probe[main.condInt16]Return@c9214]
-	PrepareEventRoot dc 00 00 00 00 00 00 00 
+	PrepareEventRoot df 00 00 00 00 00 00 00 
 	Return 
 // 0x29a: ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	ExprPrepare 
@@ -180,15 +180,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@c91b8]
-	PrepareEventRoot dd 00 00 00 13 00 00 00 
+	PrepareEventRoot e0 00 00 00 13 00 00 00 
 	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[1]]
 	Return 
 // 0x2e6: ProcessEvent[Probe[main.condInt16]Return@c9214]
-	PrepareEventRoot de 00 00 00 00 00 00 00 
+	PrepareEventRoot e1 00 00 00 00 00 00 00 
 	Return 
 // 0x2f0: ProcessCondition[Probe[main.condInt32]@0xc9258]
 	ConditionBegin 
@@ -204,15 +204,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
-	PrepareEventRoot df 00 00 00 11 00 00 00 
+	PrepareEventRoot e2 00 00 00 11 00 00 00 
 	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	Return 
 // 0x33f: ProcessEvent[Probe[main.condInt32]Return@c92b4]
-	PrepareEventRoot e0 00 00 00 00 00 00 00 
+	PrepareEventRoot e3 00 00 00 00 00 00 00 
 	Return 
 // 0x349: ProcessCondition[Probe[main.condInt32]@0xc9258]
 	ConditionBegin 
@@ -228,15 +228,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
-	PrepareEventRoot e1 00 00 00 11 00 00 00 
+	PrepareEventRoot e4 00 00 00 11 00 00 00 
 	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	Return 
 // 0x398: ProcessEvent[Probe[main.condInt32]Return@c92b4]
-	PrepareEventRoot e2 00 00 00 00 00 00 00 
+	PrepareEventRoot e5 00 00 00 00 00 00 00 
 	Return 
 // 0x3a2: ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	ExprPrepare 
@@ -248,15 +248,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@c9258]
-	PrepareEventRoot e3 00 00 00 15 00 00 00 
+	PrepareEventRoot e6 00 00 00 15 00 00 00 
 	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[1]]
 	Return 
 // 0x3ee: ProcessEvent[Probe[main.condInt32]Return@c92b4]
-	PrepareEventRoot e4 00 00 00 00 00 00 00 
+	PrepareEventRoot e7 00 00 00 00 00 00 00 
 	Return 
 // 0x3f8: ProcessCondition[Probe[main.condInt64]@0xc92f8]
 	ConditionBegin 
@@ -272,15 +272,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@c92f8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc92f8]
-	PrepareEventRoot e5 00 00 00 11 00 00 00 
+	PrepareEventRoot e8 00 00 00 11 00 00 00 
 	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	Return 
 // 0x44b: ProcessEvent[Probe[main.condInt64]Return@c9354]
-	PrepareEventRoot e6 00 00 00 00 00 00 00 
+	PrepareEventRoot e9 00 00 00 00 00 00 00 
 	Return 
 // 0x455: ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	ExprPrepare 
@@ -292,15 +292,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@c92f8]
-	PrepareEventRoot e7 00 00 00 19 00 00 00 
+	PrepareEventRoot ea 00 00 00 19 00 00 00 
 	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[1]]
 	Return 
 // 0x4a1: ProcessEvent[Probe[main.condInt64]Return@c9354]
-	PrepareEventRoot e8 00 00 00 00 00 00 00 
+	PrepareEventRoot eb 00 00 00 00 00 00 00 
 	Return 
 // 0x4ab: ProcessCondition[Probe[main.condInt8]@0xc9108]
 	ConditionBegin 
@@ -316,15 +316,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@c9108]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc9108]
-	PrepareEventRoot d7 00 00 00 11 00 00 00 
+	PrepareEventRoot da 00 00 00 11 00 00 00 
 	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	Return 
 // 0x4f7: ProcessEvent[Probe[main.condInt8]Return@c916c]
-	PrepareEventRoot d8 00 00 00 00 00 00 00 
+	PrepareEventRoot db 00 00 00 00 00 00 00 
 	Return 
 // 0x501: ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	ExprPrepare 
@@ -336,15 +336,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@c9108]
-	PrepareEventRoot d9 00 00 00 12 00 00 00 
+	PrepareEventRoot dc 00 00 00 12 00 00 00 
 	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[1]]
 	Return 
 // 0x54d: ProcessEvent[Probe[main.condInt8]Return@c916c]
-	PrepareEventRoot da 00 00 00 00 00 00 00 
+	PrepareEventRoot dd 00 00 00 00 00 00 00 
 	Return 
 // 0x557: ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
 	ConditionBegin 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
-	PrepareEventRoot 2b 01 00 00 11 00 00 00 
+	PrepareEventRoot 2e 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@c9cb4]
-	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	PrepareEventRoot 2f 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
-	PrepareEventRoot 1f 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Return 
 // 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
-	PrepareEventRoot 20 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 93 13 00 00 // ProcessType[*main.condFields]
+	Call 29 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
-	PrepareEventRoot 21 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	Return 
 // 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
-	PrepareEventRoot 22 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x6b3: ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x708: ProcessEvent[Probe[main.condOnly]@c9c08]
 	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
-	PrepareEventRoot 27 01 00 00 19 00 00 00 
+	PrepareEventRoot 2a 01 00 00 19 00 00 00 
 	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
 // 0x721: ProcessEvent[Probe[main.condOnly]Return@c9c64]
-	PrepareEventRoot 28 01 00 00 00 00 00 00 
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
 // 0x72b: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x763: ProcessEvent[Probe[main.condOnly]@c9c08]
-	PrepareEventRoot 29 01 00 00 19 00 00 00 
+	PrepareEventRoot 2c 01 00 00 19 00 00 00 
 	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
 // 0x777: ProcessEvent[Probe[main.condOnly]Return@c9c64]
-	PrepareEventRoot 2a 01 00 00 00 00 00 00 
+	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
 // 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
-	PrepareEventRoot 19 01 00 00 11 00 00 00 
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
 	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
 // 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 1a 01 00 00 00 00 00 00 
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
 // 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x829: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
-	PrepareEventRoot 1b 01 00 00 11 00 00 00 
+	PrepareEventRoot 1e 01 00 00 11 00 00 00 
 	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
 // 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 1c 01 00 00 00 00 00 00 
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
 // 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 93 13 00 00 // ProcessType[*main.condFields]
+	Call 29 1a 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x884: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
-	PrepareEventRoot 1d 01 00 00 19 00 00 00 
+	PrepareEventRoot 20 01 00 00 19 00 00 00 
 	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	Return 
 // 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 1e 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
 	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
-	PrepareEventRoot 23 01 00 00 09 00 00 00 
+	PrepareEventRoot 26 01 00 00 09 00 00 00 
 	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Return 
 // 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
-	PrepareEventRoot 24 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
 // 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
-	PrepareEventRoot 25 01 00 00 11 00 00 00 
+	PrepareEventRoot 28 01 00 00 11 00 00 00 
 	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
-	PrepareEventRoot 26 01 00 00 09 00 00 00 
+	PrepareEventRoot 29 01 00 00 09 00 00 00 
 	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	Return 
 // 0x958: ProcessCondition[Probe[main.condString]@0xc9818]
@@ -612,15 +612,15 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x99c: ProcessEvent[Probe[main.condString]@c9818]
 	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
-	PrepareEventRoot 05 01 00 00 11 00 00 00 
+	PrepareEventRoot 08 01 00 00 11 00 00 00 
 	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
 // 0x9b0: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 06 01 00 00 00 00 00 00 
+	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
 // 0x9ba: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
@@ -637,37 +637,37 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x9f9: ProcessEvent[Probe[main.condString]@c9818]
 	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
-	PrepareEventRoot 07 01 00 00 11 00 00 00 
+	PrepareEventRoot 0a 01 00 00 11 00 00 00 
 	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
 // 0xa0d: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 08 01 00 00 00 00 00 00 
+	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
 // 0xa17: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa39: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xa5b: ProcessEvent[Probe[main.condString]@c9818]
-	PrepareEventRoot 09 01 00 00 21 00 00 00 
+	PrepareEventRoot 0c 01 00 00 21 00 00 00 
 	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
 // 0xa6f: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 0a 01 00 00 00 00 00 00 
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
 // 0xa79: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
@@ -684,23 +684,23 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xabd: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xadf: ProcessEvent[Probe[main.condString]@c9818]
 	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
-	PrepareEventRoot 0b 01 00 00 21 00 00 00 
+	PrepareEventRoot 0e 01 00 00 21 00 00 00 
 	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
 // 0xaf8: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 0c 01 00 00 00 00 00 00 
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
 // 0xb02: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
@@ -716,15 +716,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb43: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 0d 01 00 00 11 00 00 00 
+	PrepareEventRoot 10 01 00 00 11 00 00 00 
 	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
 // 0xb57: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 0e 01 00 00 00 00 00 00 
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
 // 0xb61: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
@@ -740,15 +740,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xb9f: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 0f 01 00 00 11 00 00 00 
+	PrepareEventRoot 12 01 00 00 11 00 00 00 
 	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
 // 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 10 01 00 00 00 00 00 00 
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
 // 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
@@ -764,15 +764,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc02: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 11 01 00 00 11 00 00 00 
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
 	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
 // 0xc16: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 12 01 00 00 00 00 00 00 
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
 // 0xc20: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
@@ -788,15 +788,15 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xc61: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 13 01 00 00 11 00 00 00 
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
 	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
 // 0xc75: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 14 01 00 00 00 00 00 00 
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
 // 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
@@ -812,36 +812,36 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xcc2: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 15 01 00 00 11 00 00 00 
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
 	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
 // 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 16 01 00 00 00 00 00 00 
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
 // 0xce0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 23 15 00 00 // ProcessType[main.condFields]
+	Call bf 1b 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd01: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd23: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	PrepareEventRoot 17 01 00 00 61 00 00 00 
+	PrepareEventRoot 1a 01 00 00 61 00 00 00 
 	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	Return 
 // 0xd37: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 18 01 00 00 00 00 00 00 
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
 // 0xd41: ProcessCondition[Probe[main.condUint16]@0xc9448]
 	ConditionBegin 
@@ -857,15 +857,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xd7a: ProcessEvent[Probe[main.condUint16]@c9448]
 	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
-	PrepareEventRoot ef 00 00 00 11 00 00 00 
+	PrepareEventRoot f2 00 00 00 11 00 00 00 
 	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	Return 
 // 0xd8e: ProcessEvent[Probe[main.condUint16]Return@c94a4]
-	PrepareEventRoot f0 00 00 00 00 00 00 00 
+	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
 // 0xd98: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
@@ -877,15 +877,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xdd0: ProcessEvent[Probe[main.condUint16]@c9448]
-	PrepareEventRoot f1 00 00 00 13 00 00 00 
+	PrepareEventRoot f4 00 00 00 13 00 00 00 
 	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	Return 
 // 0xde4: ProcessEvent[Probe[main.condUint16]Return@c94a4]
-	PrepareEventRoot f2 00 00 00 00 00 00 00 
+	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
 // 0xdee: ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	ConditionBegin 
@@ -901,15 +901,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe29: ProcessEvent[Probe[main.condUint32]@c94e8]
 	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
-	PrepareEventRoot f3 00 00 00 11 00 00 00 
+	PrepareEventRoot f6 00 00 00 11 00 00 00 
 	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	Return 
 // 0xe3d: ProcessEvent[Probe[main.condUint32]Return@c9544]
-	PrepareEventRoot f4 00 00 00 00 00 00 00 
+	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
 // 0xe47: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
@@ -921,15 +921,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xe7f: ProcessEvent[Probe[main.condUint32]@c94e8]
-	PrepareEventRoot f5 00 00 00 15 00 00 00 
+	PrepareEventRoot f8 00 00 00 15 00 00 00 
 	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	Return 
 // 0xe93: ProcessEvent[Probe[main.condUint32]Return@c9544]
-	PrepareEventRoot f6 00 00 00 00 00 00 00 
+	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
 // 0xe9d: ProcessCondition[Probe[main.condUint64]@0xc9588]
 	ConditionBegin 
@@ -945,15 +945,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xedc: ProcessEvent[Probe[main.condUint64]@c9588]
 	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
-	PrepareEventRoot f7 00 00 00 11 00 00 00 
+	PrepareEventRoot fa 00 00 00 11 00 00 00 
 	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	Return 
 // 0xef0: ProcessEvent[Probe[main.condUint64]Return@c95e4]
-	PrepareEventRoot f8 00 00 00 00 00 00 00 
+	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
 // 0xefa: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
@@ -965,15 +965,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf32: ProcessEvent[Probe[main.condUint64]@c9588]
-	PrepareEventRoot f9 00 00 00 19 00 00 00 
+	PrepareEventRoot fc 00 00 00 19 00 00 00 
 	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	Return 
 // 0xf46: ProcessEvent[Probe[main.condUint64]Return@c95e4]
-	PrepareEventRoot fa 00 00 00 00 00 00 00 
+	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
 // 0xf50: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
@@ -989,15 +989,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xf88: ProcessEvent[Probe[main.condUint8]@c9398]
 	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
-	PrepareEventRoot e9 00 00 00 11 00 00 00 
+	PrepareEventRoot ec 00 00 00 11 00 00 00 
 	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
 // 0xf9c: ProcessEvent[Probe[main.condUint8]Return@c93fc]
-	PrepareEventRoot ea 00 00 00 00 00 00 00 
+	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
 // 0xfa6: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
@@ -1013,15 +1013,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0xfde: ProcessEvent[Probe[main.condUint8]@c9398]
 	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
-	PrepareEventRoot eb 00 00 00 11 00 00 00 
+	PrepareEventRoot ee 00 00 00 11 00 00 00 
 	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
 // 0xff2: ProcessEvent[Probe[main.condUint8]Return@c93fc]
-	PrepareEventRoot ec 00 00 00 00 00 00 00 
+	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
 // 0xffc: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
@@ -1033,15 +1033,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1034: ProcessEvent[Probe[main.condUint8]@c9398]
-	PrepareEventRoot ed 00 00 00 12 00 00 00 
+	PrepareEventRoot f0 00 00 00 12 00 00 00 
 	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	Return 
 // 0x1048: ProcessEvent[Probe[main.condUint8]Return@c93fc]
-	PrepareEventRoot ee 00 00 00 00 00 00 00 
+	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
 // 0x1052: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	ExprPrepare 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1062: ProcessEvent[Probe[main.inlined]@c8040]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
 	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	Return 
 // 0x1071: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1087: ProcessEvent[Probe[main.inlined]@c8ed8]
-	PrepareEventRoot 2f 01 00 00 09 00 00 00 
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
 	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	Return 
 // 0x1096: ProcessEvent[Probe[main.inlined]Return@c8f0c]
-	PrepareEventRoot 30 01 00 00 00 00 00 00 
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
 // 0x10a0: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	ExprPrepare 
@@ -1070,11 +1070,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x10b6: ProcessEvent[Probe[main.intArg]@c8c08]
-	PrepareEventRoot c0 00 00 00 09 00 00 00 
+	PrepareEventRoot c3 00 00 00 09 00 00 00 
 	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	Return 
 // 0x10c5: ProcessEvent[Probe[main.intArg]Return@c8c3c]
-	PrepareEventRoot c1 00 00 00 00 00 00 00 
+	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
 // 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	ExprPrepare 
@@ -1082,20 +1082,20 @@
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
 // 0x10eb: ProcessEvent[Probe[main.intArrayArg]@c8d68]
-	PrepareEventRoot ca 00 00 00 19 00 00 00 
+	PrepareEventRoot cd 00 00 00 19 00 00 00 
 	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	Return 
 // 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
-	PrepareEventRoot cb 00 00 00 00 00 00 00 
+	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
 // 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 14 00 00 // ProcessType[[3]string]
+	Call df 1a 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
-	PrepareEventRoot d0 00 00 00 31 00 00 00 
+	PrepareEventRoot d3 00 00 00 31 00 00 00 
 	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	Return 
 // 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
@@ -1104,477 +1104,891 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 99 14 00 00 // ProcessType[[]int]
+	Call 35 1b 00 00 // ProcessType[[]int]
 	Return 
 // 0x115d: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
-	PrepareEventRoot c8 00 00 00 19 00 00 00 
+	PrepareEventRoot cb 00 00 00 19 00 00 00 
 	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	Return 
 // 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
-	PrepareEventRoot c9 00 00 00 00 00 00 00 
+	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
-	Return 
-// 0x1198: ProcessEvent[Probe[main.stringArg]@c8c78]
-	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	Return 
-// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
-	PrepareEventRoot c3 00 00 00 00 00 00 00 
-	Return 
-// 0x11b1: ProcessEvent[Probe[main.stringArg]@c8c78]
-	PrepareEventRoot c4 00 00 00 00 00 00 00 
-	Return 
-// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
-	PrepareEventRoot c5 00 00 00 00 00 00 00 
-	Return 
-// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 64 15 00 00 // ProcessType[map[string]int]
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11fb: ProcessEvent[Probe[main.mapArg]@c8f98]
-	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
-	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
+	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
-	PrepareEventRoot d2 00 00 00 00 00 00 00 
+// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x1219: ProcessEvent[Probe[main.noArgs]@c9098]
-	PrepareEventRoot d5 00 00 00 00 00 00 00 
-	Return 
-// 0x1223: ProcessEvent[Probe[main.noArgs]Return@c90cc]
-	PrepareEventRoot d6 00 00 00 00 00 00 00 
-	Return 
-// 0x122d: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
+	Call bf 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x124f: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1271: ProcessEvent[Probe[main.stringArg]@c8c78]
-	PrepareEventRoot c6 00 00 00 21 00 00 00 
-	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+	PrepareEventRoot 60 01 00 00 61 00 00 00 
+	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
+	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	Return 
-// 0x1285: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
-	PrepareEventRoot c7 00 00 00 00 00 00 00 
+// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+// 0x122d: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	Return 
+// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	Return 
+// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
+	Return 
+// 0x1255: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+	Return 
+// 0x125f: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+	Return 
+// 0x1269: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
-	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 43 14 00 00 // ProcessType[[3]string]
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
-	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+// 0x1284: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
-	PrepareEventRoot cf 00 00 00 00 00 00 00 
+// 0x12a6: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 40 01 00 00 19 00 00 00 
+	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	Return 
-// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Return 
+// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*string]
+	Return 
+// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1339: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 44 01 00 00 19 00 00 00 
+	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+	Return 
+// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 2f 1a 00 00 // ProcessType[*main.lenFields]
+	Return 
+// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 54 01 00 00 19 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+	Return 
+// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 56 01 00 00 00 00 00 00 
+	Return 
+// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
+	Return 
+// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 58 01 00 00 09 00 00 00 
+	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Return 
+// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
+	Return 
+// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Return 
+// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+	Return 
+// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x144c: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 3a 01 00 00 09 00 00 00 
+	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Return 
+// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+	Return 
+// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call c7 14 00 00 // ProcessType[[]string]
+	Call 35 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
-	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
-	PrepareEventRoot cd 00 00 00 00 00 00 00 
+// 0x14b0: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 3c 01 00 00 29 00 00 00 
+	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
 	Return 
-// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x14ce: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x14eb: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x150d: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x1521: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x152b: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1541: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x1550: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x155a: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1577: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1599: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x15ad: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x15b7: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x15cd: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x15dc: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x15e6: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1608: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x162a: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 38 01 00 00 21 00 00 00 
+	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+	Return 
+// 0x163e: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
+	Call ca 1b 00 00 // ProcessType[main.lenFields]
+	Return 
+// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x168b: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 46 01 00 00 59 00 00 00 
+	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+	Return 
+// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 48 01 00 00 00 00 00 00 
+	Return 
+// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1720: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 4c 01 00 00 09 00 00 00 
+	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+	Return 
+// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1755: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+	Return 
+// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x178a: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 50 01 00 00 09 00 00 00 
+	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
+	Return 
+// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 52 01 00 00 11 00 00 00 
+	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
+	Return 
+// 0x1806: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1828: ProcessEvent[Probe[main.stringArg]@c8c78]
+	PrepareEventRoot c5 00 00 00 11 00 00 00 
+	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Return 
+// 0x1837: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+	PrepareEventRoot c6 00 00 00 00 00 00 00 
+	Return 
+// 0x1841: ProcessEvent[Probe[main.stringArg]@c8c78]
+	PrepareEventRoot c7 00 00 00 00 00 00 00 
+	Return 
+// 0x184b: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+	PrepareEventRoot c8 00 00 00 00 00 00 00 
+	Return 
+// 0x1855: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 70 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
-	PrepareEventRoot 2e 01 00 00 09 00 00 00 
-	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x1870: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x133f: ProcessType[*****int]
-	ProcessPointer 87 00 00 00 
+// 0x188b: ProcessEvent[Probe[main.mapArg]@c8f98]
+	PrepareEventRoot d4 00 00 00 11 00 00 00 
+	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	Return 
-// 0x1345: ProcessType[****int]
-	ProcessPointer be 00 00 00 
+// 0x189f: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
+	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x134b: ProcessType[***int]
-	ProcessPointer 88 00 00 00 
+// 0x18a9: ProcessEvent[Probe[main.noArgs]@c9098]
+	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x1351: ProcessType[**int]
+// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@c90cc]
+	PrepareEventRoot d9 00 00 00 00 00 00 00 
+	Return 
+// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x18df: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
+	Call bc 1d 00 00 // ProcessType[string]
+	Return 
+// 0x1901: ProcessEvent[Probe[main.stringArg]@c8c78]
+	PrepareEventRoot c9 00 00 00 21 00 00 00 
+	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+	Return 
+// 0x1915: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+	PrepareEventRoot ca 00 00 00 00 00 00 00 
+	Return 
+// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
+	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
+	Call df 1a 00 00 // ProcessType[[3]string]
+	Return 
+// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
+	PrepareEventRoot d1 00 00 00 31 00 00 00 
+	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+	Return 
+// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
+	PrepareEventRoot d2 00 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call 63 1b 00 00 // ProcessType[[]string]
+	Return 
+// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
+	PrepareEventRoot cf 00 00 00 19 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+	Return 
+// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
+	PrepareEventRoot d0 00 00 00 00 00 00 00 
+	Return 
+// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
+	PrepareEventRoot 64 01 00 00 00 00 00 00 
+	Return 
+// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Call 3a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Return 
+// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
+	PrepareEventRoot 65 01 00 00 09 00 00 00 
+	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+	Return 
+// 0x19cf: ProcessType[*****int]
+	ProcessPointer 8a 00 00 00 
+	Return 
+// 0x19d5: ProcessType[****int]
+	ProcessPointer c1 00 00 00 
+	Return 
+// 0x19db: ProcessType[***int]
+	ProcessPointer 8b 00 00 00 
+	Return 
+// 0x19e1: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1357: ProcessType[*[]runtime.ancestorInfo]
+// 0x19e7: ProcessType[*[]int]
+	ProcessPointer 70 00 00 00 
+	Return 
+// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x135d: ProcessType[*bool]
+// 0x19f3: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1363: ProcessType[*error]
+// 0x19f9: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1369: ProcessType[*float32]
+// 0x19ff: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x136f: ProcessType[*float64]
+// 0x1a05: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1375: ProcessType[*int]
+// 0x1a0b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x137b: ProcessType[*int32]
+// 0x1a11: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1381: ProcessType[*int64]
+// 0x1a17: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1387: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1a1d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x138d: ProcessType[*main.bigStruct]
-	ProcessPointer a5 00 00 00 
-	Return 
-// 0x1393: ProcessType[*main.condFields]
-	ProcessPointer 7e 00 00 00 
-	Return 
-// 0x1399: ProcessType[*runtime._defer]
-	ProcessPointer 1c 00 00 00 
-	Return 
-// 0x139f: ProcessType[*runtime._panic]
-	ProcessPointer 1a 00 00 00 
-	Return 
-// 0x13a5: ProcessType[*runtime.cgoCallers]
-	ProcessPointer 46 00 00 00 
-	Return 
-// 0x13ab: ProcessType[*runtime.coro]
-	ProcessPointer 31 00 00 00 
-	Return 
-// 0x13b1: ProcessType[*runtime.g]
-	ProcessPointer 17 00 00 00 
-	Return 
-// 0x13b7: ProcessType[*runtime.m]
-	ProcessPointer 1e 00 00 00 
-	Return 
-// 0x13bd: ProcessType[*runtime.p]
-	ProcessPointer 8f 00 00 00 
-	Return 
-// 0x13c3: ProcessType[*runtime.sudog]
-	ProcessPointer 2b 00 00 00 
-	Return 
-// 0x13c9: ProcessType[*runtime.synctestBubble]
-	ProcessPointer 33 00 00 00 
-	Return 
-// 0x13cf: ProcessType[*runtime.timer]
-	ProcessPointer 2e 00 00 00 
-	Return 
-// 0x13d5: ProcessType[*runtime.traceBuf]
-	ProcessPointer 54 00 00 00 
-	Return 
-// 0x13db: ProcessType[*runtime.xRegState]
-	ProcessPointer 36 00 00 00 
-	Return 
-// 0x13e1: ProcessType[*string]
-	ProcessPointer 09 00 00 00 
-	Return 
-// 0x13e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessPointer b5 00 00 00 
-	Return 
-// 0x13ed: ProcessType[*table<string,int>]
-	ProcessPointer 96 00 00 00 
-	Return 
-// 0x13f3: ProcessType[*table<string,main.bigStruct>]
-	ProcessPointer 9e 00 00 00 
-	Return 
-// 0x13f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1a23: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x13ff: ProcessType[*uint]
+// 0x1a29: ProcessType[*main.condFields]
+	ProcessPointer 7e 00 00 00 
+	Return 
+// 0x1a2f: ProcessType[*main.lenFields]
+	ProcessPointer 81 00 00 00 
+	Return 
+// 0x1a35: ProcessType[*runtime._defer]
+	ProcessPointer 1c 00 00 00 
+	Return 
+// 0x1a3b: ProcessType[*runtime._panic]
+	ProcessPointer 1a 00 00 00 
+	Return 
+// 0x1a41: ProcessType[*runtime.cgoCallers]
+	ProcessPointer 46 00 00 00 
+	Return 
+// 0x1a47: ProcessType[*runtime.coro]
+	ProcessPointer 31 00 00 00 
+	Return 
+// 0x1a4d: ProcessType[*runtime.g]
+	ProcessPointer 17 00 00 00 
+	Return 
+// 0x1a53: ProcessType[*runtime.m]
+	ProcessPointer 1e 00 00 00 
+	Return 
+// 0x1a59: ProcessType[*runtime.p]
+	ProcessPointer 92 00 00 00 
+	Return 
+// 0x1a5f: ProcessType[*runtime.sudog]
+	ProcessPointer 2b 00 00 00 
+	Return 
+// 0x1a65: ProcessType[*runtime.synctestBubble]
+	ProcessPointer 33 00 00 00 
+	Return 
+// 0x1a6b: ProcessType[*runtime.timer]
+	ProcessPointer 2e 00 00 00 
+	Return 
+// 0x1a71: ProcessType[*runtime.traceBuf]
+	ProcessPointer 54 00 00 00 
+	Return 
+// 0x1a77: ProcessType[*runtime.xRegState]
+	ProcessPointer 36 00 00 00 
+	Return 
+// 0x1a7d: ProcessType[*string]
+	ProcessPointer 09 00 00 00 
+	Return 
+// 0x1a83: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessPointer b8 00 00 00 
+	Return 
+// 0x1a89: ProcessType[*table<string,int>]
+	ProcessPointer 99 00 00 00 
+	Return 
+// 0x1a8f: ProcessType[*table<string,main.bigStruct>]
+	ProcessPointer a1 00 00 00 
+	Return 
+// 0x1a95: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessPointer ab 00 00 00 
+	Return 
+// 0x1a9b: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1405: ProcessType[*uint16]
+// 0x1aa1: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x140b: ProcessType[*uint32]
+// 0x1aa7: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1411: ProcessType[*uint64]
+// 0x1aad: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1417: ProcessType[*uint8]
+// 0x1ab3: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x141d: ProcessType[*uintptr]
+// 0x1ab9: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1423: ProcessType[[2]*runtime.traceBuf]
+// 0x1abf: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call d5 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call 71 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1433: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1acf: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 23 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call bf 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1443: ProcessType[[3]string]
+// 0x1adf: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1453: ProcessType[[]*runtime.p]
+// 0x1aef: ProcessType[[]*runtime.p]
+	ProcessSlice 93 00 00 00 08 00 00 00 
+	Return 
+// 0x1af9: ProcessType[[]*runtime.p.array]
+	ProcessSliceDataPrep 
+	Call 59 1a 00 00 // ProcessType[*runtime.p]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b05: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 83 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b11: ProcessType[[]*table<string,int>.array]
+	ProcessSliceDataPrep 
+	Call 89 1a 00 00 // ProcessType[*table<string,int>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b1d: ProcessType[[]*table<string,main.bigStruct>.array]
+	ProcessSliceDataPrep 
+	Call 8f 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b29: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+	ProcessSliceDataPrep 
+	Call 95 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessSliceDataRepeat 08 00 00 00 
+	Return 
+// 0x1b35: ProcessType[[]int]
+	ProcessSlice 95 00 00 00 08 00 00 00 
+	Return 
+// 0x1b3f: ProcessType[[]noalg.map.group[string]int.array]
+	ProcessSliceDataPrep 
+	Call 70 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b4b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+	ProcessSliceDataPrep 
+	Call 7b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b57: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+	ProcessSliceDataPrep 
+	Call 86 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessSliceDataRepeat 00 00 00 00 
+	Return 
+// 0x1b63: ProcessType[[]string]
+	ProcessSlice 97 00 00 00 10 00 00 00 
+	Return 
+// 0x1b6d: ProcessType[[]string.array]
+	ProcessSliceDataPrep 
+	Call bc 1d 00 00 // ProcessType[string]
+	ProcessSliceDataRepeat 10 00 00 00 
+	Return 
+// 0x1b79: ProcessType[[]uint8]
+	ProcessSlice 8e 00 00 00 01 00 00 00 
+	Return 
+// 0x1b83: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x145d: ProcessType[[]*runtime.p.array]
-	ProcessSliceDataPrep 
-	Call bd 13 00 00 // ProcessType[*runtime.p]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1469: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call e7 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1475: ProcessType[[]*table<string,int>.array]
-	ProcessSliceDataPrep 
-	Call ed 13 00 00 // ProcessType[*table<string,int>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1481: ProcessType[[]*table<string,main.bigStruct>.array]
-	ProcessSliceDataPrep 
-	Call f3 13 00 00 // ProcessType[*table<string,main.bigStruct>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x148d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
-	ProcessSliceDataPrep 
-	Call f9 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessSliceDataRepeat 08 00 00 00 
-	Return 
-// 0x1499: ProcessType[[]int]
-	ProcessSlice 92 00 00 00 08 00 00 00 
-	Return 
-// 0x14a3: ProcessType[[]noalg.map.group[string]int.array]
-	ProcessSliceDataPrep 
-	Call a6 15 00 00 // ProcessType[noalg.map.group[string]int]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14af: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
-	ProcessSliceDataPrep 
-	Call b1 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14bb: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
-	ProcessSliceDataPrep 
-	Call bc 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessSliceDataRepeat 00 00 00 00 
-	Return 
-// 0x14c7: ProcessType[[]string]
-	ProcessSlice 94 00 00 00 10 00 00 00 
-	Return 
-// 0x14d1: ProcessType[[]string.array]
-	ProcessSliceDataPrep 
-	Call f2 16 00 00 // ProcessType[string]
-	ProcessSliceDataRepeat 10 00 00 00 
-	Return 
-// 0x14dd: ProcessType[[]uint8]
-	ProcessSlice 8b 00 00 00 01 00 00 00 
-	Return 
-// 0x14e7: ProcessType[[]uintptr]
-	ProcessSlice 8d 00 00 00 08 00 00 00 
-	Return 
-// 0x14f1: ProcessType[error]
+// 0x1b8d: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x14f3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups bd 00 00 00 88 00 00 00 00 08 
+// 0x1b8f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x14ff: ProcessType[groupReference<string,int>]
-	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
+// 0x1b9b: ProcessType[groupReference<string,int>]
+	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x150b: ProcessType[groupReference<string,main.bigStruct>]
-	ProcessGoSwissMapGroups a7 00 00 00 c8 00 00 00 00 08 
+// 0x1ba7: ProcessType[groupReference<string,main.bigStruct>]
+	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1517: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
+// 0x1bb3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1523: ProcessType[main.condFields]
+// 0x1bbf: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x152e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap bc 00 00 00 b8 00 00 00 10 18 
+// 0x1bca: ProcessType[main.lenFields]
+	Call bc 1d 00 00 // ProcessType[string]
+	IncrementOutputOffset 10 00 00 00 
+	Call 35 1b 00 00 // ProcessType[[]int]
+	IncrementOutputOffset 18 00 00 00 
+	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	IncrementOutputOffset 08 00 00 00 
+	Call 7d 1a 00 00 // ProcessType[*string]
+	IncrementOutputOffset 08 00 00 00 
+	Call e7 19 00 00 // ProcessType[*[]int]
 	Return 
-// 0x153a: ProcessType[map<string,int>]
-	ProcessGoSwissMap 9c 00 00 00 99 00 00 00 10 18 
+// 0x1bf8: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1546: ProcessType[map<string,main.bigStruct>]
-	ProcessGoSwissMap a6 00 00 00 a1 00 00 00 10 18 
+// 0x1c04: ProcessType[map<string,int>]
+	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1552: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
-	ProcessGoSwissMap b3 00 00 00 ab 00 00 00 10 18 
+// 0x1c10: ProcessType[map<string,main.bigStruct>]
+	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x155e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer b0 00 00 00 
+// 0x1c1c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1564: ProcessType[map[string]int]
+// 0x1c28: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer b3 00 00 00 
+	Return 
+// 0x1c2e: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x156a: ProcessType[map[string]main.bigStruct]
+// 0x1c34: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1570: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
-	ProcessPointer 83 00 00 00 
+// 0x1c3a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1576: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c40: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c7 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 91 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1586: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c50: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call d7 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call a1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1596: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c60: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call dd 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call a7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15a6: ProcessType[noalg.map.group[string]int]
+// 0x1c70: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 86 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 50 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15b1: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c7b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 76 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 40 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15bc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c86: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 96 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15c7: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call f2 16 00 00 // ProcessType[string]
+// 0x1c91: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call bc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8d 13 00 00 // ProcessType[*main.bigStruct]
+	Call 23 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15d7: ProcessType[noalg.struct { key string; elem int }]
-	Call f2 16 00 00 // ProcessType[string]
+// 0x1ca1: ProcessType[noalg.struct { key string; elem int }]
+	Call bc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x15dd: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1ca7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 28 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x15e8: ProcessType[runtime.g]
+// 0x1cb2: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 9f 13 00 00 // ProcessType[*runtime._panic]
+	Call 3b 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 99 13 00 00 // ProcessType[*runtime._defer]
+	Call 35 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call dd 14 00 00 // ProcessType[[]uint8]
+	Call 79 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call c3 13 00 00 // ProcessType[*runtime.sudog]
+	Call 5f 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call cf 13 00 00 // ProcessType[*runtime.timer]
+	Call 6b 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call ab 13 00 00 // ProcessType[*runtime.coro]
+	Call 47 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call c9 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 65 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call ec 16 00 00 // ProcessType[runtime.xRegPerG]
+	Call b6 1d 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1657: ProcessType[runtime.m]
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+// 0x1d21: ProcessType[runtime.m]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call b1 13 00 00 // ProcessType[*runtime.g]
+	Call 4d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call f2 16 00 00 // ProcessType[string]
+	Call bc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 53 14 00 00 // ProcessType[[]*runtime.p]
+	Call ef 1a 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call a5 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 41 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call cb 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 16 00 00 // ProcessType[runtime.mTraceState]
+	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call e6 16 00 00 // ProcessType[runtime.mWeakPointer]
+	Call b0 1d 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x16cb: ProcessType[runtime.mLockProfile]
+// 0x1d95: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 14 00 00 // ProcessType[[]uintptr]
+	Call 83 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16d6: ProcessType[runtime.mTraceState]
+// 0x1da0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 33 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call b7 13 00 00 // ProcessType[*runtime.m]
+	Call cf 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 53 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x16e6: ProcessType[runtime.mWeakPointer]
-	Call 87 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1db0: ProcessType[runtime.mWeakPointer]
+	Call 1d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x16ec: ProcessType[runtime.xRegPerG]
-	Call db 13 00 00 // ProcessType[*runtime.xRegState]
+// 0x1db6: ProcessType[runtime.xRegPerG]
+	Call 77 1a 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x16f2: ProcessType[string]
-	ProcessString 89 00 00 00 
+// 0x1dbc: ProcessType[string]
+	ProcessString 8c 00 00 00 
 	Return 
-// 0x16f8: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dc2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call f3 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 8f 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1703: ProcessType[table<string,int>]
+// 0x1dcd: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call ff 14 00 00 // ProcessType[groupReference<string,int>]
+	Call 9b 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x170e: ProcessType[table<string,main.bigStruct>]
+// 0x1dd8: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 0b 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call a7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1719: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1de3: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 17 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1842,32 +2256,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5143
+ID: 5 Len: 8 Enqueue: 6835
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5874
-ID: 10 Len: 8 Enqueue: 4957
+ID: 9 Len: 16 Enqueue: 7612
+ID: 10 Len: 8 Enqueue: 6643
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 5361
+ID: 15 Len: 16 Enqueue: 7053
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 5149
-ID: 21 Len: 8 Enqueue: 4987
-ID: 22 Len: 8 Enqueue: 5131
-ID: 23 Len: 456 Enqueue: 5608
+ID: 20 Len: 8 Enqueue: 6841
+ID: 21 Len: 8 Enqueue: 6673
+ID: 22 Len: 8 Enqueue: 6823
+ID: 23 Len: 456 Enqueue: 7346
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 5023
+ID: 25 Len: 8 Enqueue: 6715
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 5017
+ID: 27 Len: 8 Enqueue: 6709
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 5047
-ID: 30 Len: 1824 Enqueue: 5719
+ID: 29 Len: 8 Enqueue: 6739
+ID: 30 Len: 1824 Enqueue: 7457
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -1876,51 +2290,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 5341
-ID: 40 Len: 8 Enqueue: 4951
+ID: 39 Len: 24 Enqueue: 7033
+ID: 40 Len: 8 Enqueue: 6637
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 5059
+ID: 42 Len: 8 Enqueue: 6751
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 5351
-ID: 45 Len: 8 Enqueue: 5071
+ID: 44 Len: 24 Enqueue: 7043
+ID: 45 Len: 8 Enqueue: 6763
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 5035
+ID: 48 Len: 8 Enqueue: 6727
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 5065
+ID: 50 Len: 8 Enqueue: 6757
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 5868
-ID: 53 Len: 8 Enqueue: 5083
+ID: 52 Len: 8 Enqueue: 7606
+ID: 53 Len: 8 Enqueue: 6775
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 5041
+ID: 59 Len: 8 Enqueue: 6733
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 5203
+ID: 66 Len: 24 Enqueue: 6895
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 5053
-ID: 69 Len: 8 Enqueue: 5029
+ID: 68 Len: 8 Enqueue: 6745
+ID: 69 Len: 8 Enqueue: 6721
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5835
+ID: 75 Len: 56 Enqueue: 7573
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 5846
-ID: 81 Len: 32 Enqueue: 5171
-ID: 82 Len: 16 Enqueue: 5155
-ID: 83 Len: 8 Enqueue: 5077
+ID: 80 Len: 72 Enqueue: 7584
+ID: 81 Len: 32 Enqueue: 6863
+ID: 82 Len: 16 Enqueue: 6847
+ID: 83 Len: 8 Enqueue: 6769
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -1935,212 +2349,267 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 5862
-ID: 99 Len: 8 Enqueue: 4999
+ID: 98 Len: 8 Enqueue: 7600
+ID: 99 Len: 8 Enqueue: 6685
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 5089
+ID: 101 Len: 8 Enqueue: 6781
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 4975
-ID: 105 Len: 8 Enqueue: 4981
-ID: 106 Len: 8 Enqueue: 5137
-ID: 107 Len: 8 Enqueue: 4993
-ID: 108 Len: 8 Enqueue: 4963
-ID: 109 Len: 8 Enqueue: 4969
-ID: 110 Len: 8 Enqueue: 5119
-ID: 111 Len: 8 Enqueue: 5125
-ID: 112 Len: 24 Enqueue: 5273
+ID: 104 Len: 8 Enqueue: 6661
+ID: 105 Len: 8 Enqueue: 6667
+ID: 106 Len: 8 Enqueue: 6829
+ID: 107 Len: 8 Enqueue: 6679
+ID: 108 Len: 8 Enqueue: 6649
+ID: 109 Len: 8 Enqueue: 6655
+ID: 110 Len: 8 Enqueue: 6811
+ID: 111 Len: 8 Enqueue: 6817
+ID: 112 Len: 24 Enqueue: 6965
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 5319
-ID: 115 Len: 48 Enqueue: 5187
-ID: 116 Len: 8 Enqueue: 5476
+ID: 114 Len: 24 Enqueue: 7011
+ID: 115 Len: 48 Enqueue: 6879
+ID: 116 Len: 8 Enqueue: 7214
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5434
+ID: 118 Len: 48 Enqueue: 7172
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5101
-ID: 121 Len: 8 Enqueue: 5482
+ID: 120 Len: 8 Enqueue: 6793
+ID: 121 Len: 8 Enqueue: 7220
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 5446
+ID: 123 Len: 48 Enqueue: 7184
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 5107
-ID: 126 Len: 80 Enqueue: 5411
+ID: 125 Len: 8 Enqueue: 6799
+ID: 126 Len: 80 Enqueue: 7103
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5011
-ID: 129 Len: 8 Enqueue: 5488
-ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 48 Enqueue: 5458
-ID: 132 Len: 8 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 5113
-ID: 134 Len: 8 Enqueue: 4927
-ID: 135 Len: 8 Enqueue: 4933
-ID: 136 Len: 8 Enqueue: 4945
-ID: 137 Len: 1 Enqueue: 0
-ID: 138 Len: 8 Enqueue: 0
-ID: 139 Len: 1 Enqueue: 0
-ID: 140 Len: 8 Enqueue: 0
+ID: 128 Len: 8 Enqueue: 6697
+ID: 129 Len: 72 Enqueue: 7114
+ID: 130 Len: 8 Enqueue: 6631
+ID: 131 Len: 8 Enqueue: 6703
+ID: 132 Len: 8 Enqueue: 7226
+ID: 133 Len: 8 Enqueue: 0
+ID: 134 Len: 48 Enqueue: 7196
+ID: 135 Len: 8 Enqueue: 0
+ID: 136 Len: 8 Enqueue: 6805
+ID: 137 Len: 8 Enqueue: 6607
+ID: 138 Len: 8 Enqueue: 6613
+ID: 139 Len: 8 Enqueue: 6625
+ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
-ID: 142 Len: 8 Enqueue: 0
+ID: 142 Len: 1 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 8 Enqueue: 5213
+ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 16 Enqueue: 5329
+ID: 147 Len: 8 Enqueue: 6905
+ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 32 Enqueue: 5891
-ID: 151 Len: 16 Enqueue: 5375
+ID: 150 Len: 8 Enqueue: 0
+ID: 151 Len: 16 Enqueue: 7021
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 5542
-ID: 154 Len: 192 Enqueue: 5510
-ID: 155 Len: 24 Enqueue: 5591
-ID: 156 Len: 8 Enqueue: 5237
-ID: 157 Len: 200 Enqueue: 5283
-ID: 158 Len: 32 Enqueue: 5902
-ID: 159 Len: 16 Enqueue: 5387
-ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 200 Enqueue: 5553
-ID: 162 Len: 192 Enqueue: 5494
-ID: 163 Len: 24 Enqueue: 5575
-ID: 164 Len: 8 Enqueue: 5005
-ID: 165 Len: 184 Enqueue: 0
-ID: 166 Len: 8 Enqueue: 5249
-ID: 167 Len: 200 Enqueue: 5295
-ID: 168 Len: 32 Enqueue: 5913
-ID: 169 Len: 16 Enqueue: 5399
-ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 136 Enqueue: 5564
-ID: 172 Len: 128 Enqueue: 5526
-ID: 173 Len: 16 Enqueue: 5597
-ID: 174 Len: 8 Enqueue: 5470
-ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 48 Enqueue: 5422
-ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5095
-ID: 179 Len: 8 Enqueue: 5261
-ID: 180 Len: 136 Enqueue: 5307
-ID: 181 Len: 32 Enqueue: 5880
-ID: 182 Len: 16 Enqueue: 5363
-ID: 183 Len: 8 Enqueue: 0
-ID: 184 Len: 136 Enqueue: 0
-ID: 185 Len: 128 Enqueue: 0
-ID: 186 Len: 16 Enqueue: 0
-ID: 187 Len: 8 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 5225
-ID: 189 Len: 136 Enqueue: 0
-ID: 190 Len: 8 Enqueue: 4939
-ID: 191 Len: 128 Enqueue: 0
-ID: 192 Len: 9 Enqueue: 0
-ID: 193 Len: 0 Enqueue: 0
-ID: 194 Len: 17 Enqueue: 0
-ID: 195 Len: 0 Enqueue: 0
+ID: 153 Len: 32 Enqueue: 7629
+ID: 154 Len: 16 Enqueue: 7067
+ID: 155 Len: 8 Enqueue: 0
+ID: 156 Len: 200 Enqueue: 7280
+ID: 157 Len: 192 Enqueue: 7248
+ID: 158 Len: 24 Enqueue: 7329
+ID: 159 Len: 8 Enqueue: 6929
+ID: 160 Len: 200 Enqueue: 6975
+ID: 161 Len: 32 Enqueue: 7640
+ID: 162 Len: 16 Enqueue: 7079
+ID: 163 Len: 8 Enqueue: 0
+ID: 164 Len: 200 Enqueue: 7291
+ID: 165 Len: 192 Enqueue: 7232
+ID: 166 Len: 24 Enqueue: 7313
+ID: 167 Len: 8 Enqueue: 6691
+ID: 168 Len: 184 Enqueue: 0
+ID: 169 Len: 8 Enqueue: 6941
+ID: 170 Len: 200 Enqueue: 6987
+ID: 171 Len: 32 Enqueue: 7651
+ID: 172 Len: 16 Enqueue: 7091
+ID: 173 Len: 8 Enqueue: 0
+ID: 174 Len: 136 Enqueue: 7302
+ID: 175 Len: 128 Enqueue: 7264
+ID: 176 Len: 16 Enqueue: 7335
+ID: 177 Len: 8 Enqueue: 7208
+ID: 178 Len: 8 Enqueue: 0
+ID: 179 Len: 48 Enqueue: 7160
+ID: 180 Len: 8 Enqueue: 0
+ID: 181 Len: 8 Enqueue: 6787
+ID: 182 Len: 8 Enqueue: 6953
+ID: 183 Len: 136 Enqueue: 6999
+ID: 184 Len: 32 Enqueue: 7618
+ID: 185 Len: 16 Enqueue: 7055
+ID: 186 Len: 8 Enqueue: 0
+ID: 187 Len: 136 Enqueue: 0
+ID: 188 Len: 128 Enqueue: 0
+ID: 189 Len: 16 Enqueue: 0
+ID: 190 Len: 8 Enqueue: 0
+ID: 191 Len: 8 Enqueue: 6917
+ID: 192 Len: 136 Enqueue: 0
+ID: 193 Len: 8 Enqueue: 6619
+ID: 194 Len: 128 Enqueue: 0
+ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
-ID: 197 Len: 0 Enqueue: 0
-ID: 198 Len: 33 Enqueue: 0
+ID: 197 Len: 17 Enqueue: 0
+ID: 198 Len: 0 Enqueue: 0
 ID: 199 Len: 0 Enqueue: 0
-ID: 200 Len: 25 Enqueue: 0
-ID: 201 Len: 0 Enqueue: 0
-ID: 202 Len: 25 Enqueue: 0
-ID: 203 Len: 0 Enqueue: 0
-ID: 204 Len: 25 Enqueue: 0
-ID: 205 Len: 0 Enqueue: 0
-ID: 206 Len: 49 Enqueue: 0
-ID: 207 Len: 0 Enqueue: 0
-ID: 208 Len: 49 Enqueue: 0
-ID: 209 Len: 17 Enqueue: 0
+ID: 200 Len: 0 Enqueue: 0
+ID: 201 Len: 33 Enqueue: 0
+ID: 202 Len: 0 Enqueue: 0
+ID: 203 Len: 25 Enqueue: 0
+ID: 204 Len: 0 Enqueue: 0
+ID: 205 Len: 25 Enqueue: 0
+ID: 206 Len: 0 Enqueue: 0
+ID: 207 Len: 25 Enqueue: 0
+ID: 208 Len: 0 Enqueue: 0
+ID: 209 Len: 49 Enqueue: 0
 ID: 210 Len: 0 Enqueue: 0
-ID: 211 Len: 17 Enqueue: 0
-ID: 212 Len: 0 Enqueue: 0
+ID: 211 Len: 49 Enqueue: 0
+ID: 212 Len: 17 Enqueue: 0
 ID: 213 Len: 0 Enqueue: 0
-ID: 214 Len: 0 Enqueue: 0
-ID: 215 Len: 17 Enqueue: 0
+ID: 214 Len: 17 Enqueue: 0
+ID: 215 Len: 0 Enqueue: 0
 ID: 216 Len: 0 Enqueue: 0
-ID: 217 Len: 18 Enqueue: 0
-ID: 218 Len: 0 Enqueue: 0
-ID: 219 Len: 17 Enqueue: 0
-ID: 220 Len: 0 Enqueue: 0
-ID: 221 Len: 19 Enqueue: 0
-ID: 222 Len: 0 Enqueue: 0
-ID: 223 Len: 17 Enqueue: 0
-ID: 224 Len: 0 Enqueue: 0
-ID: 225 Len: 17 Enqueue: 0
-ID: 226 Len: 0 Enqueue: 0
-ID: 227 Len: 21 Enqueue: 0
-ID: 228 Len: 0 Enqueue: 0
-ID: 229 Len: 17 Enqueue: 0
-ID: 230 Len: 0 Enqueue: 0
-ID: 231 Len: 25 Enqueue: 0
-ID: 232 Len: 0 Enqueue: 0
-ID: 233 Len: 17 Enqueue: 0
-ID: 234 Len: 0 Enqueue: 0
-ID: 235 Len: 17 Enqueue: 0
-ID: 236 Len: 0 Enqueue: 0
-ID: 237 Len: 18 Enqueue: 0
-ID: 238 Len: 0 Enqueue: 0
-ID: 239 Len: 17 Enqueue: 0
-ID: 240 Len: 0 Enqueue: 0
-ID: 241 Len: 19 Enqueue: 0
-ID: 242 Len: 0 Enqueue: 0
-ID: 243 Len: 17 Enqueue: 0
-ID: 244 Len: 0 Enqueue: 0
-ID: 245 Len: 21 Enqueue: 0
-ID: 246 Len: 0 Enqueue: 0
-ID: 247 Len: 17 Enqueue: 0
-ID: 248 Len: 0 Enqueue: 0
-ID: 249 Len: 25 Enqueue: 0
-ID: 250 Len: 0 Enqueue: 0
-ID: 251 Len: 17 Enqueue: 0
-ID: 252 Len: 0 Enqueue: 0
-ID: 253 Len: 17 Enqueue: 0
-ID: 254 Len: 0 Enqueue: 0
-ID: 255 Len: 17 Enqueue: 0
-ID: 256 Len: 0 Enqueue: 0
-ID: 257 Len: 17 Enqueue: 0
-ID: 258 Len: 0 Enqueue: 0
-ID: 259 Len: 18 Enqueue: 0
-ID: 260 Len: 0 Enqueue: 0
-ID: 261 Len: 17 Enqueue: 0
-ID: 262 Len: 0 Enqueue: 0
-ID: 263 Len: 17 Enqueue: 0
-ID: 264 Len: 0 Enqueue: 0
-ID: 265 Len: 33 Enqueue: 0
-ID: 266 Len: 0 Enqueue: 0
-ID: 267 Len: 33 Enqueue: 0
-ID: 268 Len: 0 Enqueue: 0
-ID: 269 Len: 17 Enqueue: 0
-ID: 270 Len: 0 Enqueue: 0
-ID: 271 Len: 17 Enqueue: 0
-ID: 272 Len: 0 Enqueue: 0
-ID: 273 Len: 17 Enqueue: 0
-ID: 274 Len: 0 Enqueue: 0
-ID: 275 Len: 17 Enqueue: 0
-ID: 276 Len: 0 Enqueue: 0
-ID: 277 Len: 17 Enqueue: 0
-ID: 278 Len: 0 Enqueue: 0
-ID: 279 Len: 97 Enqueue: 0
-ID: 280 Len: 0 Enqueue: 0
-ID: 281 Len: 17 Enqueue: 0
-ID: 282 Len: 0 Enqueue: 0
-ID: 283 Len: 17 Enqueue: 0
-ID: 284 Len: 0 Enqueue: 0
-ID: 285 Len: 25 Enqueue: 0
-ID: 286 Len: 0 Enqueue: 0
-ID: 287 Len: 17 Enqueue: 0
-ID: 288 Len: 0 Enqueue: 0
-ID: 289 Len: 25 Enqueue: 0
-ID: 290 Len: 0 Enqueue: 0
-ID: 291 Len: 9 Enqueue: 0
-ID: 292 Len: 0 Enqueue: 0
-ID: 293 Len: 17 Enqueue: 0
+ID: 217 Len: 0 Enqueue: 0
+ID: 218 Len: 17 Enqueue: 0
+ID: 219 Len: 0 Enqueue: 0
+ID: 220 Len: 18 Enqueue: 0
+ID: 221 Len: 0 Enqueue: 0
+ID: 222 Len: 17 Enqueue: 0
+ID: 223 Len: 0 Enqueue: 0
+ID: 224 Len: 19 Enqueue: 0
+ID: 225 Len: 0 Enqueue: 0
+ID: 226 Len: 17 Enqueue: 0
+ID: 227 Len: 0 Enqueue: 0
+ID: 228 Len: 17 Enqueue: 0
+ID: 229 Len: 0 Enqueue: 0
+ID: 230 Len: 21 Enqueue: 0
+ID: 231 Len: 0 Enqueue: 0
+ID: 232 Len: 17 Enqueue: 0
+ID: 233 Len: 0 Enqueue: 0
+ID: 234 Len: 25 Enqueue: 0
+ID: 235 Len: 0 Enqueue: 0
+ID: 236 Len: 17 Enqueue: 0
+ID: 237 Len: 0 Enqueue: 0
+ID: 238 Len: 17 Enqueue: 0
+ID: 239 Len: 0 Enqueue: 0
+ID: 240 Len: 18 Enqueue: 0
+ID: 241 Len: 0 Enqueue: 0
+ID: 242 Len: 17 Enqueue: 0
+ID: 243 Len: 0 Enqueue: 0
+ID: 244 Len: 19 Enqueue: 0
+ID: 245 Len: 0 Enqueue: 0
+ID: 246 Len: 17 Enqueue: 0
+ID: 247 Len: 0 Enqueue: 0
+ID: 248 Len: 21 Enqueue: 0
+ID: 249 Len: 0 Enqueue: 0
+ID: 250 Len: 17 Enqueue: 0
+ID: 251 Len: 0 Enqueue: 0
+ID: 252 Len: 25 Enqueue: 0
+ID: 253 Len: 0 Enqueue: 0
+ID: 254 Len: 17 Enqueue: 0
+ID: 255 Len: 0 Enqueue: 0
+ID: 256 Len: 17 Enqueue: 0
+ID: 257 Len: 0 Enqueue: 0
+ID: 258 Len: 17 Enqueue: 0
+ID: 259 Len: 0 Enqueue: 0
+ID: 260 Len: 17 Enqueue: 0
+ID: 261 Len: 0 Enqueue: 0
+ID: 262 Len: 18 Enqueue: 0
+ID: 263 Len: 0 Enqueue: 0
+ID: 264 Len: 17 Enqueue: 0
+ID: 265 Len: 0 Enqueue: 0
+ID: 266 Len: 17 Enqueue: 0
+ID: 267 Len: 0 Enqueue: 0
+ID: 268 Len: 33 Enqueue: 0
+ID: 269 Len: 0 Enqueue: 0
+ID: 270 Len: 33 Enqueue: 0
+ID: 271 Len: 0 Enqueue: 0
+ID: 272 Len: 17 Enqueue: 0
+ID: 273 Len: 0 Enqueue: 0
+ID: 274 Len: 17 Enqueue: 0
+ID: 275 Len: 0 Enqueue: 0
+ID: 276 Len: 17 Enqueue: 0
+ID: 277 Len: 0 Enqueue: 0
+ID: 278 Len: 17 Enqueue: 0
+ID: 279 Len: 0 Enqueue: 0
+ID: 280 Len: 17 Enqueue: 0
+ID: 281 Len: 0 Enqueue: 0
+ID: 282 Len: 97 Enqueue: 0
+ID: 283 Len: 0 Enqueue: 0
+ID: 284 Len: 17 Enqueue: 0
+ID: 285 Len: 0 Enqueue: 0
+ID: 286 Len: 17 Enqueue: 0
+ID: 287 Len: 0 Enqueue: 0
+ID: 288 Len: 25 Enqueue: 0
+ID: 289 Len: 0 Enqueue: 0
+ID: 290 Len: 17 Enqueue: 0
+ID: 291 Len: 0 Enqueue: 0
+ID: 292 Len: 25 Enqueue: 0
+ID: 293 Len: 0 Enqueue: 0
 ID: 294 Len: 9 Enqueue: 0
-ID: 295 Len: 25 Enqueue: 0
-ID: 296 Len: 0 Enqueue: 0
-ID: 297 Len: 25 Enqueue: 0
-ID: 298 Len: 0 Enqueue: 0
-ID: 299 Len: 17 Enqueue: 0
+ID: 295 Len: 0 Enqueue: 0
+ID: 296 Len: 17 Enqueue: 0
+ID: 297 Len: 9 Enqueue: 0
+ID: 298 Len: 25 Enqueue: 0
+ID: 299 Len: 0 Enqueue: 0
 ID: 300 Len: 25 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 9 Enqueue: 0
-ID: 303 Len: 9 Enqueue: 0
-ID: 304 Len: 0 Enqueue: 0
-ID: 305 Len: 17 Enqueue: 0
+ID: 302 Len: 17 Enqueue: 0
+ID: 303 Len: 25 Enqueue: 0
+ID: 304 Len: 17 Enqueue: 0
+ID: 305 Len: 0 Enqueue: 0
 ID: 306 Len: 9 Enqueue: 0
+ID: 307 Len: 0 Enqueue: 0
+ID: 308 Len: 17 Enqueue: 0
+ID: 309 Len: 0 Enqueue: 0
+ID: 310 Len: 9 Enqueue: 0
+ID: 311 Len: 0 Enqueue: 0
+ID: 312 Len: 33 Enqueue: 0
+ID: 313 Len: 0 Enqueue: 0
+ID: 314 Len: 9 Enqueue: 0
+ID: 315 Len: 0 Enqueue: 0
+ID: 316 Len: 41 Enqueue: 0
+ID: 317 Len: 0 Enqueue: 0
+ID: 318 Len: 0 Enqueue: 0
+ID: 319 Len: 0 Enqueue: 0
+ID: 320 Len: 25 Enqueue: 0
+ID: 321 Len: 0 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
+ID: 323 Len: 0 Enqueue: 0
+ID: 324 Len: 25 Enqueue: 0
+ID: 325 Len: 0 Enqueue: 0
+ID: 326 Len: 89 Enqueue: 0
+ID: 327 Len: 0 Enqueue: 0
+ID: 328 Len: 0 Enqueue: 0
+ID: 329 Len: 0 Enqueue: 0
+ID: 330 Len: 9 Enqueue: 0
+ID: 331 Len: 0 Enqueue: 0
+ID: 332 Len: 9 Enqueue: 0
+ID: 333 Len: 0 Enqueue: 0
+ID: 334 Len: 9 Enqueue: 0
+ID: 335 Len: 0 Enqueue: 0
+ID: 336 Len: 9 Enqueue: 0
+ID: 337 Len: 0 Enqueue: 0
+ID: 338 Len: 17 Enqueue: 0
+ID: 339 Len: 0 Enqueue: 0
+ID: 340 Len: 25 Enqueue: 0
+ID: 341 Len: 0 Enqueue: 0
+ID: 342 Len: 0 Enqueue: 0
+ID: 343 Len: 0 Enqueue: 0
+ID: 344 Len: 9 Enqueue: 0
+ID: 345 Len: 0 Enqueue: 0
+ID: 346 Len: 9 Enqueue: 0
+ID: 347 Len: 0 Enqueue: 0
+ID: 348 Len: 25 Enqueue: 0
+ID: 349 Len: 0 Enqueue: 0
+ID: 350 Len: 0 Enqueue: 0
+ID: 351 Len: 0 Enqueue: 0
+ID: 352 Len: 97 Enqueue: 0
+ID: 353 Len: 0 Enqueue: 0
+ID: 354 Len: 0 Enqueue: 0
+ID: 355 Len: 0 Enqueue: 0
+ID: 356 Len: 0 Enqueue: 0
+ID: 357 Len: 9 Enqueue: 0
+ID: 358 Len: 9 Enqueue: 0
+ID: 359 Len: 0 Enqueue: 0
+ID: 360 Len: 17 Enqueue: 0
+ID: 361 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 46 1d 00 00 // ProcessType[*****int]
+	Call 65 1f 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@c826c]
-	PrepareEventRoot 78 01 00 00 11 00 00 00 
+	PrepareEventRoot 88 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 58 1d 00 00 // ProcessType[**int]
+	Call 77 1f 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c82a4]
-	PrepareEventRoot 79 01 00 00 09 00 00 00 
+	PrepareEventRoot 89 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xc82a4.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ca 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ca 21 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@c9008]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@c9768]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@c9768]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@c9768]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@c9628]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@c96c8]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@c91b8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc91b8]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@c91b8]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@c9258]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@c92f8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc92f8]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@c92f8]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@c9108]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc9108]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@c9108]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,11 +360,11 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
-	PrepareEventRoot 2e 01 00 00 11 00 00 00 
+	PrepareEventRoot 32 01 00 00 11 00 00 00 
 	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	Return 
 // 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
@@ -377,10 +377,10 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@c9cb4]
-	PrepareEventRoot 2f 01 00 00 19 00 00 00 
+	PrepareEventRoot 33 01 00 00 19 00 00 00 
 	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[1]]
 	Return 
@@ -399,36 +399,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
-	PrepareEventRoot 22 01 00 00 11 00 00 00 
+	PrepareEventRoot 26 01 00 00 11 00 00 00 
 	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Return 
 // 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
-	PrepareEventRoot 23 01 00 00 00 00 00 00 
+	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
 // 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.condFields]
+	Call bf 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
-	PrepareEventRoot 24 01 00 00 19 00 00 00 
+	PrepareEventRoot 28 01 00 00 19 00 00 00 
 	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	Return 
 // 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
-	PrepareEventRoot 25 01 00 00 00 00 00 00 
+	PrepareEventRoot 29 01 00 00 00 00 00 00 
 	Return 
 // 0x6b7: ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	ConditionBegin 
@@ -449,16 +449,16 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@c9c08]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
-	PrepareEventRoot 2a 01 00 00 19 00 00 00 
+	PrepareEventRoot 2e 01 00 00 19 00 00 00 
 	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
 // 0x725: ProcessEvent[Probe[main.condOnly]Return@c9c64]
-	PrepareEventRoot 2b 01 00 00 00 00 00 00 
+	PrepareEventRoot 2f 01 00 00 00 00 00 00 
 	Return 
 // 0x72f: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
@@ -470,15 +470,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@c9c08]
-	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	PrepareEventRoot 30 01 00 00 19 00 00 00 
 	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
 // 0x77b: ProcessEvent[Probe[main.condOnly]Return@c9c64]
-	PrepareEventRoot 2d 01 00 00 00 00 00 00 
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
 // 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
@@ -495,15 +495,15 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
-	PrepareEventRoot 1c 01 00 00 11 00 00 00 
+	PrepareEventRoot 20 01 00 00 11 00 00 00 
 	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
 // 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 1d 01 00 00 00 00 00 00 
+	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
 // 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
@@ -520,36 +520,36 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
-	PrepareEventRoot 1e 01 00 00 11 00 00 00 
+	PrepareEventRoot 22 01 00 00 11 00 00 00 
 	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
 // 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 1f 01 00 00 00 00 00 00 
+	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
 // 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a0 1d 00 00 // ProcessType[*main.condFields]
+	Call bf 1f 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
-	PrepareEventRoot 20 01 00 00 19 00 00 00 
+	PrepareEventRoot 24 01 00 00 19 00 00 00 
 	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	Return 
 // 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
-	PrepareEventRoot 21 01 00 00 00 00 00 00 
+	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
 // 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	ConditionBegin 
@@ -567,11 +567,11 @@
 	Return 
 // 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
 	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
-	PrepareEventRoot 26 01 00 00 09 00 00 00 
+	PrepareEventRoot 2a 01 00 00 09 00 00 00 
 	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Return 
 // 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
-	PrepareEventRoot 27 01 00 00 00 00 00 00 
+	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
 // 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
@@ -584,7 +584,7 @@
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
 // 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
-	PrepareEventRoot 28 01 00 00 11 00 00 00 
+	PrepareEventRoot 2c 01 00 00 11 00 00 00 
 	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	Return 
@@ -594,7 +594,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
-	PrepareEventRoot 29 01 00 00 09 00 00 00 
+	PrepareEventRoot 2d 01 00 00 09 00 00 00 
 	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	Return 
 // 0x964: ProcessCondition[Probe[main.condString]@0xc9818]
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@c9818]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@c9818]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
@@ -651,25 +651,57 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0xa45: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xa50: ProcessEvent[Probe[main.condString]@c9818]
+	PrepareEventRoot 0c 01 00 00 02 00 00 00 
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Return 
+// 0xa5f: ProcessEvent[Probe[main.condString]Return@c9878]
+	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+	Return 
+// 0xa69: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadString ff 00 
+	ExprLoadLiteral 09 00 05 00 00 00 68 65 6c 6c 6f 
+	ExprCmpEqString 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0xa96: ProcessEvent[Probe[main.condString]@c9818]
+	PrepareEventRoot 0e 01 00 00 02 00 00 00 
+	Call 69 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Return 
+// 0xaa5: ProcessEvent[Probe[main.condString]Return@c9878]
+	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+	Return 
+// 0xaaf: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 52 23 00 00 // ProcessType[string]
+	Return 
+// 0xad1: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xa67: ProcessEvent[Probe[main.condString]@c9818]
-	PrepareEventRoot 0c 01 00 00 21 00 00 00 
-	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
-	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xaf3: ProcessEvent[Probe[main.condString]@c9818]
+	PrepareEventRoot 10 01 00 00 21 00 00 00 
+	Call af 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call d1 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xa7b: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 0d 01 00 00 00 00 00 00 
+// 0xb07: ProcessEvent[Probe[main.condString]Return@c9878]
+	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xa85: ProcessCondition[Probe[main.condString]@0xc9818]
+// 0xb11: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +711,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xaa7: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+// 0xb33: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xac9: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xb55: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xaeb: ProcessEvent[Probe[main.condString]@c9818]
-	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
-	PrepareEventRoot 0e 01 00 00 21 00 00 00 
-	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
-	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xb77: ProcessEvent[Probe[main.condString]@c9818]
+	Call 11 0b 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
+	PrepareEventRoot 12 01 00 00 21 00 00 00 
+	Call 33 0b 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call 55 0b 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xb04: ProcessEvent[Probe[main.condString]Return@c9878]
-	PrepareEventRoot 0f 01 00 00 00 00 00 00 
+// 0xb90: ProcessEvent[Probe[main.condString]Return@c9878]
+	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xb9a: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +743,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xbb9: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xb4f: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xbdb: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 9a 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+	PrepareEventRoot 14 01 00 00 11 00 00 00 
+	Call b9 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 11 01 00 00 00 00 00 00 
+// 0xbef: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xbf9: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +767,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xc15: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xbab: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xc37: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call f9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+	PrepareEventRoot 16 01 00 00 11 00 00 00 
+	Call 15 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 13 01 00 00 00 00 00 00 
+// 0xc4b: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xc55: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +791,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xc78: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xc0e: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xc9a: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 55 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+	PrepareEventRoot 18 01 00 00 11 00 00 00 
+	Call 78 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 15 01 00 00 00 00 00 00 
+// 0xcae: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xcb8: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +815,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xcd7: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xc6d: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xcf9: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call b8 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+	PrepareEventRoot 1a 01 00 00 11 00 00 00 
+	Call d7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 17 01 00 00 00 00 00 00 
+// 0xd0d: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xd17: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +839,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xd38: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xcce: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
-	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xd5a: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 17 0d 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+	PrepareEventRoot 1c 01 00 00 11 00 00 00 
+	Call 38 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 19 01 00 00 00 00 00 00 
+// 0xd6e: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xd78: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 36 1f 00 00 // ProcessType[main.condFields]
+	Call 55 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
+// 0xd99: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xd2f: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	PrepareEventRoot 1a 01 00 00 61 00 00 00 
-	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
-	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
+// 0xdbb: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	PrepareEventRoot 1e 01 00 00 61 00 00 00 
+	Call 78 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 99 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	Return 
-// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@c9970]
-	PrepareEventRoot 1b 01 00 00 00 00 00 00 
+// 0xdcf: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xc9448]
+// 0xdd9: ProcessCondition[Probe[main.condUint16]@0xc9448]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +884,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd64: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+// 0xdf0: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xd86: ProcessEvent[Probe[main.condUint16]@c9448]
-	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
+// 0xe12: ProcessEvent[Probe[main.condUint16]@c9448]
+	Call d9 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+	Call f0 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	Return 
-// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@c94a4]
+// 0xe26: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xda4: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+// 0xe30: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdba: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
+// 0xe46: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xddc: ProcessEvent[Probe[main.condUint16]@c9448]
+// 0xe68: ProcessEvent[Probe[main.condUint16]@c9448]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
-	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
-	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
+	Call 30 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+	Call 46 0e 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	Return 
-// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@c94a4]
+// 0xe7c: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xc94e8]
+// 0xe86: ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +928,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe13: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+// 0xe9f: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xe35: ProcessEvent[Probe[main.condUint32]@c94e8]
-	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
+// 0xec1: ProcessEvent[Probe[main.condUint32]@c94e8]
+	Call 86 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+	Call 9f 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	Return 
-// 0xe49: ProcessEvent[Probe[main.condUint32]Return@c9544]
+// 0xed5: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xe53: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+// 0xedf: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe69: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
+// 0xef5: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xe8b: ProcessEvent[Probe[main.condUint32]@c94e8]
+// 0xf17: ProcessEvent[Probe[main.condUint32]@c94e8]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
-	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
-	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
+	Call df 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+	Call f5 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	Return 
-// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@c9544]
+// 0xf2b: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xea9: ProcessCondition[Probe[main.condUint64]@0xc9588]
+// 0xf35: ProcessCondition[Probe[main.condUint64]@0xc9588]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +972,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xec6: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+// 0xf52: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xee8: ProcessEvent[Probe[main.condUint64]@c9588]
-	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
+// 0xf74: ProcessEvent[Probe[main.condUint64]@c9588]
+	Call 35 0f 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+	Call 52 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	Return 
-// 0xefc: ProcessEvent[Probe[main.condUint64]Return@c95e4]
+// 0xf88: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xf06: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+// 0xf92: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
+// 0xfa8: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xf3e: ProcessEvent[Probe[main.condUint64]@c9588]
+// 0xfca: ProcessEvent[Probe[main.condUint64]@c9588]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
-	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
-	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
+	Call 92 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+	Call a8 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	Return 
-// 0xf52: ProcessEvent[Probe[main.condUint64]Return@c95e4]
+// 0xfde: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0xfe8: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +1016,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf72: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0xffe: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xf94: ProcessEvent[Probe[main.condUint8]@c9398]
-	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0x1020: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call e8 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call fe 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0x1034: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0x103e: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,165 +1040,165 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0x1054: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0xfea: ProcessEvent[Probe[main.condUint8]@c9398]
-	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0x1076: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call 3e 10 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call 54 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0xffe: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0x108a: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0x1008: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0x1094: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x101e: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
+// 0x10aa: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1040: ProcessEvent[Probe[main.condUint8]@c9398]
+// 0x10cc: ProcessEvent[Probe[main.condUint8]@c9398]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
-	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
-	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
+	Call 94 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call aa 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	Return 
-// 0x1054: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0x10e0: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0x105e: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+// 0x10ea: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x106e: ProcessEvent[Probe[main.inlined]@c8040]
-	PrepareEventRoot 76 01 00 00 09 00 00 00 
-	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+// 0x10fa: ProcessEvent[Probe[main.inlined]@c8040]
+	PrepareEventRoot 86 01 00 00 09 00 00 00 
+	Call ea 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	Return 
-// 0x107d: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1093: ProcessEvent[Probe[main.inlined]@c8ed8]
-	PrepareEventRoot 76 01 00 00 09 00 00 00 
-	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
-	Return 
-// 0x10a2: ProcessEvent[Probe[main.inlined]Return@c8f0c]
-	PrepareEventRoot 77 01 00 00 00 00 00 00 
-	Return 
-// 0x10ac: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
+// 0x1109: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10c2: ProcessEvent[Probe[main.intArg]@c8c08]
+// 0x111f: ProcessEvent[Probe[main.inlined]@c8ed8]
+	PrepareEventRoot 86 01 00 00 09 00 00 00 
+	Call 09 11 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
+	Return 
+// 0x112e: ProcessEvent[Probe[main.inlined]Return@c8f0c]
+	PrepareEventRoot 87 01 00 00 00 00 00 00 
+	Return 
+// 0x1138: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x114e: ProcessEvent[Probe[main.intArg]@c8c08]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
-	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
+	Call 38 11 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	Return 
-// 0x10d1: ProcessEvent[Probe[main.intArg]Return@c8c3c]
+// 0x115d: ProcessEvent[Probe[main.intArg]Return@c8c3c]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
+// 0x1167: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@c8d68]
+// 0x1183: ProcessEvent[Probe[main.intArrayArg]@c8d68]
 	PrepareEventRoot cd 00 00 00 19 00 00 00 
-	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
+	Call 67 11 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	Return 
-// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
+// 0x1192: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
+// 0x119c: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 56 1e 00 00 // ProcessType[[3]string]
+	Call 75 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
+// 0x11bd: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
-	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
+	Call 9c 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	Return 
-// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
+// 0x11cc: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x1169: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
+// 0x11f5: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
-	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
+	Call cc 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	Return 
-// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
+// 0x1204: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
+// 0x120e: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
+// 0x1224: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ca55c]
-	PrepareEventRoot 6c 01 00 00 19 00 00 00 
-	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
-	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
+// 0x1246: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+	PrepareEventRoot 7c 01 00 00 19 00 00 00 
+	Call 0e 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
+	Call 24 12 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
-	PrepareEventRoot 6d 01 00 00 00 00 00 00 
+// 0x125a: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+	PrepareEventRoot 7d 01 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
+// 0x1264: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 36 1f 00 00 // ProcessType[main.condFields]
+	Call 55 21 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
+// 0x1285: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
-	PrepareEventRoot 70 01 00 00 61 00 00 00 
-	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
-	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
+// 0x12a7: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+	PrepareEventRoot 80 01 00 00 61 00 00 00 
+	Call 64 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
+	Call 85 12 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	Return 
-// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
-	PrepareEventRoot 71 01 00 00 00 00 00 00 
+// 0x12bb: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+	PrepareEventRoot 81 01 00 00 00 00 00 00 
 	Return 
-// 0x1239: ProcessEvent[Probe[main.lenErrInt]@ca55c]
-	PrepareEventRoot 6e 01 00 00 00 00 00 00 
+// 0x12c5: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+	PrepareEventRoot 7e 01 00 00 00 00 00 00 
 	Return 
-// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
-	PrepareEventRoot 6f 01 00 00 00 00 00 00 
+// 0x12cf: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+	PrepareEventRoot 7f 01 00 00 00 00 00 00 
 	Return 
-// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
-	PrepareEventRoot 72 01 00 00 00 00 00 00 
+// 0x12d9: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+	PrepareEventRoot 82 01 00 00 00 00 00 00 
 	Return 
-// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
-	PrepareEventRoot 73 01 00 00 00 00 00 00 
+// 0x12e3: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+	PrepareEventRoot 83 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessCondition[Probe[main.lenMap]@0xca13c]
+// 0x12ed: ProcessCondition[Probe[main.lenMap]@0xca13c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1176,35 +1208,51 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x128b: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x1317: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x12ad: ProcessEvent[Probe[main.lenMap]@ca13c]
-	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
-	PrepareEventRoot 44 01 00 00 11 00 00 00 
-	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x1339: ProcessEvent[Probe[main.lenMap]@ca13c]
+	Call ed 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
+	PrepareEventRoot 52 01 00 00 11 00 00 00 
+	Call 17 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	Return 
-// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x134d: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x1357: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x138c: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 54 01 00 00 02 00 00 00 
+	Call 57 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Return 
+// 0x139b: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x13a5: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12ee: ProcessEvent[Probe[main.lenMap]@ca13c]
-	PrepareEventRoot 46 01 00 00 09 00 00 00 
-	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x13c8: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 56 01 00 00 09 00 00 00 
+	Call a5 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	Return 
-// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x13d7: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x1307: ProcessCondition[Probe[main.lenMap]@0xca13c]
+// 0x13e1: ProcessCondition[Probe[main.lenMap]@0xca13c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -1214,151 +1262,151 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1331: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x140b: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1353: ProcessEvent[Probe[main.lenMap]@ca13c]
-	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
-	PrepareEventRoot 48 01 00 00 11 00 00 00 
-	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x142d: ProcessEvent[Probe[main.lenMap]@ca13c]
+	Call e1 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
+	PrepareEventRoot 58 01 00 00 11 00 00 00 
+	Call 0b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	Return 
-// 0x1367: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1441: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1371: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x144b: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenMap]@ca13c]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x146e: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call 4b 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	Return 
-// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x147d: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x1487: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+// 0x14a2: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x13ea: ProcessEvent[Probe[main.lenMap]@ca13c]
-	PrepareEventRoot 4c 01 00 00 19 00 00 00 
-	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
-	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+// 0x14c4: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	Call 87 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Call a2 14 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	Return 
-// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x14d8: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x14e2: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x142b: ProcessEvent[Probe[main.lenPtrString]@ca22c]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x1505: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 5e 01 00 00 09 00 00 00 
+	Call e2 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	Return 
-// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1514: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x151e: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*string]
+	Call 13 20 00 00 // ProcessType[*string]
 	Return 
-// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+// 0x1539: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1481: ProcessEvent[Probe[main.lenPtrString]@ca22c]
-	PrepareEventRoot 50 01 00 00 19 00 00 00 
-	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
-	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+// 0x155b: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 60 01 00 00 19 00 00 00 
+	Call 1e 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Call 39 15 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	Return 
-// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x156f: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1579: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a6 1d 00 00 // ProcessType[*main.lenFields]
+	Call c5 1f 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+// 0x1594: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 64 01 00 00 19 00 00 00 
-	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
-	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+// 0x15b6: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 74 01 00 00 19 00 00 00 
+	Call 79 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call 94 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	Return 
-// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 65 01 00 00 00 00 00 00 
+// 0x15ca: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 75 01 00 00 00 00 00 00 
 	Return 
-// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x15d4: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1604: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
+	Call d4 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+// 0x1613: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x161d: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 68 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1640: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 78 01 00 00 09 00 00 00 
+	Call 1d 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 69 01 00 00 00 00 00 00 
+// 0x164f: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 79 01 00 00 00 00 00 00 
 	Return 
-// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1659: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 6a 01 00 00 09 00 00 00 
-	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x167c: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 7a 01 00 00 09 00 00 00 
+	Call 59 16 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 6b 01 00 00 00 00 00 00 
+// 0x168b: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 7b 01 00 00 00 00 00 00 
 	Return 
-// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xca04c]
+// 0x1695: ProcessCondition[Probe[main.lenSlice]@0xca04c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1367,34 +1415,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x16b2: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x15fa: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
-	PrepareEventRoot 3a 01 00 00 11 00 00 00 
-	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x16d4: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	Call 95 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
+	PrepareEventRoot 46 01 00 00 11 00 00 00 
+	Call b2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
+// 0x16e8: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x16f2: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x171a: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 48 01 00 00 02 00 00 00 
+	Call f2 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Return 
+// 0x1729: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1733: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x162e: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	PrepareEventRoot 3c 01 00 00 09 00 00 00 
-	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x1749: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 33 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+// 0x1758: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xca04c]
+// 0x1762: ProcessCondition[Probe[main.lenSlice]@0xca04c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1403,57 +1466,102 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x177f: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1686: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
-	PrepareEventRoot 3e 01 00 00 11 00 00 00 
-	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x17a1: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	Call 62 17 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
+	PrepareEventRoot 4c 01 00 00 11 00 00 00 
+	Call 7f 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x17b5: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x17bf: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16ba: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	PrepareEventRoot 40 01 00 00 09 00 00 00 
-	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x17d5: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call bf 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x17e4: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x17ee: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	Return 
-// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+// 0x1817: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x171e: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	PrepareEventRoot 42 01 00 00 29 00 00 00 
-	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+// 0x1839: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 50 01 00 00 29 00 00 00 
+	Call ee 17 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Call 17 18 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
 	Return 
-// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x184d: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x173c: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x1857: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x187f: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 34 01 00 00 02 00 00 00 
+	Call 57 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x188e: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1898: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x18c0: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 36 01 00 00 02 00 00 00 
+	Call 98 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x18cf: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 37 01 00 00 00 00 00 00 
+	Return 
+// 0x18d9: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x1901: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 38 01 00 00 02 00 00 00 
+	Call d9 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x1910: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 39 01 00 00 00 00 00 00 
+	Return 
+// 0x191a: ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1462,34 +1570,49 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1937: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x177b: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1959: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call 1a 19 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call 37 19 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x178f: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x196d: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1799: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1977: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
+	Return 
+// 0x199f: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 3c 01 00 00 02 00 00 00 
+	Call 77 19 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x19ae: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
+	Return 
+// 0x19b8: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17af: ProcessEvent[Probe[main.lenString]@c9f6c]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x19ce: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 3e 01 00 00 09 00 00 00 
+	Call b8 19 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x17be: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x19dd: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x17c8: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x19e7: ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1498,140 +1621,140 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e5: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1a04: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1807: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1a26: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call e7 19 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 40 01 00 00 11 00 00 00 
+	Call 04 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x181b: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x1a3a: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x1825: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1a44: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x183b: ProcessEvent[Probe[main.lenString]@c9f6c]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1a5a: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 42 01 00 00 09 00 00 00 
+	Call 44 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x184a: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 37 01 00 00 00 00 00 00 
+// 0x1a69: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x1854: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1a73: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1876: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+// 0x1a95: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1898: ProcessEvent[Probe[main.lenString]@c9f6c]
-	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
-	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+// 0x1ab7: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 44 01 00 00 21 00 00 00 
+	Call 73 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 95 1a 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	Return 
-// 0x18ac: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 39 01 00 00 00 00 00 00 
+// 0x1acb: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1ad5: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call 41 1f 00 00 // ProcessType[main.lenFields]
+	Call 60 21 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+// 0x1af6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 52 01 00 00 59 00 00 00 
-	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
-	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+// 0x1b18: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 62 01 00 00 59 00 00 00 
+	Call d5 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call f6 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	Return 
-// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1b2c: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1b36: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1940: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 54 01 00 00 09 00 00 00 
-	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 64 01 00 00 09 00 00 00 
+	Call 36 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x1b6e: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1b78: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1982: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 56 01 00 00 09 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1ba1: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	Call 78 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x1bb0: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1bba: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1be3: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 68 01 00 00 09 00 00 00 
+	Call ba 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1bf2: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1bfc: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1c18: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call fc 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x1c27: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1c31: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 5c 01 00 00 09 00 00 00 
-	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1c4d: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 6c 01 00 00 09 00 00 00 
+	Call 31 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+// 0x1c5c: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
-// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x1c66: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -1641,22 +1764,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
-	PrepareEventRoot 5e 01 00 00 11 00 00 00 
-	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1cb8: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call 66 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 6e 01 00 00 11 00 00 00 
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+// 0x1ccc: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
-// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x1cd6: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
@@ -1665,22 +1788,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1cf9: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
-	PrepareEventRoot 60 01 00 00 11 00 00 00 
-	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1d1b: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call d6 1c 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 70 01 00 00 11 00 00 00 
+	Call f9 1c 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+// 0x1d2f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
-// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x1d39: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1689,500 +1812,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1d5c: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
-	PrepareEventRoot 62 01 00 00 11 00 00 00 
-	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1d7e: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call 39 1d 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 72 01 00 00 11 00 00 00 
+	Call 5c 1d 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+// 0x1d92: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x1d9c: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1b9f: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1dbe: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 9c 1d 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	Return 
-// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1dcd: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1bb8: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1dd7: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1de1: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+// 0x1deb: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+// 0x1e06: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1c02: ProcessEvent[Probe[main.mapArg]@c8f98]
+// 0x1e21: ProcessEvent[Probe[main.mapArg]@c8f98]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
-	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+	Call eb 1d 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+	Call 06 1e 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	Return 
-// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
+// 0x1e35: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x1c20: ProcessEvent[Probe[main.noArgs]@c9098]
+// 0x1e3f: ProcessEvent[Probe[main.noArgs]@c9098]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@c90cc]
+// 0x1e49: ProcessEvent[Probe[main.noArgs]Return@c90cc]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x1e53: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+// 0x1e75: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1c78: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1e97: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+	Call 53 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 75 1e 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	Return 
-// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1eab: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+// 0x1eb5: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 56 1e 00 00 // ProcessType[[3]string]
+	Call 75 20 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
+// 0x1ed6: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+	Call b5 1e 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	Return 
-// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
+// 0x1ee5: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+// 0x1eef: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call da 1e 00 00 // ProcessType[[]string]
+	Call f9 20 00 00 // ProcessType[[]string]
 	Return 
-// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
+// 0x1f18: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+	Call ef 1e 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	Return 
-// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
+// 0x1f27: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
-	PrepareEventRoot 74 01 00 00 00 00 00 00 
+// 0x1f31: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
+	PrepareEventRoot 84 01 00 00 00 00 00 00 
 	Return 
-// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x1f3b: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call b1 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call d0 21 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
-	PrepareEventRoot 75 01 00 00 09 00 00 00 
-	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x1f56: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
+	PrepareEventRoot 85 01 00 00 09 00 00 00 
+	Call 3b 1f 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	Return 
-// 0x1d46: ProcessType[*****int]
+// 0x1f65: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x1d4c: ProcessType[****int]
+// 0x1f6b: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x1d52: ProcessType[***int]
+// 0x1f71: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x1d58: ProcessType[**int]
+// 0x1f77: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1d5e: ProcessType[*[]int]
+// 0x1f7d: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
+// 0x1f83: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1d6a: ProcessType[*bool]
+// 0x1f89: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1d70: ProcessType[*error]
+// 0x1f8f: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1d76: ProcessType[*float32]
+// 0x1f95: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1d7c: ProcessType[*float64]
+// 0x1f9b: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1d82: ProcessType[*int]
+// 0x1fa1: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1d88: ProcessType[*int32]
+// 0x1fa7: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1d8e: ProcessType[*int64]
+// 0x1fad: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1d94: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1fb3: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1d9a: ProcessType[*main.bigStruct]
+// 0x1fb9: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1da0: ProcessType[*main.condFields]
+// 0x1fbf: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1da6: ProcessType[*main.lenFields]
+// 0x1fc5: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1dac: ProcessType[*runtime._defer]
+// 0x1fcb: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1db2: ProcessType[*runtime._panic]
+// 0x1fd1: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1db8: ProcessType[*runtime.cgoCallers]
+// 0x1fd7: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1dbe: ProcessType[*runtime.coro]
+// 0x1fdd: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1dc4: ProcessType[*runtime.g]
+// 0x1fe3: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1dca: ProcessType[*runtime.m]
+// 0x1fe9: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1dd0: ProcessType[*runtime.p]
+// 0x1fef: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1dd6: ProcessType[*runtime.sudog]
+// 0x1ff5: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1ddc: ProcessType[*runtime.synctestBubble]
+// 0x1ffb: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1de2: ProcessType[*runtime.timer]
+// 0x2001: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1de8: ProcessType[*runtime.traceBuf]
+// 0x2007: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1dee: ProcessType[*runtime.xRegState]
+// 0x200d: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1df4: ProcessType[*string]
+// 0x2013: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1dfa: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2019: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1e00: ProcessType[*table<string,int>]
+// 0x201f: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1e06: ProcessType[*table<string,main.bigStruct>]
+// 0x2025: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1e0c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x202b: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1e12: ProcessType[*uint]
+// 0x2031: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1e18: ProcessType[*uint16]
+// 0x2037: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1e1e: ProcessType[*uint32]
+// 0x203d: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1e24: ProcessType[*uint64]
+// 0x2043: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1e2a: ProcessType[*uint8]
+// 0x2049: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1e30: ProcessType[*uintptr]
+// 0x204f: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1e36: ProcessType[[2]*runtime.traceBuf]
+// 0x2055: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call e8 1d 00 00 // ProcessType[*runtime.traceBuf]
+	Call 07 20 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e46: ProcessType[[2][2]*runtime.traceBuf]
+// 0x2065: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 36 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 55 20 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1e56: ProcessType[[3]string]
+// 0x2075: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1e66: ProcessType[[]*runtime.p]
+// 0x2085: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1e70: ProcessType[[]*runtime.p.array]
+// 0x208f: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call d0 1d 00 00 // ProcessType[*runtime.p]
+	Call ef 1f 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e7c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x209b: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call fa 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call 19 20 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e88: ProcessType[[]*table<string,int>.array]
+// 0x20a7: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 00 1e 00 00 // ProcessType[*table<string,int>]
+	Call 1f 20 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1e94: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x20b3: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 06 1e 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 25 20 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1ea0: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x20bf: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 0c 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2b 20 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1eac: ProcessType[[]int]
+// 0x20cb: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1eb6: ProcessType[[]noalg.map.group[string]int.array]
+// 0x20d5: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call e7 1f 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 06 22 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ec2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x20e1: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call f2 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 11 22 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1ece: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x20ed: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call fd 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 1c 22 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1eda: ProcessType[[]string]
+// 0x20f9: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1ee4: ProcessType[[]string.array]
+// 0x2103: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1ef0: ProcessType[[]uint8]
+// 0x210f: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1efa: ProcessType[[]uintptr]
+// 0x2119: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1f04: ProcessType[error]
+// 0x2123: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1f06: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x2125: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f12: ProcessType[groupReference<string,int>]
+// 0x2131: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f1e: ProcessType[groupReference<string,main.bigStruct>]
+// 0x213d: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1f2a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2149: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1f36: ProcessType[main.condFields]
+// 0x2155: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x1f41: ProcessType[main.lenFields]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2160: ProcessType[main.lenFields]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call ac 1e 00 00 // ProcessType[[]int]
+	Call cb 20 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call a5 1f 00 00 // ProcessType[map[string]int]
+	Call c4 21 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call f4 1d 00 00 // ProcessType[*string]
+	Call 13 20 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5e 1d 00 00 // ProcessType[*[]int]
+	Call 7d 1f 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1f6f: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x218e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1f7b: ProcessType[map<string,int>]
+// 0x219a: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1f87: ProcessType[map<string,main.bigStruct>]
+// 0x21a6: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1f93: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x21b2: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1f9f: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x21be: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1fa5: ProcessType[map[string]int]
+// 0x21c4: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1fab: ProcessType[map[string]main.bigStruct]
+// 0x21ca: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1fb1: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x21d0: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1fb7: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x21d6: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 08 20 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 27 22 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fc7: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x21e6: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 18 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 37 22 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1fd7: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x21f6: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 1e 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 3d 22 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1fe7: ProcessType[noalg.map.group[string]int]
+// 0x2206: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call c7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call e6 21 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1ff2: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x2211: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call b7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call d6 21 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ffd: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x221c: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call d7 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call f6 21 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x2008: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2227: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9a 1d 00 00 // ProcessType[*main.bigStruct]
+	Call b9 1f 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x2018: ProcessType[noalg.struct { key string; elem int }]
-	Call 33 21 00 00 // ProcessType[string]
+// 0x2237: ProcessType[noalg.struct { key string; elem int }]
+	Call 52 23 00 00 // ProcessType[string]
 	Return 
-// 0x201e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x223d: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9f 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call be 21 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x2029: ProcessType[runtime.g]
+// 0x2248: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call b2 1d 00 00 // ProcessType[*runtime._panic]
+	Call d1 1f 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call ac 1d 00 00 // ProcessType[*runtime._defer]
+	Call cb 1f 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call f0 1e 00 00 // ProcessType[[]uint8]
+	Call 0f 21 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 83 1f 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call d6 1d 00 00 // ProcessType[*runtime.sudog]
+	Call f5 1f 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call e2 1d 00 00 // ProcessType[*runtime.timer]
+	Call 01 20 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call be 1d 00 00 // ProcessType[*runtime.coro]
+	Call dd 1f 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call dc 1d 00 00 // ProcessType[*runtime.synctestBubble]
+	Call fb 1f 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 2d 21 00 00 // ProcessType[runtime.xRegPerG]
+	Call 4c 23 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x2098: ProcessType[runtime.m]
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+// 0x22b7: ProcessType[runtime.m]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call c4 1d 00 00 // ProcessType[*runtime.g]
+	Call e3 1f 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 33 21 00 00 // ProcessType[string]
+	Call 52 23 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 66 1e 00 00 // ProcessType[[]*runtime.p]
+	Call 85 20 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call b8 1d 00 00 // ProcessType[*runtime.cgoCallers]
+	Call d7 1f 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 0c 21 00 00 // ProcessType[runtime.mLockProfile]
+	Call 2b 23 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call 17 21 00 00 // ProcessType[runtime.mTraceState]
+	Call 36 23 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 27 21 00 00 // ProcessType[runtime.mWeakPointer]
+	Call 46 23 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x210c: ProcessType[runtime.mLockProfile]
+// 0x232b: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call fa 1e 00 00 // ProcessType[[]uintptr]
+	Call 19 21 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x2117: ProcessType[runtime.mTraceState]
+// 0x2336: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 46 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call ca 1d 00 00 // ProcessType[*runtime.m]
+	Call 65 20 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call e9 1f 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x2127: ProcessType[runtime.mWeakPointer]
-	Call 94 1d 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x2346: ProcessType[runtime.mWeakPointer]
+	Call b3 1f 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x212d: ProcessType[runtime.xRegPerG]
-	Call ee 1d 00 00 // ProcessType[*runtime.xRegState]
+// 0x234c: ProcessType[runtime.xRegPerG]
+	Call 0d 20 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x2133: ProcessType[string]
+// 0x2352: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x2139: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2358: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 06 1f 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 25 21 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x2144: ProcessType[table<string,int>]
+// 0x2363: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 12 1f 00 00 // ProcessType[groupReference<string,int>]
+	Call 31 21 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x214f: ProcessType[table<string,main.bigStruct>]
+// 0x236e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1e 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 3d 21 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x215a: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x2379: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 2a 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 49 21 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2450,32 +2573,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 7722
+ID: 5 Len: 8 Enqueue: 8265
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 8499
-ID: 10 Len: 8 Enqueue: 7530
+ID: 9 Len: 16 Enqueue: 9042
+ID: 10 Len: 8 Enqueue: 8073
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7940
+ID: 15 Len: 16 Enqueue: 8483
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 7728
-ID: 21 Len: 8 Enqueue: 7560
-ID: 22 Len: 8 Enqueue: 7710
-ID: 23 Len: 456 Enqueue: 8233
+ID: 20 Len: 8 Enqueue: 8271
+ID: 21 Len: 8 Enqueue: 8103
+ID: 22 Len: 8 Enqueue: 8253
+ID: 23 Len: 456 Enqueue: 8776
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 7602
+ID: 25 Len: 8 Enqueue: 8145
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 7596
+ID: 27 Len: 8 Enqueue: 8139
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 7626
-ID: 30 Len: 1824 Enqueue: 8344
+ID: 29 Len: 8 Enqueue: 8169
+ID: 30 Len: 1824 Enqueue: 8887
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2484,51 +2607,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7920
-ID: 40 Len: 8 Enqueue: 7524
+ID: 39 Len: 24 Enqueue: 8463
+ID: 40 Len: 8 Enqueue: 8067
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 7638
+ID: 42 Len: 8 Enqueue: 8181
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7930
-ID: 45 Len: 8 Enqueue: 7650
+ID: 44 Len: 24 Enqueue: 8473
+ID: 45 Len: 8 Enqueue: 8193
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 7614
+ID: 48 Len: 8 Enqueue: 8157
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 7644
+ID: 50 Len: 8 Enqueue: 8187
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 8493
-ID: 53 Len: 8 Enqueue: 7662
+ID: 52 Len: 8 Enqueue: 9036
+ID: 53 Len: 8 Enqueue: 8205
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 7620
+ID: 59 Len: 8 Enqueue: 8163
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 7782
+ID: 66 Len: 24 Enqueue: 8325
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 7632
-ID: 69 Len: 8 Enqueue: 7608
+ID: 68 Len: 8 Enqueue: 8175
+ID: 69 Len: 8 Enqueue: 8151
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 8460
+ID: 75 Len: 56 Enqueue: 9003
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 8471
-ID: 81 Len: 32 Enqueue: 7750
-ID: 82 Len: 16 Enqueue: 7734
-ID: 83 Len: 8 Enqueue: 7656
+ID: 80 Len: 72 Enqueue: 9014
+ID: 81 Len: 32 Enqueue: 8293
+ID: 82 Len: 16 Enqueue: 8277
+ID: 83 Len: 8 Enqueue: 8199
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2543,48 +2666,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 8487
-ID: 99 Len: 8 Enqueue: 7572
+ID: 98 Len: 8 Enqueue: 9030
+ID: 99 Len: 8 Enqueue: 8115
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 7668
+ID: 101 Len: 8 Enqueue: 8211
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 7548
-ID: 105 Len: 8 Enqueue: 7554
-ID: 106 Len: 8 Enqueue: 7716
-ID: 107 Len: 8 Enqueue: 7566
-ID: 108 Len: 8 Enqueue: 7536
-ID: 109 Len: 8 Enqueue: 7542
-ID: 110 Len: 8 Enqueue: 7698
-ID: 111 Len: 8 Enqueue: 7704
-ID: 112 Len: 24 Enqueue: 7852
+ID: 104 Len: 8 Enqueue: 8091
+ID: 105 Len: 8 Enqueue: 8097
+ID: 106 Len: 8 Enqueue: 8259
+ID: 107 Len: 8 Enqueue: 8109
+ID: 108 Len: 8 Enqueue: 8079
+ID: 109 Len: 8 Enqueue: 8085
+ID: 110 Len: 8 Enqueue: 8241
+ID: 111 Len: 8 Enqueue: 8247
+ID: 112 Len: 24 Enqueue: 8395
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7898
-ID: 115 Len: 48 Enqueue: 7766
-ID: 116 Len: 8 Enqueue: 8101
+ID: 114 Len: 24 Enqueue: 8441
+ID: 115 Len: 48 Enqueue: 8309
+ID: 116 Len: 8 Enqueue: 8644
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 8059
+ID: 118 Len: 48 Enqueue: 8602
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 7680
-ID: 121 Len: 8 Enqueue: 8107
+ID: 120 Len: 8 Enqueue: 8223
+ID: 121 Len: 8 Enqueue: 8650
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 8071
+ID: 123 Len: 48 Enqueue: 8614
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 7686
-ID: 126 Len: 80 Enqueue: 7990
+ID: 125 Len: 8 Enqueue: 8229
+ID: 126 Len: 80 Enqueue: 8533
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 7584
-ID: 129 Len: 72 Enqueue: 8001
-ID: 130 Len: 8 Enqueue: 7518
-ID: 131 Len: 8 Enqueue: 7590
-ID: 132 Len: 8 Enqueue: 8113
+ID: 128 Len: 8 Enqueue: 8127
+ID: 129 Len: 72 Enqueue: 8544
+ID: 130 Len: 8 Enqueue: 8061
+ID: 131 Len: 8 Enqueue: 8133
+ID: 132 Len: 8 Enqueue: 8656
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 8083
+ID: 134 Len: 48 Enqueue: 8626
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 7692
-ID: 137 Len: 8 Enqueue: 7494
-ID: 138 Len: 8 Enqueue: 7500
-ID: 139 Len: 8 Enqueue: 7512
+ID: 136 Len: 8 Enqueue: 8235
+ID: 137 Len: 8 Enqueue: 8037
+ID: 138 Len: 8 Enqueue: 8043
+ID: 139 Len: 8 Enqueue: 8055
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2592,53 +2715,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 7792
+ID: 147 Len: 8 Enqueue: 8335
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7908
+ID: 151 Len: 16 Enqueue: 8451
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 8516
-ID: 154 Len: 16 Enqueue: 7954
+ID: 153 Len: 32 Enqueue: 9059
+ID: 154 Len: 16 Enqueue: 8497
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 8167
-ID: 157 Len: 192 Enqueue: 8135
-ID: 158 Len: 24 Enqueue: 8216
-ID: 159 Len: 8 Enqueue: 7816
-ID: 160 Len: 200 Enqueue: 7862
-ID: 161 Len: 32 Enqueue: 8527
-ID: 162 Len: 16 Enqueue: 7966
+ID: 156 Len: 200 Enqueue: 8710
+ID: 157 Len: 192 Enqueue: 8678
+ID: 158 Len: 24 Enqueue: 8759
+ID: 159 Len: 8 Enqueue: 8359
+ID: 160 Len: 200 Enqueue: 8405
+ID: 161 Len: 32 Enqueue: 9070
+ID: 162 Len: 16 Enqueue: 8509
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 8178
-ID: 165 Len: 192 Enqueue: 8119
-ID: 166 Len: 24 Enqueue: 8200
-ID: 167 Len: 8 Enqueue: 7578
+ID: 164 Len: 200 Enqueue: 8721
+ID: 165 Len: 192 Enqueue: 8662
+ID: 166 Len: 24 Enqueue: 8743
+ID: 167 Len: 8 Enqueue: 8121
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 7828
-ID: 170 Len: 200 Enqueue: 7874
-ID: 171 Len: 32 Enqueue: 8538
-ID: 172 Len: 16 Enqueue: 7978
+ID: 169 Len: 8 Enqueue: 8371
+ID: 170 Len: 200 Enqueue: 8417
+ID: 171 Len: 32 Enqueue: 9081
+ID: 172 Len: 16 Enqueue: 8521
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 8189
-ID: 175 Len: 128 Enqueue: 8151
-ID: 176 Len: 16 Enqueue: 8222
-ID: 177 Len: 8 Enqueue: 8095
+ID: 174 Len: 136 Enqueue: 8732
+ID: 175 Len: 128 Enqueue: 8694
+ID: 176 Len: 16 Enqueue: 8765
+ID: 177 Len: 8 Enqueue: 8638
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 8047
+ID: 179 Len: 48 Enqueue: 8590
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 7674
-ID: 182 Len: 8 Enqueue: 7840
-ID: 183 Len: 136 Enqueue: 7886
-ID: 184 Len: 32 Enqueue: 8505
-ID: 185 Len: 16 Enqueue: 7942
+ID: 181 Len: 8 Enqueue: 8217
+ID: 182 Len: 8 Enqueue: 8383
+ID: 183 Len: 136 Enqueue: 8429
+ID: 184 Len: 32 Enqueue: 9048
+ID: 185 Len: 16 Enqueue: 8485
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 7804
+ID: 191 Len: 8 Enqueue: 8347
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 7506
+ID: 193 Len: 8 Enqueue: 8049
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
@@ -2713,13 +2836,13 @@ ID: 264 Len: 17 Enqueue: 0
 ID: 265 Len: 0 Enqueue: 0
 ID: 266 Len: 17 Enqueue: 0
 ID: 267 Len: 0 Enqueue: 0
-ID: 268 Len: 33 Enqueue: 0
+ID: 268 Len: 2 Enqueue: 0
 ID: 269 Len: 0 Enqueue: 0
-ID: 270 Len: 33 Enqueue: 0
+ID: 270 Len: 2 Enqueue: 0
 ID: 271 Len: 0 Enqueue: 0
-ID: 272 Len: 17 Enqueue: 0
+ID: 272 Len: 33 Enqueue: 0
 ID: 273 Len: 0 Enqueue: 0
-ID: 274 Len: 17 Enqueue: 0
+ID: 274 Len: 33 Enqueue: 0
 ID: 275 Len: 0 Enqueue: 0
 ID: 276 Len: 17 Enqueue: 0
 ID: 277 Len: 0 Enqueue: 0
@@ -2727,81 +2850,81 @@ ID: 278 Len: 17 Enqueue: 0
 ID: 279 Len: 0 Enqueue: 0
 ID: 280 Len: 17 Enqueue: 0
 ID: 281 Len: 0 Enqueue: 0
-ID: 282 Len: 97 Enqueue: 0
+ID: 282 Len: 17 Enqueue: 0
 ID: 283 Len: 0 Enqueue: 0
 ID: 284 Len: 17 Enqueue: 0
 ID: 285 Len: 0 Enqueue: 0
-ID: 286 Len: 17 Enqueue: 0
+ID: 286 Len: 97 Enqueue: 0
 ID: 287 Len: 0 Enqueue: 0
-ID: 288 Len: 25 Enqueue: 0
+ID: 288 Len: 17 Enqueue: 0
 ID: 289 Len: 0 Enqueue: 0
 ID: 290 Len: 17 Enqueue: 0
 ID: 291 Len: 0 Enqueue: 0
 ID: 292 Len: 25 Enqueue: 0
 ID: 293 Len: 0 Enqueue: 0
-ID: 294 Len: 9 Enqueue: 0
+ID: 294 Len: 17 Enqueue: 0
 ID: 295 Len: 0 Enqueue: 0
-ID: 296 Len: 17 Enqueue: 0
-ID: 297 Len: 9 Enqueue: 0
-ID: 298 Len: 25 Enqueue: 0
+ID: 296 Len: 25 Enqueue: 0
+ID: 297 Len: 0 Enqueue: 0
+ID: 298 Len: 9 Enqueue: 0
 ID: 299 Len: 0 Enqueue: 0
-ID: 300 Len: 25 Enqueue: 0
-ID: 301 Len: 0 Enqueue: 0
-ID: 302 Len: 17 Enqueue: 0
-ID: 303 Len: 25 Enqueue: 0
-ID: 304 Len: 17 Enqueue: 0
+ID: 300 Len: 17 Enqueue: 0
+ID: 301 Len: 9 Enqueue: 0
+ID: 302 Len: 25 Enqueue: 0
+ID: 303 Len: 0 Enqueue: 0
+ID: 304 Len: 25 Enqueue: 0
 ID: 305 Len: 0 Enqueue: 0
-ID: 306 Len: 9 Enqueue: 0
-ID: 307 Len: 0 Enqueue: 0
-ID: 308 Len: 17 Enqueue: 0
+ID: 306 Len: 17 Enqueue: 0
+ID: 307 Len: 25 Enqueue: 0
+ID: 308 Len: 2 Enqueue: 0
 ID: 309 Len: 0 Enqueue: 0
-ID: 310 Len: 9 Enqueue: 0
+ID: 310 Len: 2 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
-ID: 312 Len: 33 Enqueue: 0
+ID: 312 Len: 2 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
 ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 9 Enqueue: 0
+ID: 316 Len: 2 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 17 Enqueue: 0
+ID: 318 Len: 9 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
-ID: 320 Len: 9 Enqueue: 0
+ID: 320 Len: 17 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 41 Enqueue: 0
+ID: 322 Len: 9 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
-ID: 324 Len: 17 Enqueue: 0
+ID: 324 Len: 33 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 9 Enqueue: 0
+ID: 326 Len: 17 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 17 Enqueue: 0
+ID: 328 Len: 2 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
 ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 25 Enqueue: 0
+ID: 332 Len: 17 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
-ID: 336 Len: 25 Enqueue: 0
+ID: 336 Len: 41 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 89 Enqueue: 0
+ID: 338 Len: 17 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 9 Enqueue: 0
+ID: 340 Len: 2 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
 ID: 342 Len: 9 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
-ID: 344 Len: 9 Enqueue: 0
+ID: 344 Len: 17 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
 ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
-ID: 348 Len: 9 Enqueue: 0
+ID: 348 Len: 25 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 17 Enqueue: 0
+ID: 350 Len: 9 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 17 Enqueue: 0
+ID: 352 Len: 25 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 17 Enqueue: 0
+ID: 354 Len: 89 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 25 Enqueue: 0
+ID: 356 Len: 9 Enqueue: 0
 ID: 357 Len: 0 Enqueue: 0
 ID: 358 Len: 9 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
@@ -2809,17 +2932,33 @@ ID: 360 Len: 9 Enqueue: 0
 ID: 361 Len: 0 Enqueue: 0
 ID: 362 Len: 9 Enqueue: 0
 ID: 363 Len: 0 Enqueue: 0
-ID: 364 Len: 25 Enqueue: 0
+ID: 364 Len: 9 Enqueue: 0
 ID: 365 Len: 0 Enqueue: 0
-ID: 366 Len: 0 Enqueue: 0
+ID: 366 Len: 17 Enqueue: 0
 ID: 367 Len: 0 Enqueue: 0
-ID: 368 Len: 97 Enqueue: 0
+ID: 368 Len: 17 Enqueue: 0
 ID: 369 Len: 0 Enqueue: 0
-ID: 370 Len: 0 Enqueue: 0
+ID: 370 Len: 17 Enqueue: 0
 ID: 371 Len: 0 Enqueue: 0
-ID: 372 Len: 0 Enqueue: 0
-ID: 373 Len: 9 Enqueue: 0
+ID: 372 Len: 25 Enqueue: 0
+ID: 373 Len: 0 Enqueue: 0
 ID: 374 Len: 9 Enqueue: 0
 ID: 375 Len: 0 Enqueue: 0
-ID: 376 Len: 17 Enqueue: 0
-ID: 377 Len: 9 Enqueue: 0
+ID: 376 Len: 9 Enqueue: 0
+ID: 377 Len: 0 Enqueue: 0
+ID: 378 Len: 9 Enqueue: 0
+ID: 379 Len: 0 Enqueue: 0
+ID: 380 Len: 25 Enqueue: 0
+ID: 381 Len: 0 Enqueue: 0
+ID: 382 Len: 0 Enqueue: 0
+ID: 383 Len: 0 Enqueue: 0
+ID: 384 Len: 97 Enqueue: 0
+ID: 385 Len: 0 Enqueue: 0
+ID: 386 Len: 0 Enqueue: 0
+ID: 387 Len: 0 Enqueue: 0
+ID: 388 Len: 0 Enqueue: 0
+ID: 389 Len: 9 Enqueue: 0
+ID: 390 Len: 9 Enqueue: 0
+ID: 391 Len: 0 Enqueue: 0
+ID: 392 Len: 17 Enqueue: 0
+ID: 393 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -7,16 +7,16 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call ef 19 00 00 // ProcessType[*****int]
+	Call 46 1d 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@c826c]
-	PrepareEventRoot 68 01 00 00 11 00 00 00 
+	PrepareEventRoot 78 01 00 00 11 00 00 00 
 	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[0]]
 	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	Return 
@@ -24,23 +24,23 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 01 1a 00 00 // ProcessType[**int]
+	Call 58 1d 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c82a4]
-	PrepareEventRoot 69 01 00 00 09 00 00 00 
+	PrepareEventRoot 79 01 00 00 09 00 00 00 
 	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xc82a4.expr[0]]
 	Return 
 // 0x77: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call ab 1f 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@c9008]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@c9768]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@c9768]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -108,7 +108,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@c9768]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@c9628]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@c96c8]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@c91b8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc91b8]
@@ -180,7 +180,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@c91b8]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -248,7 +248,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@c9258]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@c92f8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc92f8]
@@ -292,7 +292,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@c92f8]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@c9108]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc9108]
@@ -336,7 +336,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@c9108]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
@@ -377,7 +377,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	PrepareEventRoot 2f 01 00 00 19 00 00 00 
@@ -399,7 +399,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
@@ -413,14 +413,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.condFields]
+	Call a0 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
@@ -449,7 +449,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x70c: ProcessEvent[Probe[main.condOnly]@c9c08]
 	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
@@ -470,7 +470,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x767: ProcessEvent[Probe[main.condOnly]@c9c08]
 	PrepareEventRoot 2c 01 00 00 19 00 00 00 
@@ -495,7 +495,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
@@ -520,7 +520,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x835: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
@@ -534,14 +534,14 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 49 1a 00 00 // ProcessType[*main.condFields]
+	Call a0 1d 00 00 // ProcessType[*main.condFields]
 	Return 
 // 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x890: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
@@ -612,7 +612,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x9a8: ProcessEvent[Probe[main.condString]@c9818]
 	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
@@ -637,7 +637,7 @@
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa05: ProcessEvent[Probe[main.condString]@c9818]
 	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
@@ -652,14 +652,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa45: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xa67: ProcessEvent[Probe[main.condString]@c9818]
 	PrepareEventRoot 0c 01 00 00 21 00 00 00 
@@ -684,14 +684,14 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xac9: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xaeb: ProcessEvent[Probe[main.condString]@c9818]
 	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
@@ -716,7 +716,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xb4f: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
@@ -740,7 +740,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xbab: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
@@ -764,7 +764,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xc0e: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
@@ -788,7 +788,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xc6d: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
@@ -812,7 +812,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xcce: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
@@ -826,14 +826,14 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call df 1b 00 00 // ProcessType[main.condFields]
+	Call 36 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xd2f: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	PrepareEventRoot 1a 01 00 00 61 00 00 00 
@@ -857,7 +857,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xd86: ProcessEvent[Probe[main.condUint16]@c9448]
 	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
@@ -877,7 +877,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xddc: ProcessEvent[Probe[main.condUint16]@c9448]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
@@ -901,7 +901,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xe35: ProcessEvent[Probe[main.condUint32]@c94e8]
 	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
@@ -921,7 +921,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xe8b: ProcessEvent[Probe[main.condUint32]@c94e8]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
@@ -945,7 +945,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xee8: ProcessEvent[Probe[main.condUint64]@c9588]
 	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
@@ -965,7 +965,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xf3e: ProcessEvent[Probe[main.condUint64]@c9588]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
@@ -989,7 +989,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xf94: ProcessEvent[Probe[main.condUint8]@c9398]
 	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
@@ -1013,7 +1013,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0xfea: ProcessEvent[Probe[main.condUint8]@c9398]
 	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
@@ -1033,7 +1033,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x1040: ProcessEvent[Probe[main.condUint8]@c9398]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
@@ -1049,7 +1049,7 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x106e: ProcessEvent[Probe[main.inlined]@c8040]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
 	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	Return 
 // 0x107d: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
@@ -1058,11 +1058,11 @@
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
 // 0x1093: ProcessEvent[Probe[main.inlined]@c8ed8]
-	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	PrepareEventRoot 76 01 00 00 09 00 00 00 
 	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	Return 
 // 0x10a2: ProcessEvent[Probe[main.inlined]Return@c8f0c]
-	PrepareEventRoot 67 01 00 00 00 00 00 00 
+	PrepareEventRoot 77 01 00 00 00 00 00 00 
 	Return 
 // 0x10ac: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	ExprPrepare 
@@ -1092,7 +1092,7 @@
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ff 1a 00 00 // ProcessType[[3]string]
+	Call 56 1e 00 00 // ProcessType[[3]string]
 	Return 
 // 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
@@ -1104,7 +1104,7 @@
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
+	Call ac 1e 00 00 // ProcessType[[]int]
 	Return 
 // 0x1169: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
@@ -1123,199 +1123,242 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ca55c]
-	PrepareEventRoot 5c 01 00 00 19 00 00 00 
+	PrepareEventRoot 6c 01 00 00 19 00 00 00 
 	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
 	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	Return 
 // 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
-	PrepareEventRoot 5d 01 00 00 00 00 00 00 
+	PrepareEventRoot 6d 01 00 00 00 00 00 00 
 	Return 
 // 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call df 1b 00 00 // ProcessType[main.condFields]
+	Call 36 1f 00 00 // ProcessType[main.condFields]
 	Return 
 // 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
 // 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
-	PrepareEventRoot 60 01 00 00 61 00 00 00 
+	PrepareEventRoot 70 01 00 00 61 00 00 00 
 	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
 	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	Return 
 // 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
-	PrepareEventRoot 61 01 00 00 00 00 00 00 
+	PrepareEventRoot 71 01 00 00 00 00 00 00 
 	Return 
 // 0x1239: ProcessEvent[Probe[main.lenErrInt]@ca55c]
-	PrepareEventRoot 5e 01 00 00 00 00 00 00 
+	PrepareEventRoot 6e 01 00 00 00 00 00 00 
 	Return 
 // 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
-	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	PrepareEventRoot 6f 01 00 00 00 00 00 00 
 	Return 
 // 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
-	PrepareEventRoot 62 01 00 00 00 00 00 00 
+	PrepareEventRoot 72 01 00 00 00 00 00 00 
 	Return 
 // 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
-	PrepareEventRoot 63 01 00 00 00 00 00 00 
+	PrepareEventRoot 73 01 00 00 00 00 00 00 
 	Return 
-// 0x1261: ProcessEvent[Probe[main.lenMap]@ca13c]
-	PrepareEventRoot 3e 01 00 00 00 00 00 00 
+// 0x1261: ProcessCondition[Probe[main.lenMap]@0xca13c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
 	Return 
-// 0x126b: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 3f 01 00 00 00 00 00 00 
+// 0x128b: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1275: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x12ad: ProcessEvent[Probe[main.lenMap]@ca13c]
+	Call 61 12 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
+	PrepareEventRoot 44 01 00 00 11 00 00 00 
+	Call 8b 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Return 
+// 0x12c1: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 45 01 00 00 00 00 00 00 
+	Return 
+// 0x12cb: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x12ee: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 46 01 00 00 09 00 00 00 
+	Call cb 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Return 
+// 0x12fd: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 47 01 00 00 00 00 00 00 
+	Return 
+// 0x1307: ProcessCondition[Probe[main.lenMap]@0xca13c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 03 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1331: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprReadRegister 02 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1353: ProcessEvent[Probe[main.lenMap]@ca13c]
+	Call 07 13 00 00 // ProcessCondition[Probe[main.lenMap]@0xca13c]
+	PrepareEventRoot 48 01 00 00 11 00 00 00 
+	Call 31 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Return 
+// 0x1367: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 49 01 00 00 00 00 00 00 
+	Return 
+// 0x1371: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x1394: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 4a 01 00 00 09 00 00 00 
+	Call 71 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Return 
+// 0x13a3: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+	Return 
+// 0x13ad: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1290: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+// 0x13c8: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x12b2: ProcessEvent[Probe[main.lenMap]@ca13c]
-	PrepareEventRoot 40 01 00 00 19 00 00 00 
-	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
-	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+// 0x13ea: ProcessEvent[Probe[main.lenMap]@ca13c]
+	PrepareEventRoot 4c 01 00 00 19 00 00 00 
+	Call ad 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Call c8 13 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	Return 
-// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
-	PrepareEventRoot 41 01 00 00 00 00 00 00 
+// 0x13fe: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x1408: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@ca22c]
-	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x142b: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 4e 01 00 00 09 00 00 00 
+	Call 08 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	Return 
-// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
-	PrepareEventRoot 43 01 00 00 00 00 00 00 
+// 0x143a: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x1444: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*string]
+	Call f4 1d 00 00 // ProcessType[*string]
 	Return 
-// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+// 0x145f: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1349: ProcessEvent[Probe[main.lenPtrString]@ca22c]
-	PrepareEventRoot 44 01 00 00 19 00 00 00 
-	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
-	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+// 0x1481: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+	PrepareEventRoot 50 01 00 00 19 00 00 00 
+	Call 44 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Call 5f 14 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	Return 
-// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
-	PrepareEventRoot 45 01 00 00 00 00 00 00 
+// 0x1495: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x149f: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4f 1a 00 00 // ProcessType[*main.lenFields]
+	Call a6 1d 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+// 0x14ba: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 54 01 00 00 19 00 00 00 
-	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
-	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+// 0x14dc: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 64 01 00 00 19 00 00 00 
+	Call 9f 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call ba 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	Return 
-// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 55 01 00 00 00 00 00 00 
+// 0x14f0: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 65 01 00 00 00 00 00 00 
 	Return 
-// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 56 01 00 00 00 00 00 00 
+// 0x14fa: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprDereferencePtr 28 00 00 00 08 00 00 00 01 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 57 01 00 00 00 00 00 00 
+// 0x152a: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 66 01 00 00 09 00 00 00 
+	Call fa 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1539: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 67 01 00 00 00 00 00 00 
+	Return 
+// 0x1543: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1566: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 68 01 00 00 09 00 00 00 
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 59 01 00 00 00 00 00 00 
+// 0x1575: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 69 01 00 00 00 00 00 00 
 	Return 
-// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x157f: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
-	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x15a2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+	PrepareEventRoot 6a 01 00 00 09 00 00 00 
+	Call 7f 15 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
-	PrepareEventRoot 5b 01 00 00 00 00 00 00 
+// 0x15b1: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+	PrepareEventRoot 6b 01 00 00 00 00 00 00 
 	Return 
-// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Return 
-// 0x1464: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	PrepareEventRoot 3a 01 00 00 09 00 00 00 
-	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	Return 
-// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 3b 01 00 00 00 00 00 00 
-	Return 
-// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprReadRegister 01 08 08 00 00 00 
-	ExprReadRegister 02 08 10 00 00 00 
-	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
-	Return 
-// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
-	ExprPrepare 
-	ExprReadRegister 03 08 00 00 00 00 
-	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
-	Return 
-// 0x14c8: ProcessEvent[Probe[main.lenSlice]@ca04c]
-	PrepareEventRoot 3c 01 00 00 29 00 00 00 
-	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
-	Return 
-// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
-	PrepareEventRoot 3d 01 00 00 00 00 00 00 
-	Return 
-// 0x14e6: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x15bb: ProcessCondition[Probe[main.lenSlice]@0xca04c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1367,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1503: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x15d8: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1525: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
-	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x15fa: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	Call bb 15 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
+	PrepareEventRoot 3a 01 00 00 11 00 00 00 
+	Call d8 15 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x1539: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 31 01 00 00 00 00 00 00 
+// 0x160e: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1543: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1618: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1559: ProcessEvent[Probe[main.lenString]@c9f6c]
-	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x162e: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 3c 01 00 00 09 00 00 00 
+	Call 18 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x1568: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 33 01 00 00 00 00 00 00 
+// 0x163d: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x1572: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x1647: ProcessCondition[Probe[main.lenSlice]@0xca04c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1403,284 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x158f: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1664: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
-	ExprReadRegister 02 08 00 00 00 00 
-	ExprReadRegister 03 08 08 00 00 00 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x15b1: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
-	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1686: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	Call 47 16 00 00 // ProcessCondition[Probe[main.lenSlice]@0xca04c]
+	PrepareEventRoot 3e 01 00 00 11 00 00 00 
+	Call 64 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x15c5: ProcessEvent[Probe[main.lenString]Return@ca004]
-	PrepareEventRoot 35 01 00 00 00 00 00 00 
+// 0x169a: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x15cf: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x16a4: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15e5: ProcessEvent[Probe[main.lenString]@c9f6c]
-	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x16ba: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 40 01 00 00 09 00 00 00 
+	Call a4 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x15f4: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x16c9: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 41 01 00 00 00 00 00 00 
+	Return 
+// 0x16d3: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprReadRegister 02 08 10 00 00 00 
+	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
+	Call ac 1e 00 00 // ProcessType[[]int]
+	Return 
+// 0x16fc: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+	ExprPrepare 
+	ExprReadRegister 03 08 00 00 00 00 
+	ExprReadRegister 04 08 08 00 00 00 
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x171e: ProcessEvent[Probe[main.lenSlice]@ca04c]
+	PrepareEventRoot 42 01 00 00 29 00 00 00 
+	Call d3 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Call fc 16 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+	Return 
+// 0x1732: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+	PrepareEventRoot 43 01 00 00 00 00 00 00 
+	Return 
+// 0x173c: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1759: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x177b: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call 3c 17 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 30 01 00 00 11 00 00 00 
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x178f: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 31 01 00 00 00 00 00 00 
+	Return 
+// 0x1799: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x17af: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 32 01 00 00 09 00 00 00 
+	Call 99 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x17be: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 33 01 00 00 00 00 00 00 
+	Return 
+// 0x17c8: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 05 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x17e5: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 02 08 00 00 00 00 
+	ExprReadRegister 03 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1807: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call c8 17 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+	PrepareEventRoot 34 01 00 00 11 00 00 00 
+	Call e5 17 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x181b: ProcessEvent[Probe[main.lenString]Return@ca004]
+	PrepareEventRoot 35 01 00 00 00 00 00 00 
+	Return 
+// 0x1825: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 01 08 00 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
+	Return 
+// 0x183b: ProcessEvent[Probe[main.lenString]@c9f6c]
+	PrepareEventRoot 36 01 00 00 09 00 00 00 
+	Call 25 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Return 
+// 0x184a: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x15fe: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1854: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1620: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+// 0x1876: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1642: ProcessEvent[Probe[main.lenString]@c9f6c]
+// 0x1898: ProcessEvent[Probe[main.lenString]@c9f6c]
 	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
-	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+	Call 54 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 76 18 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	Return 
-// 0x1656: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x18ac: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x18b6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call ea 1b 00 00 // ProcessType[main.lenFields]
+	Call 41 1f 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+// 0x18d7: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 46 01 00 00 59 00 00 00 
-	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
-	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+// 0x18f9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 52 01 00 00 59 00 00 00 
+	Call b6 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call d7 18 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	Return 
-// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 47 01 00 00 00 00 00 00 
+// 0x190d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 48 01 00 00 00 00 00 00 
+// 0x1917: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 49 01 00 00 00 00 00 00 
+// 0x1940: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 54 01 00 00 09 00 00 00 
+	Call 17 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x194f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 55 01 00 00 00 00 00 00 
+	Return 
+// 0x1959: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1982: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 56 01 00 00 09 00 00 00 
+	Call 59 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 4b 01 00 00 00 00 00 00 
+// 0x1991: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x199b: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
 	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1740: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x19c4: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 58 01 00 00 09 00 00 00 
+	Call 9b 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 4d 01 00 00 00 00 00 00 
+// 0x19d3: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x19dd: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1775: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x19f9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 5a 01 00 00 09 00 00 00 
+	Call dd 19 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 4f 01 00 00 00 00 00 00 
+// 0x1a08: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1a12: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1a2e: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	PrepareEventRoot 5c 01 00 00 09 00 00 00 
+	Call 12 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 51 01 00 00 00 00 00 00 
+// 0x1a3d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x1a47: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
+	ExprDereferencePtr 00 00 00 00 08 00 00 00 ff ff ff ff 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1a77: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1a99: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call 47 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 5e 01 00 00 11 00 00 00 
+	Call 77 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x1aad: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 5f 01 00 00 00 00 00 00 
+	Return 
+// 0x1ab7: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	ConditionBegin 
+	ExprPrepare 
+	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
+	ExprPushOffset 08 00 00 00 
+	ExprLoadLiteral 08 00 00 00 00 00 00 00 00 00 
+	ExprCmpEqBase 08 
+	ConditionCheck 
+	Return 
+// 0x1ada: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	ExprPrepare 
+	ExprReadRegister 00 08 00 00 00 00 
+	ExprReadRegister 01 08 08 00 00 00 
+	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
+	Call 33 21 00 00 // ProcessType[string]
+	Return 
+// 0x1afc: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call b7 1a 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 60 01 00 00 11 00 00 00 
+	Call da 1a 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Return 
+// 0x1b10: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 61 01 00 00 00 00 00 00 
+	Return 
+// 0x1b1a: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,500 +1689,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1b3d: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1808: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
-	PrepareEventRoot 52 01 00 00 11 00 00 00 
-	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1b5f: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call 1a 1b 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+	PrepareEventRoot 62 01 00 00 11 00 00 00 
+	Call 3d 1b 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
-	PrepareEventRoot 53 01 00 00 00 00 00 00 
+// 0x1b73: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1826: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x1b7d: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1848: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1b9f: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 7d 1b 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	Return 
-// 0x1857: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1bae: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1861: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1bb8: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x186b: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1bc2: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1875: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+// 0x1bcc: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1890: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+// 0x1be7: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x18ab: ProcessEvent[Probe[main.mapArg]@c8f98]
+// 0x1c02: ProcessEvent[Probe[main.mapArg]@c8f98]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
-	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+	Call cc 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+	Call e7 1b 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	Return 
-// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
+// 0x1c16: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x18c9: ProcessEvent[Probe[main.noArgs]@c9098]
+// 0x1c20: ProcessEvent[Probe[main.noArgs]@c9098]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@c90cc]
+// 0x1c2a: ProcessEvent[Probe[main.noArgs]Return@c90cc]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x1c34: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+// 0x1c56: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1921: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1c78: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+	Call 34 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 56 1c 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	Return 
-// 0x1935: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1c8c: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+// 0x1c96: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call ff 1a 00 00 // ProcessType[[3]string]
+	Call 56 1e 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
+// 0x1cb7: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+	Call 96 1c 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	Return 
-// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
+// 0x1cc6: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+// 0x1cd0: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]string]
+	Call da 1e 00 00 // ProcessType[[]string]
 	Return 
-// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
+// 0x1cf9: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+	Call d0 1c 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	Return 
-// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
+// 0x1d08: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
-	PrepareEventRoot 64 01 00 00 00 00 00 00 
+// 0x1d12: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
+	PrepareEventRoot 74 01 00 00 00 00 00 00 
 	Return 
-// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x1d1c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 5a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call b1 1f 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
-	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x1d37: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
+	PrepareEventRoot 75 01 00 00 09 00 00 00 
+	Call 1c 1d 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	Return 
-// 0x19ef: ProcessType[*****int]
+// 0x1d46: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x19f5: ProcessType[****int]
+// 0x1d4c: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x19fb: ProcessType[***int]
+// 0x1d52: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x1a01: ProcessType[**int]
+// 0x1d58: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x1a07: ProcessType[*[]int]
+// 0x1d5e: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
+// 0x1d64: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1a13: ProcessType[*bool]
+// 0x1d6a: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x1a19: ProcessType[*error]
+// 0x1d70: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1a1f: ProcessType[*float32]
+// 0x1d76: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a25: ProcessType[*float64]
+// 0x1d7c: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a2b: ProcessType[*int]
+// 0x1d82: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a31: ProcessType[*int32]
+// 0x1d88: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a37: ProcessType[*int64]
+// 0x1d8e: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a3d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1d94: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a43: ProcessType[*main.bigStruct]
+// 0x1d9a: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1a49: ProcessType[*main.condFields]
+// 0x1da0: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a4f: ProcessType[*main.lenFields]
+// 0x1da6: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1a55: ProcessType[*runtime._defer]
+// 0x1dac: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1a5b: ProcessType[*runtime._panic]
+// 0x1db2: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1a61: ProcessType[*runtime.cgoCallers]
+// 0x1db8: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1a67: ProcessType[*runtime.coro]
+// 0x1dbe: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1a6d: ProcessType[*runtime.g]
+// 0x1dc4: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1a73: ProcessType[*runtime.m]
+// 0x1dca: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1a79: ProcessType[*runtime.p]
+// 0x1dd0: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1a7f: ProcessType[*runtime.sudog]
+// 0x1dd6: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1a85: ProcessType[*runtime.synctestBubble]
+// 0x1ddc: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1a8b: ProcessType[*runtime.timer]
+// 0x1de2: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1a91: ProcessType[*runtime.traceBuf]
+// 0x1de8: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1a97: ProcessType[*runtime.xRegState]
+// 0x1dee: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1a9d: ProcessType[*string]
+// 0x1df4: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1aa3: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1dfa: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1aa9: ProcessType[*table<string,int>]
+// 0x1e00: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1aaf: ProcessType[*table<string,main.bigStruct>]
+// 0x1e06: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1ab5: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e0c: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1abb: ProcessType[*uint]
+// 0x1e12: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1ac1: ProcessType[*uint16]
+// 0x1e18: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1ac7: ProcessType[*uint32]
+// 0x1e1e: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1acd: ProcessType[*uint64]
+// 0x1e24: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ad3: ProcessType[*uint8]
+// 0x1e2a: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ad9: ProcessType[*uintptr]
+// 0x1e30: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[2]*runtime.traceBuf]
+// 0x1e36: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 91 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call e8 1d 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1aef: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1e46: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call df 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 36 1e 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1aff: ProcessType[[3]string]
+// 0x1e56: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b0f: ProcessType[[]*runtime.p]
+// 0x1e66: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1b19: ProcessType[[]*runtime.p.array]
+// 0x1e70: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 79 1a 00 00 // ProcessType[*runtime.p]
+	Call d0 1d 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b25: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1e7c: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call a3 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call fa 1d 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b31: ProcessType[[]*table<string,int>.array]
+// 0x1e88: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call a9 1a 00 00 // ProcessType[*table<string,int>]
+	Call 00 1e 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b3d: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1e94: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call af 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call 06 1e 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b49: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1ea0: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call b5 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 0c 1e 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b55: ProcessType[[]int]
+// 0x1eac: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1b5f: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1eb6: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 90 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call e7 1f 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b6b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1ec2: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 9b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call f2 1f 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b77: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1ece: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call a6 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call fd 1f 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]string]
+// 0x1eda: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[[]string.array]
+// 0x1ee4: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b99: ProcessType[[]uint8]
+// 0x1ef0: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1ba3: ProcessType[[]uintptr]
+// 0x1efa: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1bad: ProcessType[error]
+// 0x1f04: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1baf: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f06: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bbb: ProcessType[groupReference<string,int>]
+// 0x1f12: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bc7: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1f1e: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bd3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f2a: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bdf: ProcessType[main.condFields]
+// 0x1f36: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1bea: ProcessType[main.lenFields]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x1f41: ProcessType[main.lenFields]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 55 1b 00 00 // ProcessType[[]int]
+	Call ac 1e 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 4e 1c 00 00 // ProcessType[map[string]int]
+	Call a5 1f 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9d 1a 00 00 // ProcessType[*string]
+	Call f4 1d 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call 07 1a 00 00 // ProcessType[*[]int]
+	Call 5e 1d 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1c18: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1f6f: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1c24: ProcessType[map<string,int>]
+// 0x1f7b: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1c30: ProcessType[map<string,main.bigStruct>]
+// 0x1f87: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c3c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1f93: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1c48: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1f9f: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1c4e: ProcessType[map[string]int]
+// 0x1fa5: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c54: ProcessType[map[string]main.bigStruct]
+// 0x1fab: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1c5a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1fb1: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1c60: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1fb7: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call b1 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 08 20 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c70: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1fc7: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call c1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call 18 20 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c80: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1fd7: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call c7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 1e 20 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c90: ProcessType[noalg.map.group[string]int]
+// 0x1fe7: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 70 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call c7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c9b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1ff2: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call b7 1f 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1ca6: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ffd: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 80 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call d7 1f 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1cb1: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x2008: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 43 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 9a 1d 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1cc1: ProcessType[noalg.struct { key string; elem int }]
-	Call dc 1d 00 00 // ProcessType[string]
+// 0x2018: ProcessType[noalg.struct { key string; elem int }]
+	Call 33 21 00 00 // ProcessType[string]
 	Return 
-// 0x1cc7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x201e: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 48 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 9f 1f 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cd2: ProcessType[runtime.g]
+// 0x2029: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 5b 1a 00 00 // ProcessType[*runtime._panic]
+	Call b2 1d 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 55 1a 00 00 // ProcessType[*runtime._defer]
+	Call ac 1d 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 99 1b 00 00 // ProcessType[[]uint8]
+	Call f0 1e 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 64 1d 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 7f 1a 00 00 // ProcessType[*runtime.sudog]
+	Call d6 1d 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 8b 1a 00 00 // ProcessType[*runtime.timer]
+	Call e2 1d 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 67 1a 00 00 // ProcessType[*runtime.coro]
+	Call be 1d 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 85 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call dc 1d 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call d6 1d 00 00 // ProcessType[runtime.xRegPerG]
+	Call 2d 21 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1d41: ProcessType[runtime.m]
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+// 0x2098: ProcessType[runtime.m]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 6d 1a 00 00 // ProcessType[*runtime.g]
+	Call c4 1d 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call dc 1d 00 00 // ProcessType[string]
+	Call 33 21 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 0f 1b 00 00 // ProcessType[[]*runtime.p]
+	Call 66 1e 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 61 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call b8 1d 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call b5 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call 0c 21 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call 17 21 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call d0 1d 00 00 // ProcessType[runtime.mWeakPointer]
+	Call 27 21 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x1db5: ProcessType[runtime.mLockProfile]
+// 0x210c: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call a3 1b 00 00 // ProcessType[[]uintptr]
+	Call fa 1e 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1dc0: ProcessType[runtime.mTraceState]
+// 0x2117: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call ef 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 73 1a 00 00 // ProcessType[*runtime.m]
+	Call 46 1e 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call ca 1d 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1dd0: ProcessType[runtime.mWeakPointer]
-	Call 3d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x2127: ProcessType[runtime.mWeakPointer]
+	Call 94 1d 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1dd6: ProcessType[runtime.xRegPerG]
-	Call 97 1a 00 00 // ProcessType[*runtime.xRegState]
+// 0x212d: ProcessType[runtime.xRegPerG]
+	Call ee 1d 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1ddc: ProcessType[string]
+// 0x2133: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x1de2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x2139: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call af 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call 06 1f 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1ded: ProcessType[table<string,int>]
+// 0x2144: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call bb 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call 12 1f 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1df8: ProcessType[table<string,main.bigStruct>]
+// 0x214f: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call c7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 1e 1f 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1e03: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x215a: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call d3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 2a 1f 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2256,32 +2450,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6867
+ID: 5 Len: 8 Enqueue: 7722
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7644
-ID: 10 Len: 8 Enqueue: 6675
+ID: 9 Len: 16 Enqueue: 8499
+ID: 10 Len: 8 Enqueue: 7530
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7085
+ID: 15 Len: 16 Enqueue: 7940
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6873
-ID: 21 Len: 8 Enqueue: 6705
-ID: 22 Len: 8 Enqueue: 6855
-ID: 23 Len: 456 Enqueue: 7378
+ID: 20 Len: 8 Enqueue: 7728
+ID: 21 Len: 8 Enqueue: 7560
+ID: 22 Len: 8 Enqueue: 7710
+ID: 23 Len: 456 Enqueue: 8233
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 6747
+ID: 25 Len: 8 Enqueue: 7602
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 6741
+ID: 27 Len: 8 Enqueue: 7596
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 6771
-ID: 30 Len: 1824 Enqueue: 7489
+ID: 29 Len: 8 Enqueue: 7626
+ID: 30 Len: 1824 Enqueue: 8344
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2290,51 +2484,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7065
-ID: 40 Len: 8 Enqueue: 6669
+ID: 39 Len: 24 Enqueue: 7920
+ID: 40 Len: 8 Enqueue: 7524
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 6783
+ID: 42 Len: 8 Enqueue: 7638
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7075
-ID: 45 Len: 8 Enqueue: 6795
+ID: 44 Len: 24 Enqueue: 7930
+ID: 45 Len: 8 Enqueue: 7650
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 6759
+ID: 48 Len: 8 Enqueue: 7614
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 6789
+ID: 50 Len: 8 Enqueue: 7644
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 7638
-ID: 53 Len: 8 Enqueue: 6807
+ID: 52 Len: 8 Enqueue: 8493
+ID: 53 Len: 8 Enqueue: 7662
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 6765
+ID: 59 Len: 8 Enqueue: 7620
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 6927
+ID: 66 Len: 24 Enqueue: 7782
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 6777
-ID: 69 Len: 8 Enqueue: 6753
+ID: 68 Len: 8 Enqueue: 7632
+ID: 69 Len: 8 Enqueue: 7608
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7605
+ID: 75 Len: 56 Enqueue: 8460
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 7616
-ID: 81 Len: 32 Enqueue: 6895
-ID: 82 Len: 16 Enqueue: 6879
-ID: 83 Len: 8 Enqueue: 6801
+ID: 80 Len: 72 Enqueue: 8471
+ID: 81 Len: 32 Enqueue: 7750
+ID: 82 Len: 16 Enqueue: 7734
+ID: 83 Len: 8 Enqueue: 7656
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2349,48 +2543,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 7632
-ID: 99 Len: 8 Enqueue: 6717
+ID: 98 Len: 8 Enqueue: 8487
+ID: 99 Len: 8 Enqueue: 7572
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 6813
+ID: 101 Len: 8 Enqueue: 7668
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 6693
-ID: 105 Len: 8 Enqueue: 6699
-ID: 106 Len: 8 Enqueue: 6861
-ID: 107 Len: 8 Enqueue: 6711
-ID: 108 Len: 8 Enqueue: 6681
-ID: 109 Len: 8 Enqueue: 6687
-ID: 110 Len: 8 Enqueue: 6843
-ID: 111 Len: 8 Enqueue: 6849
-ID: 112 Len: 24 Enqueue: 6997
+ID: 104 Len: 8 Enqueue: 7548
+ID: 105 Len: 8 Enqueue: 7554
+ID: 106 Len: 8 Enqueue: 7716
+ID: 107 Len: 8 Enqueue: 7566
+ID: 108 Len: 8 Enqueue: 7536
+ID: 109 Len: 8 Enqueue: 7542
+ID: 110 Len: 8 Enqueue: 7698
+ID: 111 Len: 8 Enqueue: 7704
+ID: 112 Len: 24 Enqueue: 7852
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7043
-ID: 115 Len: 48 Enqueue: 6911
-ID: 116 Len: 8 Enqueue: 7246
+ID: 114 Len: 24 Enqueue: 7898
+ID: 115 Len: 48 Enqueue: 7766
+ID: 116 Len: 8 Enqueue: 8101
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7204
+ID: 118 Len: 48 Enqueue: 8059
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6825
-ID: 121 Len: 8 Enqueue: 7252
+ID: 120 Len: 8 Enqueue: 7680
+ID: 121 Len: 8 Enqueue: 8107
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 7216
+ID: 123 Len: 48 Enqueue: 8071
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 6831
-ID: 126 Len: 80 Enqueue: 7135
+ID: 125 Len: 8 Enqueue: 7686
+ID: 126 Len: 80 Enqueue: 7990
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 6729
-ID: 129 Len: 72 Enqueue: 7146
-ID: 130 Len: 8 Enqueue: 6663
-ID: 131 Len: 8 Enqueue: 6735
-ID: 132 Len: 8 Enqueue: 7258
+ID: 128 Len: 8 Enqueue: 7584
+ID: 129 Len: 72 Enqueue: 8001
+ID: 130 Len: 8 Enqueue: 7518
+ID: 131 Len: 8 Enqueue: 7590
+ID: 132 Len: 8 Enqueue: 8113
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 7228
+ID: 134 Len: 48 Enqueue: 8083
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 6837
-ID: 137 Len: 8 Enqueue: 6639
-ID: 138 Len: 8 Enqueue: 6645
-ID: 139 Len: 8 Enqueue: 6657
+ID: 136 Len: 8 Enqueue: 7692
+ID: 137 Len: 8 Enqueue: 7494
+ID: 138 Len: 8 Enqueue: 7500
+ID: 139 Len: 8 Enqueue: 7512
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2398,53 +2592,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 6937
+ID: 147 Len: 8 Enqueue: 7792
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7053
+ID: 151 Len: 16 Enqueue: 7908
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 7661
-ID: 154 Len: 16 Enqueue: 7099
+ID: 153 Len: 32 Enqueue: 8516
+ID: 154 Len: 16 Enqueue: 7954
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 7312
-ID: 157 Len: 192 Enqueue: 7280
-ID: 158 Len: 24 Enqueue: 7361
-ID: 159 Len: 8 Enqueue: 6961
-ID: 160 Len: 200 Enqueue: 7007
-ID: 161 Len: 32 Enqueue: 7672
-ID: 162 Len: 16 Enqueue: 7111
+ID: 156 Len: 200 Enqueue: 8167
+ID: 157 Len: 192 Enqueue: 8135
+ID: 158 Len: 24 Enqueue: 8216
+ID: 159 Len: 8 Enqueue: 7816
+ID: 160 Len: 200 Enqueue: 7862
+ID: 161 Len: 32 Enqueue: 8527
+ID: 162 Len: 16 Enqueue: 7966
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 7323
-ID: 165 Len: 192 Enqueue: 7264
-ID: 166 Len: 24 Enqueue: 7345
-ID: 167 Len: 8 Enqueue: 6723
+ID: 164 Len: 200 Enqueue: 8178
+ID: 165 Len: 192 Enqueue: 8119
+ID: 166 Len: 24 Enqueue: 8200
+ID: 167 Len: 8 Enqueue: 7578
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 6973
-ID: 170 Len: 200 Enqueue: 7019
-ID: 171 Len: 32 Enqueue: 7683
-ID: 172 Len: 16 Enqueue: 7123
+ID: 169 Len: 8 Enqueue: 7828
+ID: 170 Len: 200 Enqueue: 7874
+ID: 171 Len: 32 Enqueue: 8538
+ID: 172 Len: 16 Enqueue: 7978
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 7334
-ID: 175 Len: 128 Enqueue: 7296
-ID: 176 Len: 16 Enqueue: 7367
-ID: 177 Len: 8 Enqueue: 7240
+ID: 174 Len: 136 Enqueue: 8189
+ID: 175 Len: 128 Enqueue: 8151
+ID: 176 Len: 16 Enqueue: 8222
+ID: 177 Len: 8 Enqueue: 8095
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 7192
+ID: 179 Len: 48 Enqueue: 8047
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6819
-ID: 182 Len: 8 Enqueue: 6985
-ID: 183 Len: 136 Enqueue: 7031
-ID: 184 Len: 32 Enqueue: 7650
-ID: 185 Len: 16 Enqueue: 7087
+ID: 181 Len: 8 Enqueue: 7674
+ID: 182 Len: 8 Enqueue: 7840
+ID: 183 Len: 136 Enqueue: 7886
+ID: 184 Len: 32 Enqueue: 8505
+ID: 185 Len: 16 Enqueue: 7942
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 6949
+ID: 191 Len: 8 Enqueue: 7804
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 6651
+ID: 193 Len: 8 Enqueue: 7506
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0
@@ -2565,51 +2759,67 @@ ID: 310 Len: 9 Enqueue: 0
 ID: 311 Len: 0 Enqueue: 0
 ID: 312 Len: 33 Enqueue: 0
 ID: 313 Len: 0 Enqueue: 0
-ID: 314 Len: 9 Enqueue: 0
+ID: 314 Len: 17 Enqueue: 0
 ID: 315 Len: 0 Enqueue: 0
-ID: 316 Len: 41 Enqueue: 0
+ID: 316 Len: 9 Enqueue: 0
 ID: 317 Len: 0 Enqueue: 0
-ID: 318 Len: 0 Enqueue: 0
+ID: 318 Len: 17 Enqueue: 0
 ID: 319 Len: 0 Enqueue: 0
-ID: 320 Len: 25 Enqueue: 0
+ID: 320 Len: 9 Enqueue: 0
 ID: 321 Len: 0 Enqueue: 0
-ID: 322 Len: 9 Enqueue: 0
+ID: 322 Len: 41 Enqueue: 0
 ID: 323 Len: 0 Enqueue: 0
-ID: 324 Len: 25 Enqueue: 0
+ID: 324 Len: 17 Enqueue: 0
 ID: 325 Len: 0 Enqueue: 0
-ID: 326 Len: 89 Enqueue: 0
+ID: 326 Len: 9 Enqueue: 0
 ID: 327 Len: 0 Enqueue: 0
-ID: 328 Len: 0 Enqueue: 0
+ID: 328 Len: 17 Enqueue: 0
 ID: 329 Len: 0 Enqueue: 0
 ID: 330 Len: 9 Enqueue: 0
 ID: 331 Len: 0 Enqueue: 0
-ID: 332 Len: 9 Enqueue: 0
+ID: 332 Len: 25 Enqueue: 0
 ID: 333 Len: 0 Enqueue: 0
 ID: 334 Len: 9 Enqueue: 0
 ID: 335 Len: 0 Enqueue: 0
-ID: 336 Len: 9 Enqueue: 0
+ID: 336 Len: 25 Enqueue: 0
 ID: 337 Len: 0 Enqueue: 0
-ID: 338 Len: 17 Enqueue: 0
+ID: 338 Len: 89 Enqueue: 0
 ID: 339 Len: 0 Enqueue: 0
-ID: 340 Len: 25 Enqueue: 0
+ID: 340 Len: 9 Enqueue: 0
 ID: 341 Len: 0 Enqueue: 0
-ID: 342 Len: 0 Enqueue: 0
+ID: 342 Len: 9 Enqueue: 0
 ID: 343 Len: 0 Enqueue: 0
 ID: 344 Len: 9 Enqueue: 0
 ID: 345 Len: 0 Enqueue: 0
 ID: 346 Len: 9 Enqueue: 0
 ID: 347 Len: 0 Enqueue: 0
-ID: 348 Len: 25 Enqueue: 0
+ID: 348 Len: 9 Enqueue: 0
 ID: 349 Len: 0 Enqueue: 0
-ID: 350 Len: 0 Enqueue: 0
+ID: 350 Len: 17 Enqueue: 0
 ID: 351 Len: 0 Enqueue: 0
-ID: 352 Len: 97 Enqueue: 0
+ID: 352 Len: 17 Enqueue: 0
 ID: 353 Len: 0 Enqueue: 0
-ID: 354 Len: 0 Enqueue: 0
+ID: 354 Len: 17 Enqueue: 0
 ID: 355 Len: 0 Enqueue: 0
-ID: 356 Len: 0 Enqueue: 0
-ID: 357 Len: 9 Enqueue: 0
+ID: 356 Len: 25 Enqueue: 0
+ID: 357 Len: 0 Enqueue: 0
 ID: 358 Len: 9 Enqueue: 0
 ID: 359 Len: 0 Enqueue: 0
-ID: 360 Len: 17 Enqueue: 0
-ID: 361 Len: 9 Enqueue: 0
+ID: 360 Len: 9 Enqueue: 0
+ID: 361 Len: 0 Enqueue: 0
+ID: 362 Len: 9 Enqueue: 0
+ID: 363 Len: 0 Enqueue: 0
+ID: 364 Len: 25 Enqueue: 0
+ID: 365 Len: 0 Enqueue: 0
+ID: 366 Len: 0 Enqueue: 0
+ID: 367 Len: 0 Enqueue: 0
+ID: 368 Len: 97 Enqueue: 0
+ID: 369 Len: 0 Enqueue: 0
+ID: 370 Len: 0 Enqueue: 0
+ID: 371 Len: 0 Enqueue: 0
+ID: 372 Len: 0 Enqueue: 0
+ID: 373 Len: 9 Enqueue: 0
+ID: 374 Len: 9 Enqueue: 0
+ID: 375 Len: 0 Enqueue: 0
+ID: 376 Len: 17 Enqueue: 0
+ID: 377 Len: 9 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -7,13 +7,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call cf 19 00 00 // ProcessType[*****int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call ef 19 00 00 // ProcessType[*****int]
 	Return 
 // 0x39: ProcessEvent[Probe[main.PointerChainArg]@c826c]
 	PrepareEventRoot 68 01 00 00 11 00 00 00 
@@ -24,7 +24,7 @@
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call e1 19 00 00 // ProcessType[**int]
+	Call 01 1a 00 00 // ProcessType[**int]
 	Return 
 // 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c82a4]
 	PrepareEventRoot 69 01 00 00 09 00 00 00 
@@ -34,13 +34,13 @@
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 34 1c 00 00 // ProcessType[map[string]main.bigStruct]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 54 1c 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
 // 0xad: ProcessEvent[Probe[main.bigMapArg]@c9008]
 	PrepareEventRoot d6 00 00 00 11 00 00 00 
@@ -64,7 +64,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x103: ProcessEvent[Probe[main.condBool]@c9768]
 	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -88,7 +88,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x159: ProcessEvent[Probe[main.condBool]@c9768]
 	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
@@ -107,8 +107,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1af: ProcessEvent[Probe[main.condBool]@c9768]
 	PrepareEventRoot 06 01 00 00 12 00 00 00 
@@ -123,7 +123,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x1ef: ProcessEvent[Probe[main.condFloat32]@c9628]
 	PrepareEventRoot fe 00 00 00 11 00 00 00 
@@ -137,7 +137,7 @@
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x22a: ProcessEvent[Probe[main.condFloat64]@c96c8]
 	PrepareEventRoot 00 01 00 00 11 00 00 00 
@@ -160,7 +160,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x27c: ProcessEvent[Probe[main.condInt16]@c91b8]
 	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc91b8]
@@ -179,8 +179,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x2d2: ProcessEvent[Probe[main.condInt16]@c91b8]
 	PrepareEventRoot e0 00 00 00 13 00 00 00 
@@ -204,7 +204,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x32b: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -228,7 +228,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x384: ProcessEvent[Probe[main.condInt32]@c9258]
 	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
@@ -247,8 +247,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x3da: ProcessEvent[Probe[main.condInt32]@c9258]
 	PrepareEventRoot e6 00 00 00 15 00 00 00 
@@ -272,7 +272,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x437: ProcessEvent[Probe[main.condInt64]@c92f8]
 	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc92f8]
@@ -291,8 +291,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x48d: ProcessEvent[Probe[main.condInt64]@c92f8]
 	PrepareEventRoot ea 00 00 00 19 00 00 00 
@@ -316,7 +316,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x4e3: ProcessEvent[Probe[main.condInt8]@c9108]
 	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc9108]
@@ -335,8 +335,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x539: ProcessEvent[Probe[main.condInt8]@c9108]
 	PrepareEventRoot dc 00 00 00 12 00 00 00 
@@ -360,7 +360,7 @@
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x596: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
@@ -376,8 +376,8 @@
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
 // 0x5e2: ProcessEvent[Probe[main.condLine]Line@c9cb4]
 	PrepareEventRoot 2f 01 00 00 19 00 00 00 
@@ -388,49 +388,49 @@
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
+// 0x61c: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
+// 0x63e: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
 	PrepareEventRoot 22 01 00 00 11 00 00 00 
-	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
+	Call 1c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Return 
-// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
+// 0x652: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
 	PrepareEventRoot 23 01 00 00 00 00 00 00 
 	Return 
-// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
+// 0x65c: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.condFields]
+	Call 49 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
+// 0x677: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
+// 0x699: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	PrepareEventRoot 24 01 00 00 19 00 00 00 
-	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
-	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
+	Call 5c 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
+	Call 77 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	Return 
-// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
+// 0x6ad: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
 	PrepareEventRoot 25 01 00 00 00 00 00 00 
 	Return 
-// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xc9c08]
+// 0x6b7: ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -439,119 +439,119 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+// 0x6d4: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
+// 0x6ea: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x708: ProcessEvent[Probe[main.condOnly]@c9c08]
-	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
+// 0x70c: ProcessEvent[Probe[main.condOnly]@c9c08]
+	Call b7 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	PrepareEventRoot 2a 01 00 00 19 00 00 00 
-	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
-	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
+	Call d4 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+	Call ea 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
-// 0x721: ProcessEvent[Probe[main.condOnly]Return@c9c64]
+// 0x725: ProcessEvent[Probe[main.condOnly]Return@c9c64]
 	PrepareEventRoot 2b 01 00 00 00 00 00 00 
 	Return 
-// 0x72b: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+// 0x72f: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x741: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
+// 0x745: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x763: ProcessEvent[Probe[main.condOnly]@c9c08]
+// 0x767: ProcessEvent[Probe[main.condOnly]@c9c08]
 	PrepareEventRoot 2c 01 00 00 19 00 00 00 
-	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
-	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
+	Call 2f 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+	Call 45 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
-// 0x777: ProcessEvent[Probe[main.condOnly]Return@c9c64]
+// 0x77b: ProcessEvent[Probe[main.condOnly]Return@c9c64]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
+// 0x785: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 04 00 00 00 04 00 00 00 
+	ExprDereferencePtr 04 00 00 00 04 00 00 00 ff ff ff ff 
 	ExprPushOffset 04 00 00 00 
 	ExprLoadLiteral 04 00 2c 01 00 00 
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+// 0x7ab: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
-	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
+// 0x7cd: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
+	Call 85 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	PrepareEventRoot 1c 01 00 00 11 00 00 00 
-	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+	Call ab 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
-// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
+// 0x7e1: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 1d 01 00 00 00 00 00 00 
 	Return 
-// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
+// 0x7eb: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 38 00 00 00 10 00 00 00 
+	ExprDereferencePtr 38 00 00 00 10 00 00 00 ff ff ff ff 
 	ExprReadString ff 00 
 	ExprLoadLiteral 09 00 05 00 00 00 77 6f 72 6c 64 
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+// 0x813: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
-	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
+// 0x835: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
+	Call eb 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	PrepareEventRoot 1e 01 00 00 11 00 00 00 
-	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+	Call 13 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
-// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
+// 0x849: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 1f 01 00 00 00 00 00 00 
 	Return 
-// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+// 0x853: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 29 1a 00 00 // ProcessType[*main.condFields]
+	Call 49 1a 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
+// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
+// 0x890: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	PrepareEventRoot 20 01 00 00 19 00 00 00 
-	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
-	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
+	Call 53 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	Return 
-// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
+// 0x8a4: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 21 01 00 00 00 00 00 00 
 	Return 
-// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
+// 0x8ae: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -560,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
+// 0x8cb: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
-	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
+// 0x8e1: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
+	Call ae 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	PrepareEventRoot 26 01 00 00 09 00 00 00 
-	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
+	Call cb 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Return 
-// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
+// 0x8f5: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
 	PrepareEventRoot 27 01 00 00 00 00 00 00 
 	Return 
-// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
+// 0x8ff: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
+// 0x915: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
 	Return 
-// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
+// 0x92b: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
 	PrepareEventRoot 28 01 00 00 11 00 00 00 
-	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
-	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
+	Call ff 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
+	Call 15 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	Return 
-// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
+// 0x93f: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
+// 0x955: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
 	PrepareEventRoot 29 01 00 00 09 00 00 00 
-	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
+	Call 3f 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	Return 
-// 0x958: ProcessCondition[Probe[main.condString]@0xc9818]
+// 0x964: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -607,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x97a: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+// 0x986: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x99c: ProcessEvent[Probe[main.condString]@c9818]
-	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
+// 0x9a8: ProcessEvent[Probe[main.condString]@c9818]
+	Call 64 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 08 01 00 00 11 00 00 00 
-	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call 86 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
-// 0x9b0: ProcessEvent[Probe[main.condString]Return@c9878]
+// 0x9bc: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 09 01 00 00 00 00 00 00 
 	Return 
-// 0x9ba: ProcessCondition[Probe[main.condString]@0xc9818]
+// 0x9c6: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -632,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9d7: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+// 0x9e3: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x9f9: ProcessEvent[Probe[main.condString]@c9818]
-	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
+// 0xa05: ProcessEvent[Probe[main.condString]@c9818]
+	Call c6 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 0a 01 00 00 11 00 00 00 
-	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call e3 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
-// 0xa0d: ProcessEvent[Probe[main.condString]Return@c9878]
+// 0xa19: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 0b 01 00 00 00 00 00 00 
 	Return 
-// 0xa17: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+// 0xa23: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa39: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xa45: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xa5b: ProcessEvent[Probe[main.condString]@c9818]
+// 0xa67: ProcessEvent[Probe[main.condString]@c9818]
 	PrepareEventRoot 0c 01 00 00 21 00 00 00 
-	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
-	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+	Call 23 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call 45 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xa6f: ProcessEvent[Probe[main.condString]Return@c9878]
+// 0xa7b: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 0d 01 00 00 00 00 00 00 
 	Return 
-// 0xa79: ProcessCondition[Probe[main.condString]@0xc9818]
+// 0xa85: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -679,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xa9b: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+// 0xaa7: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xabd: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+// 0xac9: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xadf: ProcessEvent[Probe[main.condString]@c9818]
-	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
+// 0xaeb: ProcessEvent[Probe[main.condString]@c9818]
+	Call 85 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 0e 01 00 00 21 00 00 00 
-	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
-	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
+	Call a7 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call c9 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xaf8: ProcessEvent[Probe[main.condString]Return@c9878]
+// 0xb04: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 0f 01 00 00 00 00 00 00 
 	Return 
-// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xb0e: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -711,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xb2d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb43: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xb4f: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 0e 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 10 01 00 00 11 00 00 00 
-	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 2d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xb63: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 11 01 00 00 00 00 00 00 
 	Return 
-// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xb6d: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -735,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xb89: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xb9f: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xbab: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 6d 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 12 01 00 00 11 00 00 00 
-	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 89 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xbbf: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 13 01 00 00 00 00 00 00 
 	Return 
-// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xbc9: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -759,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xbec: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc02: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xc0e: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call c9 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 14 01 00 00 11 00 00 00 
-	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call ec 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xc22: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 15 01 00 00 00 00 00 00 
 	Return 
-// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xc2c: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -783,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xc4b: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xc61: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xc6d: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 2c 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 16 01 00 00 11 00 00 00 
-	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 4b 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xc81: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 17 01 00 00 00 00 00 00 
 	Return 
-// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xc8b: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -807,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xcac: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xcc2: ProcessEvent[Probe[main.condStructArg]@c98bc]
-	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
+// 0xcce: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 8b 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 18 01 00 00 11 00 00 00 
-	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call ac 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xce2: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 19 01 00 00 00 00 00 00 
 	Return 
-// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+// 0xcec: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call bf 1b 00 00 // ProcessType[main.condFields]
+	Call df 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
+// 0xd0d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd23: ProcessEvent[Probe[main.condStructArg]@c98bc]
+// 0xd2f: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	PrepareEventRoot 1a 01 00 00 61 00 00 00 
-	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
-	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
+	Call ec 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 0d 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	Return 
-// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@c9970]
+// 0xd43: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 1b 01 00 00 00 00 00 00 
 	Return 
-// 0xd41: ProcessCondition[Probe[main.condUint16]@0xc9448]
+// 0xd4d: ProcessCondition[Probe[main.condUint16]@0xc9448]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -852,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd58: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+// 0xd64: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xd7a: ProcessEvent[Probe[main.condUint16]@c9448]
-	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
+// 0xd86: ProcessEvent[Probe[main.condUint16]@c9448]
+	Call 4d 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
 	PrepareEventRoot f2 00 00 00 11 00 00 00 
-	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+	Call 64 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	Return 
-// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@c94a4]
+// 0xd9a: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f3 00 00 00 00 00 00 00 
 	Return 
-// 0xd98: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+// 0xda4: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdae: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
+// 0xdba: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 03 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xdd0: ProcessEvent[Probe[main.condUint16]@c9448]
+// 0xddc: ProcessEvent[Probe[main.condUint16]@c9448]
 	PrepareEventRoot f4 00 00 00 13 00 00 00 
-	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
-	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
+	Call a4 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+	Call ba 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	Return 
-// 0xde4: ProcessEvent[Probe[main.condUint16]Return@c94a4]
+// 0xdf0: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f5 00 00 00 00 00 00 00 
 	Return 
-// 0xdee: ProcessCondition[Probe[main.condUint32]@0xc94e8]
+// 0xdfa: ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -896,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe07: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+// 0xe13: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe29: ProcessEvent[Probe[main.condUint32]@c94e8]
-	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
+// 0xe35: ProcessEvent[Probe[main.condUint32]@c94e8]
+	Call fa 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	PrepareEventRoot f6 00 00 00 11 00 00 00 
-	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+	Call 13 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	Return 
-// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@c9544]
+// 0xe49: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f7 00 00 00 00 00 00 00 
 	Return 
-// 0xe47: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+// 0xe53: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
+// 0xe69: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 05 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xe7f: ProcessEvent[Probe[main.condUint32]@c94e8]
+// 0xe8b: ProcessEvent[Probe[main.condUint32]@c94e8]
 	PrepareEventRoot f8 00 00 00 15 00 00 00 
-	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
-	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
+	Call 53 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+	Call 69 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	Return 
-// 0xe93: ProcessEvent[Probe[main.condUint32]Return@c9544]
+// 0xe9f: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f9 00 00 00 00 00 00 00 
 	Return 
-// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xc9588]
+// 0xea9: ProcessCondition[Probe[main.condUint64]@0xc9588]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -940,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xeba: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+// 0xec6: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xedc: ProcessEvent[Probe[main.condUint64]@c9588]
-	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
+// 0xee8: ProcessEvent[Probe[main.condUint64]@c9588]
+	Call a9 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
 	PrepareEventRoot fa 00 00 00 11 00 00 00 
-	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+	Call c6 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	Return 
-// 0xef0: ProcessEvent[Probe[main.condUint64]Return@c95e4]
+// 0xefc: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot fb 00 00 00 00 00 00 00 
 	Return 
-// 0xefa: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+// 0xf06: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf10: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
+// 0xf1c: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf32: ProcessEvent[Probe[main.condUint64]@c9588]
+// 0xf3e: ProcessEvent[Probe[main.condUint64]@c9588]
 	PrepareEventRoot fc 00 00 00 19 00 00 00 
-	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
-	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
+	Call 06 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+	Call 1c 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	Return 
-// 0xf46: ProcessEvent[Probe[main.condUint64]Return@c95e4]
+// 0xf52: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot fd 00 00 00 00 00 00 00 
 	Return 
-// 0xf50: ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0xf5c: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -984,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf66: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0xf72: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xf88: ProcessEvent[Probe[main.condUint8]@c9398]
-	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0xf94: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call 5c 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot ec 00 00 00 11 00 00 00 
-	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call 72 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0xfa8: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ed 00 00 00 00 00 00 00 
 	Return 
-// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0xfb2: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1008,314 +1008,314 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0xfc8: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0xfde: ProcessEvent[Probe[main.condUint8]@c9398]
-	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
+// 0xfea: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call b2 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot ee 00 00 00 11 00 00 00 
-	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call c8 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0xff2: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0xffe: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ef 00 00 00 00 00 00 00 
 	Return 
-// 0xffc: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+// 0x1008: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1012: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
+// 0x101e: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 02 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1034: ProcessEvent[Probe[main.condUint8]@c9398]
+// 0x1040: ProcessEvent[Probe[main.condUint8]@c9398]
 	PrepareEventRoot f0 00 00 00 12 00 00 00 
-	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
-	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
+	Call 08 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call 1e 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	Return 
-// 0x1048: ProcessEvent[Probe[main.condUint8]Return@c93fc]
+// 0x1054: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot f1 00 00 00 00 00 00 00 
 	Return 
-// 0x1052: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+// 0x105e: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1062: ProcessEvent[Probe[main.inlined]@c8040]
+// 0x106e: ProcessEvent[Probe[main.inlined]@c8040]
 	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+	Call 5e 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	Return 
-// 0x1071: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
+// 0x107d: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1087: ProcessEvent[Probe[main.inlined]@c8ed8]
+// 0x1093: ProcessEvent[Probe[main.inlined]@c8ed8]
 	PrepareEventRoot 66 01 00 00 09 00 00 00 
-	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
+	Call 7d 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	Return 
-// 0x1096: ProcessEvent[Probe[main.inlined]Return@c8f0c]
+// 0x10a2: ProcessEvent[Probe[main.inlined]Return@c8f0c]
 	PrepareEventRoot 67 01 00 00 00 00 00 00 
 	Return 
-// 0x10a0: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
+// 0x10ac: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10b6: ProcessEvent[Probe[main.intArg]@c8c08]
+// 0x10c2: ProcessEvent[Probe[main.intArg]@c8c08]
 	PrepareEventRoot c3 00 00 00 09 00 00 00 
-	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
+	Call ac 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	Return 
-// 0x10c5: ProcessEvent[Probe[main.intArg]Return@c8c3c]
+// 0x10d1: ProcessEvent[Probe[main.intArg]Return@c8c3c]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
+// 0x10db: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@c8d68]
+// 0x10f7: ProcessEvent[Probe[main.intArrayArg]@c8d68]
 	PrepareEventRoot cd 00 00 00 19 00 00 00 
-	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
+	Call db 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	Return 
-// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
+// 0x1106: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
 	PrepareEventRoot ce 00 00 00 00 00 00 00 
 	Return 
-// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
+// 0x1110: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call df 1a 00 00 // ProcessType[[3]string]
+	Call ff 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
+// 0x1131: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
 	PrepareEventRoot d3 00 00 00 31 00 00 00 
-	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
+	Call 10 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	Return 
-// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
+// 0x1140: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x115d: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
+// 0x1169: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
 	PrepareEventRoot cb 00 00 00 19 00 00 00 
-	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
+	Call 40 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	Return 
-// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
+// 0x1178: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
 	PrepareEventRoot cc 00 00 00 00 00 00 00 
 	Return 
-// 0x1176: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
+// 0x1182: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x118c: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
+// 0x1198: ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x11ae: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+// 0x11ba: ProcessEvent[Probe[main.lenErrInt]@ca55c]
 	PrepareEventRoot 5c 01 00 00 19 00 00 00 
-	Call 76 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
-	Call 8c 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
+	Call 82 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[0]]
+	Call 98 11 00 00 // ProcessExpression[Probe[main.lenErrInt]@0xca55c.expr[1]]
 	Return 
-// 0x11c2: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+// 0x11ce: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
 	PrepareEventRoot 5d 01 00 00 00 00 00 00 
 	Return 
-// 0x11cc: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
+// 0x11d8: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call bf 1b 00 00 // ProcessType[main.condFields]
+	Call df 1b 00 00 // ProcessType[main.condFields]
 	Return 
-// 0x11ed: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
+// 0x11f9: ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 51 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x120f: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+// 0x121b: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
 	PrepareEventRoot 60 01 00 00 61 00 00 00 
-	Call cc 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
-	Call ed 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
+	Call d8 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[0]]
+	Call f9 11 00 00 // ProcessExpression[Probe[main.lenErrStruct]@0xca63c.expr[1]]
 	Return 
-// 0x1223: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+// 0x122f: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
 	PrepareEventRoot 61 01 00 00 00 00 00 00 
 	Return 
-// 0x122d: ProcessEvent[Probe[main.lenErrInt]@ca55c]
+// 0x1239: ProcessEvent[Probe[main.lenErrInt]@ca55c]
 	PrepareEventRoot 5e 01 00 00 00 00 00 00 
 	Return 
-// 0x1237: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
+// 0x1243: ProcessEvent[Probe[main.lenErrInt]Return@ca5f8]
 	PrepareEventRoot 5f 01 00 00 00 00 00 00 
 	Return 
-// 0x1241: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
+// 0x124d: ProcessEvent[Probe[main.lenErrStruct]@ca63c]
 	PrepareEventRoot 62 01 00 00 00 00 00 00 
 	Return 
-// 0x124b: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
+// 0x1257: ProcessEvent[Probe[main.lenErrStruct]Return@ca700]
 	PrepareEventRoot 63 01 00 00 00 00 00 00 
 	Return 
-// 0x1255: ProcessEvent[Probe[main.lenMap]@ca13c]
+// 0x1261: ProcessEvent[Probe[main.lenMap]@ca13c]
 	PrepareEventRoot 3e 01 00 00 00 00 00 00 
 	Return 
-// 0x125f: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+// 0x126b: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
 	PrepareEventRoot 3f 01 00 00 00 00 00 00 
 	Return 
-// 0x1269: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+// 0x1275: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1284: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+// 0x1290: ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x12a6: ProcessEvent[Probe[main.lenMap]@ca13c]
+// 0x12b2: ProcessEvent[Probe[main.lenMap]@ca13c]
 	PrepareEventRoot 40 01 00 00 19 00 00 00 
-	Call 69 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
-	Call 84 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
+	Call 75 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[0]]
+	Call 90 12 00 00 // ProcessExpression[Probe[main.lenMap]@0xca13c.expr[1]]
 	Return 
-// 0x12ba: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
+// 0x12c6: ProcessEvent[Probe[main.lenMap]Return@ca1e4]
 	PrepareEventRoot 41 01 00 00 00 00 00 00 
 	Return 
-// 0x12c4: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x12d0: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x12e3: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+// 0x12f3: ProcessEvent[Probe[main.lenPtrString]@ca22c]
 	PrepareEventRoot 42 01 00 00 09 00 00 00 
-	Call c4 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Call d0 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	Return 
-// 0x12f2: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+// 0x1302: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
 	PrepareEventRoot 43 01 00 00 00 00 00 00 
 	Return 
-// 0x12fc: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+// 0x130c: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*string]
+	Call 9d 1a 00 00 // ProcessType[*string]
 	Return 
-// 0x1317: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+// 0x1327: ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1339: ProcessEvent[Probe[main.lenPtrString]@ca22c]
+// 0x1349: ProcessEvent[Probe[main.lenPtrString]@ca22c]
 	PrepareEventRoot 44 01 00 00 19 00 00 00 
-	Call fc 12 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
-	Call 17 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
+	Call 0c 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[0]]
+	Call 27 13 00 00 // ProcessExpression[Probe[main.lenPtrString]@0xca22c.expr[1]]
 	Return 
-// 0x134d: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
+// 0x135d: ProcessEvent[Probe[main.lenPtrString]Return@ca2bc]
 	PrepareEventRoot 45 01 00 00 00 00 00 00 
 	Return 
-// 0x1357: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1367: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2f 1a 00 00 // ProcessType[*main.lenFields]
+	Call 4f 1a 00 00 // ProcessType[*main.lenFields]
 	Return 
-// 0x1372: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+// 0x1382: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
-	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 09 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1394: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+// 0x13a4: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
 	PrepareEventRoot 54 01 00 00 19 00 00 00 
-	Call 57 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
-	Call 72 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
+	Call 67 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call 82 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[1]]
 	Return 
-// 0x13a8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+// 0x13b8: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
 	PrepareEventRoot 55 01 00 00 00 00 00 00 
 	Return 
-// 0x13b2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+// 0x13c2: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
 	PrepareEventRoot 56 01 00 00 00 00 00 00 
 	Return 
-// 0x13bc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+// 0x13cc: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
 	PrepareEventRoot 57 01 00 00 00 00 00 00 
 	Return 
-// 0x13c6: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x13d6: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 18 00 00 00 08 00 00 00 
+	ExprDereferencePtr 18 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x13e5: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+// 0x13f9: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
 	PrepareEventRoot 58 01 00 00 09 00 00 00 
-	Call c6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call d6 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x13f4: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+// 0x1408: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
 	PrepareEventRoot 59 01 00 00 00 00 00 00 
 	Return 
-// 0x13fe: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+// 0x1412: ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x141d: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
+// 0x1435: ProcessEvent[Probe[main.lenPtrStructFields]@ca43c]
 	PrepareEventRoot 5a 01 00 00 09 00 00 00 
-	Call fe 13 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
+	Call 12 14 00 00 // ProcessExpression[Probe[main.lenPtrStructFields]@0xca43c.expr[0]]
 	Return 
-// 0x142c: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
+// 0x1444: ProcessEvent[Probe[main.lenPtrStructFields]Return@ca50c]
 	PrepareEventRoot 5b 01 00 00 00 00 00 00 
 	Return 
-// 0x1436: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x144e: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x144c: ProcessEvent[Probe[main.lenSlice]@ca04c]
+// 0x1464: ProcessEvent[Probe[main.lenSlice]@ca04c]
 	PrepareEventRoot 3a 01 00 00 09 00 00 00 
-	Call 36 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Call 4e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	Return 
-// 0x145b: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+// 0x1473: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
 	PrepareEventRoot 3b 01 00 00 00 00 00 00 
 	Return 
-// 0x1465: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+// 0x147d: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	Return 
-// 0x148e: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+// 0x14a6: ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 03 08 00 00 00 00 
 	ExprReadRegister 04 08 08 00 00 00 
-	ExprSave 19 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 19 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x14b0: ProcessEvent[Probe[main.lenSlice]@ca04c]
+// 0x14c8: ProcessEvent[Probe[main.lenSlice]@ca04c]
 	PrepareEventRoot 3c 01 00 00 29 00 00 00 
-	Call 65 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
-	Call 8e 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
+	Call 7d 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[0]]
+	Call a6 14 00 00 // ProcessExpression[Probe[main.lenSlice]@0xca04c.expr[1]]
 	Return 
-// 0x14c4: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
+// 0x14dc: ProcessEvent[Probe[main.lenSlice]Return@ca0f0]
 	PrepareEventRoot 3d 01 00 00 00 00 00 00 
 	Return 
-// 0x14ce: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x14e6: ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1324,34 +1324,34 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x14eb: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1503: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x150d: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call ce 14 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x1525: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call e6 14 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	PrepareEventRoot 30 01 00 00 11 00 00 00 
-	Call eb 14 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 03 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x1521: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x1539: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 31 01 00 00 00 00 00 00 
 	Return 
-// 0x152b: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x1543: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1541: ProcessEvent[Probe[main.lenString]@c9f6c]
+// 0x1559: ProcessEvent[Probe[main.lenString]@c9f6c]
 	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 2b 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 43 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x1550: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x1568: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 33 01 00 00 00 00 00 00 
 	Return 
-// 0x155a: ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x1572: ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
@@ -1360,133 +1360,133 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x1577: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x158f: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1599: ProcessEvent[Probe[main.lenString]@c9f6c]
-	Call 5a 15 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
+// 0x15b1: ProcessEvent[Probe[main.lenString]@c9f6c]
+	Call 72 15 00 00 // ProcessCondition[Probe[main.lenString]@0xc9f6c]
 	PrepareEventRoot 34 01 00 00 11 00 00 00 
-	Call 77 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 8f 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x15ad: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x15c5: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 35 01 00 00 00 00 00 00 
 	Return 
-// 0x15b7: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x15cf: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x15cd: ProcessEvent[Probe[main.lenString]@c9f6c]
+// 0x15e5: ProcessEvent[Probe[main.lenString]@c9f6c]
 	PrepareEventRoot 36 01 00 00 09 00 00 00 
-	Call b7 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call cf 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	Return 
-// 0x15dc: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x15f4: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 37 01 00 00 00 00 00 00 
 	Return 
-// 0x15e6: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+// 0x15fe: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1608: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+// 0x1620: ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x162a: ProcessEvent[Probe[main.lenString]@c9f6c]
+// 0x1642: ProcessEvent[Probe[main.lenString]@c9f6c]
 	PrepareEventRoot 38 01 00 00 21 00 00 00 
-	Call e6 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
-	Call 08 16 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
+	Call fe 15 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[0]]
+	Call 20 16 00 00 // ProcessExpression[Probe[main.lenString]@0xc9f6c.expr[1]]
 	Return 
-// 0x163e: ProcessEvent[Probe[main.lenString]Return@ca004]
+// 0x1656: ProcessEvent[Probe[main.lenString]Return@ca004]
 	PrepareEventRoot 39 01 00 00 00 00 00 00 
 	Return 
-// 0x1648: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1660: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 48 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 48 00 00 00 00 00 00 00 
-	Call ca 1b 00 00 // ProcessType[main.lenFields]
+	Call ea 1b 00 00 // ProcessType[main.lenFields]
 	Return 
-// 0x1669: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+// 0x1681: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 49 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 49 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x168b: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x16a3: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 46 01 00 00 59 00 00 00 
-	Call 48 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
-	Call 69 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
+	Call 60 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call 81 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[1]]
 	Return 
-// 0x169f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x16b7: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 47 01 00 00 00 00 00 00 
 	Return 
-// 0x16a9: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x16c1: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 48 01 00 00 00 00 00 00 
 	Return 
-// 0x16b3: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x16cb: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 49 01 00 00 00 00 00 00 
 	Return 
-// 0x16bd: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x16d5: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x16e2: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x16fe: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 4a 01 00 00 09 00 00 00 
-	Call bd 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call d5 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x16f1: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x170d: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 4b 01 00 00 00 00 00 00 
 	Return 
-// 0x16fb: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1717: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 08 00 00 00 00 00 00 00 
-	ExprDereferencePtr 08 00 00 00 08 00 00 00 
+	ExprDereferencePtr 08 00 00 00 08 00 00 00 01 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1720: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x1740: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 4c 01 00 00 09 00 00 00 
-	Call fb 16 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call 17 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x172f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x174f: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 4d 01 00 00 00 00 00 00 
 	Return 
-// 0x1739: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x1759: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 20 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1755: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x1775: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 4e 01 00 00 09 00 00 00 
-	Call 39 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call 59 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1764: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x1784: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 4f 01 00 00 00 00 00 00 
 	Return 
-// 0x176e: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x178e: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x178a: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+// 0x17aa: ProcessEvent[Probe[main.lenStructFields]@ca30c]
 	PrepareEventRoot 50 01 00 00 09 00 00 00 
-	Call 6e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call 8e 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x1799: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x17b9: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 51 01 00 00 00 00 00 00 
 	Return 
-// 0x17a3: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x17c3: ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 10 00 00 00 08 00 00 00 00 00 00 00 
@@ -1495,500 +1495,500 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x17c6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+// 0x17e6: ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x17e8: ProcessEvent[Probe[main.lenStructFields]@ca30c]
-	Call a3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
+// 0x1808: ProcessEvent[Probe[main.lenStructFields]@ca30c]
+	Call c3 17 00 00 // ProcessCondition[Probe[main.lenStructFields]@0xca30c]
 	PrepareEventRoot 52 01 00 00 11 00 00 00 
-	Call c6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
+	Call e6 17 00 00 // ProcessExpression[Probe[main.lenStructFields]@0xca30c.expr[0]]
 	Return 
-// 0x17fc: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
+// 0x181c: ProcessEvent[Probe[main.lenStructFields]Return@ca3f8]
 	PrepareEventRoot 53 01 00 00 00 00 00 00 
 	Return 
-// 0x1806: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x1826: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1828: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1848: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c5 00 00 00 11 00 00 00 
-	Call 06 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 26 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	Return 
-// 0x1837: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1857: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c6 00 00 00 00 00 00 00 
 	Return 
-// 0x1841: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1861: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x184b: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x186b: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c8 00 00 00 00 00 00 00 
 	Return 
-// 0x1855: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+// 0x1875: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1870: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+// 0x1890: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	ExprSave 09 00 00 00 08 00 00 00 02 00 00 00 
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x188b: ProcessEvent[Probe[main.mapArg]@c8f98]
+// 0x18ab: ProcessEvent[Probe[main.mapArg]@c8f98]
 	PrepareEventRoot d4 00 00 00 11 00 00 00 
-	Call 55 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
-	Call 70 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
+	Call 75 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+	Call 90 18 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	Return 
-// 0x189f: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
+// 0x18bf: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x18a9: ProcessEvent[Probe[main.noArgs]@c9098]
+// 0x18c9: ProcessEvent[Probe[main.noArgs]@c9098]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x18b3: ProcessEvent[Probe[main.noArgs]Return@c90cc]
+// 0x18d3: ProcessEvent[Probe[main.noArgs]Return@c90cc]
 	PrepareEventRoot d9 00 00 00 00 00 00 00 
 	Return 
-// 0x18bd: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+// 0x18dd: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x18df: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+// 0x18ff: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
-	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	ExprSave 11 00 00 00 10 00 00 00 02 00 00 00 
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1901: ProcessEvent[Probe[main.stringArg]@c8c78]
+// 0x1921: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c9 00 00 00 21 00 00 00 
-	Call bd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
-	Call df 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
+	Call dd 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call ff 18 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	Return 
-// 0x1915: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
+// 0x1935: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot ca 00 00 00 00 00 00 00 
 	Return 
-// 0x191f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+// 0x193f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call df 1a 00 00 // ProcessType[[3]string]
+	Call ff 1a 00 00 // ProcessType[[3]string]
 	Return 
-// 0x1940: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
+// 0x1960: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
 	PrepareEventRoot d1 00 00 00 31 00 00 00 
-	Call 1f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
+	Call 3f 19 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	Return 
-// 0x194f: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
+// 0x196f: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1959: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+// 0x1979: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call 63 1b 00 00 // ProcessType[[]string]
+	Call 83 1b 00 00 // ProcessType[[]string]
 	Return 
-// 0x1982: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
+// 0x19a2: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
 	PrepareEventRoot cf 00 00 00 19 00 00 00 
-	Call 59 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
+	Call 79 19 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	Return 
-// 0x1991: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
+// 0x19b1: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
 	PrepareEventRoot d0 00 00 00 00 00 00 00 
 	Return 
-// 0x199b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
+// 0x19bb: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
 	PrepareEventRoot 64 01 00 00 00 00 00 00 
 	Return 
-// 0x19a5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+// 0x19c5: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 3a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 5a 1c 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x19c0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
+// 0x19e0: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
 	PrepareEventRoot 65 01 00 00 09 00 00 00 
-	Call a5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
+	Call c5 19 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	Return 
-// 0x19cf: ProcessType[*****int]
+// 0x19ef: ProcessType[*****int]
 	ProcessPointer 8a 00 00 00 
 	Return 
-// 0x19d5: ProcessType[****int]
+// 0x19f5: ProcessType[****int]
 	ProcessPointer c1 00 00 00 
 	Return 
-// 0x19db: ProcessType[***int]
+// 0x19fb: ProcessType[***int]
 	ProcessPointer 8b 00 00 00 
 	Return 
-// 0x19e1: ProcessType[**int]
+// 0x1a01: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x19e7: ProcessType[*[]int]
+// 0x1a07: ProcessType[*[]int]
 	ProcessPointer 70 00 00 00 
 	Return 
-// 0x19ed: ProcessType[*[]runtime.ancestorInfo]
+// 0x1a0d: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x19f3: ProcessType[*bool]
+// 0x1a13: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x19f9: ProcessType[*error]
+// 0x1a19: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x19ff: ProcessType[*float32]
+// 0x1a1f: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1a05: ProcessType[*float64]
+// 0x1a25: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x1a0b: ProcessType[*int]
+// 0x1a2b: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x1a11: ProcessType[*int32]
+// 0x1a31: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x1a17: ProcessType[*int64]
+// 0x1a37: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x1a1d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1a3d: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x1a23: ProcessType[*main.bigStruct]
+// 0x1a43: ProcessType[*main.bigStruct]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1a29: ProcessType[*main.condFields]
+// 0x1a49: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x1a2f: ProcessType[*main.lenFields]
+// 0x1a4f: ProcessType[*main.lenFields]
 	ProcessPointer 81 00 00 00 
 	Return 
-// 0x1a35: ProcessType[*runtime._defer]
+// 0x1a55: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x1a3b: ProcessType[*runtime._panic]
+// 0x1a5b: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x1a41: ProcessType[*runtime.cgoCallers]
+// 0x1a61: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x1a47: ProcessType[*runtime.coro]
+// 0x1a67: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x1a4d: ProcessType[*runtime.g]
+// 0x1a6d: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x1a53: ProcessType[*runtime.m]
+// 0x1a73: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x1a59: ProcessType[*runtime.p]
+// 0x1a79: ProcessType[*runtime.p]
 	ProcessPointer 92 00 00 00 
 	Return 
-// 0x1a5f: ProcessType[*runtime.sudog]
+// 0x1a7f: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x1a65: ProcessType[*runtime.synctestBubble]
+// 0x1a85: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x1a6b: ProcessType[*runtime.timer]
+// 0x1a8b: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x1a71: ProcessType[*runtime.traceBuf]
+// 0x1a91: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1a77: ProcessType[*runtime.xRegState]
+// 0x1a97: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1a7d: ProcessType[*string]
+// 0x1a9d: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x1a83: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1aa3: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b8 00 00 00 
 	Return 
-// 0x1a89: ProcessType[*table<string,int>]
+// 0x1aa9: ProcessType[*table<string,int>]
 	ProcessPointer 99 00 00 00 
 	Return 
-// 0x1a8f: ProcessType[*table<string,main.bigStruct>]
+// 0x1aaf: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer a1 00 00 00 
 	Return 
-// 0x1a95: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1ab5: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer ab 00 00 00 
 	Return 
-// 0x1a9b: ProcessType[*uint]
+// 0x1abb: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x1aa1: ProcessType[*uint16]
+// 0x1ac1: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1aa7: ProcessType[*uint32]
+// 0x1ac7: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1aad: ProcessType[*uint64]
+// 0x1acd: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x1ab3: ProcessType[*uint8]
+// 0x1ad3: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1ab9: ProcessType[*uintptr]
+// 0x1ad9: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x1abf: ProcessType[[2]*runtime.traceBuf]
+// 0x1adf: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call 71 1a 00 00 // ProcessType[*runtime.traceBuf]
+	Call 91 1a 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1acf: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1aef: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call bf 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call df 1a 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1adf: ProcessType[[3]string]
+// 0x1aff: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1aef: ProcessType[[]*runtime.p]
+// 0x1b0f: ProcessType[[]*runtime.p]
 	ProcessSlice 93 00 00 00 08 00 00 00 
 	Return 
-// 0x1af9: ProcessType[[]*runtime.p.array]
+// 0x1b19: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call 59 1a 00 00 // ProcessType[*runtime.p]
+	Call 79 1a 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b05: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1b25: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 83 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call a3 1a 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b11: ProcessType[[]*table<string,int>.array]
+// 0x1b31: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 89 1a 00 00 // ProcessType[*table<string,int>]
+	Call a9 1a 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b1d: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1b3d: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 8f 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call af 1a 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b29: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x1b49: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 95 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call b5 1a 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1b35: ProcessType[[]int]
+// 0x1b55: ProcessType[[]int]
 	ProcessSlice 95 00 00 00 08 00 00 00 
 	Return 
-// 0x1b3f: ProcessType[[]noalg.map.group[string]int.array]
+// 0x1b5f: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call 70 1c 00 00 // ProcessType[noalg.map.group[string]int]
+	Call 90 1c 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b4b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x1b6b: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call 7b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call 9b 1c 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b57: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x1b77: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call 86 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call a6 1c 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x1b63: ProcessType[[]string]
+// 0x1b83: ProcessType[[]string]
 	ProcessSlice 97 00 00 00 10 00 00 00 
 	Return 
-// 0x1b6d: ProcessType[[]string.array]
+// 0x1b8d: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1b79: ProcessType[[]uint8]
+// 0x1b99: ProcessType[[]uint8]
 	ProcessSlice 8e 00 00 00 01 00 00 00 
 	Return 
-// 0x1b83: ProcessType[[]uintptr]
+// 0x1ba3: ProcessType[[]uintptr]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1b8d: ProcessType[error]
+// 0x1bad: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x1b8f: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x1baf: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups c0 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1b9b: ProcessType[groupReference<string,int>]
+// 0x1bbb: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups a0 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1ba7: ProcessType[groupReference<string,main.bigStruct>]
+// 0x1bc7: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups aa 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1bb3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1bd3: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b7 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1bbf: ProcessType[main.condFields]
+// 0x1bdf: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1bca: ProcessType[main.lenFields]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1bea: ProcessType[main.lenFields]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 35 1b 00 00 // ProcessType[[]int]
+	Call 55 1b 00 00 // ProcessType[[]int]
 	IncrementOutputOffset 18 00 00 00 
-	Call 2e 1c 00 00 // ProcessType[map[string]int]
+	Call 4e 1c 00 00 // ProcessType[map[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 7d 1a 00 00 // ProcessType[*string]
+	Call 9d 1a 00 00 // ProcessType[*string]
 	IncrementOutputOffset 08 00 00 00 
-	Call e7 19 00 00 // ProcessType[*[]int]
+	Call 07 1a 00 00 // ProcessType[*[]int]
 	Return 
-// 0x1bf8: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x1c18: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bf 00 00 00 bb 00 00 00 10 18 
 	Return 
-// 0x1c04: ProcessType[map<string,int>]
+// 0x1c24: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9f 00 00 00 9c 00 00 00 10 18 
 	Return 
-// 0x1c10: ProcessType[map<string,main.bigStruct>]
+// 0x1c30: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a9 00 00 00 a4 00 00 00 10 18 
 	Return 
-// 0x1c1c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1c3c: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b6 00 00 00 ae 00 00 00 10 18 
 	Return 
-// 0x1c28: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c48: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b3 00 00 00 
 	Return 
-// 0x1c2e: ProcessType[map[string]int]
+// 0x1c4e: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1c34: ProcessType[map[string]main.bigStruct]
+// 0x1c54: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1c3a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1c5a: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 86 00 00 00 
 	Return 
-// 0x1c40: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1c60: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call 91 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call b1 1c 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c50: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1c70: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call a1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call c1 1c 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x1c60: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1c80: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call a7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call c7 1c 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1c70: ProcessType[noalg.map.group[string]int]
+// 0x1c90: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call 50 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 70 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x1c7b: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x1c9b: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 40 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x1c86: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1ca6: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call 60 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 80 1c 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x1c91: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1cb1: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call 23 1a 00 00 // ProcessType[*main.bigStruct]
+	Call 43 1a 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x1ca1: ProcessType[noalg.struct { key string; elem int }]
-	Call bc 1d 00 00 // ProcessType[string]
+// 0x1cc1: ProcessType[noalg.struct { key string; elem int }]
+	Call dc 1d 00 00 // ProcessType[string]
 	Return 
-// 0x1ca7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1cc7: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 28 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 48 1c 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1cb2: ProcessType[runtime.g]
+// 0x1cd2: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call 3b 1a 00 00 // ProcessType[*runtime._panic]
+	Call 5b 1a 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call 35 1a 00 00 // ProcessType[*runtime._defer]
+	Call 55 1a 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 79 1b 00 00 // ProcessType[[]uint8]
+	Call 99 1b 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call ed 19 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 0d 1a 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call 5f 1a 00 00 // ProcessType[*runtime.sudog]
+	Call 7f 1a 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call 6b 1a 00 00 // ProcessType[*runtime.timer]
+	Call 8b 1a 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call 47 1a 00 00 // ProcessType[*runtime.coro]
+	Call 67 1a 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call 65 1a 00 00 // ProcessType[*runtime.synctestBubble]
+	Call 85 1a 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call b6 1d 00 00 // ProcessType[runtime.xRegPerG]
+	Call d6 1d 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x1d21: ProcessType[runtime.m]
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+// 0x1d41: ProcessType[runtime.m]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call 4d 1a 00 00 // ProcessType[*runtime.g]
+	Call 6d 1a 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call bc 1d 00 00 // ProcessType[string]
+	Call dc 1d 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call ef 1a 00 00 // ProcessType[[]*runtime.p]
+	Call 0f 1b 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call 41 1a 00 00 // ProcessType[*runtime.cgoCallers]
+	Call 61 1a 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call 95 1d 00 00 // ProcessType[runtime.mLockProfile]
+	Call b5 1d 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call a0 1d 00 00 // ProcessType[runtime.mTraceState]
+	Call c0 1d 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call b0 1d 00 00 // ProcessType[runtime.mWeakPointer]
+	Call d0 1d 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x1d95: ProcessType[runtime.mLockProfile]
+// 0x1db5: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 83 1b 00 00 // ProcessType[[]uintptr]
+	Call a3 1b 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x1da0: ProcessType[runtime.mTraceState]
+// 0x1dc0: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call cf 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call 53 1a 00 00 // ProcessType[*runtime.m]
+	Call ef 1a 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call 73 1a 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x1db0: ProcessType[runtime.mWeakPointer]
-	Call 1d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1dd0: ProcessType[runtime.mWeakPointer]
+	Call 3d 1a 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1db6: ProcessType[runtime.xRegPerG]
-	Call 77 1a 00 00 // ProcessType[*runtime.xRegState]
+// 0x1dd6: ProcessType[runtime.xRegPerG]
+	Call 97 1a 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1dbc: ProcessType[string]
+// 0x1ddc: ProcessType[string]
 	ProcessString 8c 00 00 00 
 	Return 
-// 0x1dc2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x1de2: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 8f 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call af 1b 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x1dcd: ProcessType[table<string,int>]
+// 0x1ded: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 9b 1b 00 00 // ProcessType[groupReference<string,int>]
+	Call bb 1b 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1dd8: ProcessType[table<string,main.bigStruct>]
+// 0x1df8: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call a7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call c7 1b 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1de3: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1e03: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call b3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call d3 1b 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -2256,32 +2256,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 6835
+ID: 5 Len: 8 Enqueue: 6867
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 7612
-ID: 10 Len: 8 Enqueue: 6643
+ID: 9 Len: 16 Enqueue: 7644
+ID: 10 Len: 8 Enqueue: 6675
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 7053
+ID: 15 Len: 16 Enqueue: 7085
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 6841
-ID: 21 Len: 8 Enqueue: 6673
-ID: 22 Len: 8 Enqueue: 6823
-ID: 23 Len: 456 Enqueue: 7346
+ID: 20 Len: 8 Enqueue: 6873
+ID: 21 Len: 8 Enqueue: 6705
+ID: 22 Len: 8 Enqueue: 6855
+ID: 23 Len: 456 Enqueue: 7378
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 6715
+ID: 25 Len: 8 Enqueue: 6747
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 6709
+ID: 27 Len: 8 Enqueue: 6741
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 6739
-ID: 30 Len: 1824 Enqueue: 7457
+ID: 29 Len: 8 Enqueue: 6771
+ID: 30 Len: 1824 Enqueue: 7489
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -2290,51 +2290,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 7033
-ID: 40 Len: 8 Enqueue: 6637
+ID: 39 Len: 24 Enqueue: 7065
+ID: 40 Len: 8 Enqueue: 6669
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 6751
+ID: 42 Len: 8 Enqueue: 6783
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 7043
-ID: 45 Len: 8 Enqueue: 6763
+ID: 44 Len: 24 Enqueue: 7075
+ID: 45 Len: 8 Enqueue: 6795
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 6727
+ID: 48 Len: 8 Enqueue: 6759
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 6757
+ID: 50 Len: 8 Enqueue: 6789
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 7606
-ID: 53 Len: 8 Enqueue: 6775
+ID: 52 Len: 8 Enqueue: 7638
+ID: 53 Len: 8 Enqueue: 6807
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 6733
+ID: 59 Len: 8 Enqueue: 6765
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 6895
+ID: 66 Len: 24 Enqueue: 6927
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 6745
-ID: 69 Len: 8 Enqueue: 6721
+ID: 68 Len: 8 Enqueue: 6777
+ID: 69 Len: 8 Enqueue: 6753
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 7573
+ID: 75 Len: 56 Enqueue: 7605
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 7584
-ID: 81 Len: 32 Enqueue: 6863
-ID: 82 Len: 16 Enqueue: 6847
-ID: 83 Len: 8 Enqueue: 6769
+ID: 80 Len: 72 Enqueue: 7616
+ID: 81 Len: 32 Enqueue: 6895
+ID: 82 Len: 16 Enqueue: 6879
+ID: 83 Len: 8 Enqueue: 6801
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -2349,48 +2349,48 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 7600
-ID: 99 Len: 8 Enqueue: 6685
+ID: 98 Len: 8 Enqueue: 7632
+ID: 99 Len: 8 Enqueue: 6717
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 6781
+ID: 101 Len: 8 Enqueue: 6813
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 6661
-ID: 105 Len: 8 Enqueue: 6667
-ID: 106 Len: 8 Enqueue: 6829
-ID: 107 Len: 8 Enqueue: 6679
-ID: 108 Len: 8 Enqueue: 6649
-ID: 109 Len: 8 Enqueue: 6655
-ID: 110 Len: 8 Enqueue: 6811
-ID: 111 Len: 8 Enqueue: 6817
-ID: 112 Len: 24 Enqueue: 6965
+ID: 104 Len: 8 Enqueue: 6693
+ID: 105 Len: 8 Enqueue: 6699
+ID: 106 Len: 8 Enqueue: 6861
+ID: 107 Len: 8 Enqueue: 6711
+ID: 108 Len: 8 Enqueue: 6681
+ID: 109 Len: 8 Enqueue: 6687
+ID: 110 Len: 8 Enqueue: 6843
+ID: 111 Len: 8 Enqueue: 6849
+ID: 112 Len: 24 Enqueue: 6997
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 7011
-ID: 115 Len: 48 Enqueue: 6879
-ID: 116 Len: 8 Enqueue: 7214
+ID: 114 Len: 24 Enqueue: 7043
+ID: 115 Len: 48 Enqueue: 6911
+ID: 116 Len: 8 Enqueue: 7246
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 7172
+ID: 118 Len: 48 Enqueue: 7204
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 6793
-ID: 121 Len: 8 Enqueue: 7220
+ID: 120 Len: 8 Enqueue: 6825
+ID: 121 Len: 8 Enqueue: 7252
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 7184
+ID: 123 Len: 48 Enqueue: 7216
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 6799
-ID: 126 Len: 80 Enqueue: 7103
+ID: 125 Len: 8 Enqueue: 6831
+ID: 126 Len: 80 Enqueue: 7135
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 6697
-ID: 129 Len: 72 Enqueue: 7114
-ID: 130 Len: 8 Enqueue: 6631
-ID: 131 Len: 8 Enqueue: 6703
-ID: 132 Len: 8 Enqueue: 7226
+ID: 128 Len: 8 Enqueue: 6729
+ID: 129 Len: 72 Enqueue: 7146
+ID: 130 Len: 8 Enqueue: 6663
+ID: 131 Len: 8 Enqueue: 6735
+ID: 132 Len: 8 Enqueue: 7258
 ID: 133 Len: 8 Enqueue: 0
-ID: 134 Len: 48 Enqueue: 7196
+ID: 134 Len: 48 Enqueue: 7228
 ID: 135 Len: 8 Enqueue: 0
-ID: 136 Len: 8 Enqueue: 6805
-ID: 137 Len: 8 Enqueue: 6607
-ID: 138 Len: 8 Enqueue: 6613
-ID: 139 Len: 8 Enqueue: 6625
+ID: 136 Len: 8 Enqueue: 6837
+ID: 137 Len: 8 Enqueue: 6639
+ID: 138 Len: 8 Enqueue: 6645
+ID: 139 Len: 8 Enqueue: 6657
 ID: 140 Len: 1 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 1 Enqueue: 0
@@ -2398,53 +2398,53 @@ ID: 143 Len: 8 Enqueue: 0
 ID: 144 Len: 8 Enqueue: 0
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
-ID: 147 Len: 8 Enqueue: 6905
+ID: 147 Len: 8 Enqueue: 6937
 ID: 148 Len: 8 Enqueue: 0
 ID: 149 Len: 8 Enqueue: 0
 ID: 150 Len: 8 Enqueue: 0
-ID: 151 Len: 16 Enqueue: 7021
+ID: 151 Len: 16 Enqueue: 7053
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 32 Enqueue: 7629
-ID: 154 Len: 16 Enqueue: 7067
+ID: 153 Len: 32 Enqueue: 7661
+ID: 154 Len: 16 Enqueue: 7099
 ID: 155 Len: 8 Enqueue: 0
-ID: 156 Len: 200 Enqueue: 7280
-ID: 157 Len: 192 Enqueue: 7248
-ID: 158 Len: 24 Enqueue: 7329
-ID: 159 Len: 8 Enqueue: 6929
-ID: 160 Len: 200 Enqueue: 6975
-ID: 161 Len: 32 Enqueue: 7640
-ID: 162 Len: 16 Enqueue: 7079
+ID: 156 Len: 200 Enqueue: 7312
+ID: 157 Len: 192 Enqueue: 7280
+ID: 158 Len: 24 Enqueue: 7361
+ID: 159 Len: 8 Enqueue: 6961
+ID: 160 Len: 200 Enqueue: 7007
+ID: 161 Len: 32 Enqueue: 7672
+ID: 162 Len: 16 Enqueue: 7111
 ID: 163 Len: 8 Enqueue: 0
-ID: 164 Len: 200 Enqueue: 7291
-ID: 165 Len: 192 Enqueue: 7232
-ID: 166 Len: 24 Enqueue: 7313
-ID: 167 Len: 8 Enqueue: 6691
+ID: 164 Len: 200 Enqueue: 7323
+ID: 165 Len: 192 Enqueue: 7264
+ID: 166 Len: 24 Enqueue: 7345
+ID: 167 Len: 8 Enqueue: 6723
 ID: 168 Len: 184 Enqueue: 0
-ID: 169 Len: 8 Enqueue: 6941
-ID: 170 Len: 200 Enqueue: 6987
-ID: 171 Len: 32 Enqueue: 7651
-ID: 172 Len: 16 Enqueue: 7091
+ID: 169 Len: 8 Enqueue: 6973
+ID: 170 Len: 200 Enqueue: 7019
+ID: 171 Len: 32 Enqueue: 7683
+ID: 172 Len: 16 Enqueue: 7123
 ID: 173 Len: 8 Enqueue: 0
-ID: 174 Len: 136 Enqueue: 7302
-ID: 175 Len: 128 Enqueue: 7264
-ID: 176 Len: 16 Enqueue: 7335
-ID: 177 Len: 8 Enqueue: 7208
+ID: 174 Len: 136 Enqueue: 7334
+ID: 175 Len: 128 Enqueue: 7296
+ID: 176 Len: 16 Enqueue: 7367
+ID: 177 Len: 8 Enqueue: 7240
 ID: 178 Len: 8 Enqueue: 0
-ID: 179 Len: 48 Enqueue: 7160
+ID: 179 Len: 48 Enqueue: 7192
 ID: 180 Len: 8 Enqueue: 0
-ID: 181 Len: 8 Enqueue: 6787
-ID: 182 Len: 8 Enqueue: 6953
-ID: 183 Len: 136 Enqueue: 6999
-ID: 184 Len: 32 Enqueue: 7618
-ID: 185 Len: 16 Enqueue: 7055
+ID: 181 Len: 8 Enqueue: 6819
+ID: 182 Len: 8 Enqueue: 6985
+ID: 183 Len: 136 Enqueue: 7031
+ID: 184 Len: 32 Enqueue: 7650
+ID: 185 Len: 16 Enqueue: 7087
 ID: 186 Len: 8 Enqueue: 0
 ID: 187 Len: 136 Enqueue: 0
 ID: 188 Len: 128 Enqueue: 0
 ID: 189 Len: 16 Enqueue: 0
 ID: 190 Len: 8 Enqueue: 0
-ID: 191 Len: 8 Enqueue: 6917
+ID: 191 Len: 8 Enqueue: 6949
 ID: 192 Len: 136 Enqueue: 0
-ID: 193 Len: 8 Enqueue: 6619
+ID: 193 Len: 8 Enqueue: 6651
 ID: 194 Len: 128 Enqueue: 0
 ID: 195 Len: 9 Enqueue: 0
 ID: 196 Len: 0 Enqueue: 0

--- a/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
+++ b/pkg/dyninst/compiler/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.sm.txt
@@ -3,54 +3,54 @@
 // 0x1: ChasePointers
 	ChasePointers 
 	Return 
-// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xc8264.expr[0]]
+// 0x3: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc8264.expr[1]]
+// 0x1e: ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 66 13 00 00 // ProcessType[*****int]
+	Call 3f 13 00 00 // ProcessType[*****int]
 	Return 
-// 0x39: ProcessEvent[Probe[main.PointerChainArg]@c8264]
+// 0x39: ProcessEvent[Probe[main.PointerChainArg]@c826c]
 	PrepareEventRoot 31 01 00 00 11 00 00 00 
-	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc8264.expr[0]]
-	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc8264.expr[1]]
+	Call 03 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[0]]
+	Call 1e 00 00 00 // ProcessExpression[Probe[main.PointerChainArg]@0xc826c.expr[1]]
 	Return 
-// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xc8298.expr[0]]
+// 0x4d: ProcessExpression[Probe[main.PointerSmallChainArg]@0xc82a4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 05 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 78 13 00 00 // ProcessType[**int]
+	Call 51 13 00 00 // ProcessType[**int]
 	Return 
-// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c8298]
+// 0x68: ProcessEvent[Probe[main.PointerSmallChainArg]@c82a4]
 	PrepareEventRoot 32 01 00 00 09 00 00 00 
-	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xc8298.expr[0]]
+	Call 4d 00 00 00 // ProcessExpression[Probe[main.PointerSmallChainArg]@0xc82a4.expr[0]]
 	Return 
-// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xc8bd8.expr[0]]
+// 0x77: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 91 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc8bd8.expr[1]]
+// 0x92: ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 91 15 00 00 // ProcessType[map[string]main.bigStruct]
+	Call 6a 15 00 00 // ProcessType[map[string]main.bigStruct]
 	Return 
-// 0xad: ProcessEvent[Probe[main.bigMapArg]@c8bd8]
+// 0xad: ProcessEvent[Probe[main.bigMapArg]@c9008]
 	PrepareEventRoot d3 00 00 00 11 00 00 00 
-	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc8bd8.expr[0]]
-	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc8bd8.expr[1]]
+	Call 77 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[0]]
+	Call 92 00 00 00 // ProcessExpression[Probe[main.bigMapArg]@0xc9008.expr[1]]
 	Return 
-// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@c8c24]
+// 0xc1: ProcessEvent[Probe[main.bigMapArg]Return@c9054]
 	PrepareEventRoot d4 00 00 00 00 00 00 00 
 	Return 
-// 0xcb: ProcessCondition[Probe[main.condBool]@0xc9338]
+// 0xcb: ProcessCondition[Probe[main.condBool]@0xc9768]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -59,22 +59,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xe1: ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
+// 0xe1: ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x103: ProcessEvent[Probe[main.condBool]@c9338]
-	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9338]
+// 0x103: ProcessEvent[Probe[main.condBool]@c9768]
+	Call cb 00 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
 	PrepareEventRoot ff 00 00 00 11 00 00 00 
-	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
+	Call e1 00 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	Return 
-// 0x117: ProcessEvent[Probe[main.condBool]Return@c939c]
+// 0x117: ProcessEvent[Probe[main.condBool]Return@c97cc]
 	PrepareEventRoot 00 01 00 00 00 00 00 00 
 	Return 
-// 0x121: ProcessCondition[Probe[main.condBool]@0xc9338]
+// 0x121: ProcessCondition[Probe[main.condBool]@0xc9768]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -83,70 +83,70 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x137: ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
+// 0x137: ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x159: ProcessEvent[Probe[main.condBool]@c9338]
-	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9338]
+// 0x159: ProcessEvent[Probe[main.condBool]@c9768]
+	Call 21 01 00 00 // ProcessCondition[Probe[main.condBool]@0xc9768]
 	PrepareEventRoot 01 01 00 00 11 00 00 00 
-	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
+	Call 37 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	Return 
-// 0x16d: ProcessEvent[Probe[main.condBool]Return@c939c]
+// 0x16d: ProcessEvent[Probe[main.condBool]Return@c97cc]
 	PrepareEventRoot 02 01 00 00 00 00 00 00 
 	Return 
-// 0x177: ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
+// 0x177: ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x18d: ProcessExpression[Probe[main.condBool]@0xc9338.expr[1]]
+// 0x18d: ProcessExpression[Probe[main.condBool]@0xc9768.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1af: ProcessEvent[Probe[main.condBool]@c9338]
+// 0x1af: ProcessEvent[Probe[main.condBool]@c9768]
 	PrepareEventRoot 03 01 00 00 12 00 00 00 
-	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9338.expr[0]]
-	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9338.expr[1]]
+	Call 77 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[0]]
+	Call 8d 01 00 00 // ProcessExpression[Probe[main.condBool]@0xc9768.expr[1]]
 	Return 
-// 0x1c3: ProcessEvent[Probe[main.condBool]Return@c939c]
+// 0x1c3: ProcessEvent[Probe[main.condBool]Return@c97cc]
 	PrepareEventRoot 04 01 00 00 00 00 00 00 
 	Return 
-// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xc91f8.expr[0]]
+// 0x1cd: ProcessExpression[Probe[main.condFloat32]@0xc9628.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1ef: ProcessEvent[Probe[main.condFloat32]@c91f8]
+// 0x1ef: ProcessEvent[Probe[main.condFloat32]@c9628]
 	PrepareEventRoot fb 00 00 00 11 00 00 00 
-	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xc91f8.expr[0]]
+	Call cd 01 00 00 // ProcessExpression[Probe[main.condFloat32]@0xc9628.expr[0]]
 	Return 
-// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@c9258]
+// 0x1fe: ProcessEvent[Probe[main.condFloat32]Return@c9688]
 	PrepareEventRoot fc 00 00 00 00 00 00 00 
 	Return 
-// 0x208: ProcessExpression[Probe[main.condFloat64]@0xc9298.expr[0]]
+// 0x208: ProcessExpression[Probe[main.condFloat64]@0xc96c8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x22a: ProcessEvent[Probe[main.condFloat64]@c9298]
+// 0x22a: ProcessEvent[Probe[main.condFloat64]@c96c8]
 	PrepareEventRoot fd 00 00 00 11 00 00 00 
-	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xc9298.expr[0]]
+	Call 08 02 00 00 // ProcessExpression[Probe[main.condFloat64]@0xc96c8.expr[0]]
 	Return 
-// 0x239: ProcessEvent[Probe[main.condFloat64]Return@c92f8]
+// 0x239: ProcessEvent[Probe[main.condFloat64]Return@c9728]
 	PrepareEventRoot fe 00 00 00 00 00 00 00 
 	Return 
-// 0x243: ProcessCondition[Probe[main.condInt16]@0xc8d88]
+// 0x243: ProcessCondition[Probe[main.condInt16]@0xc91b8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -155,42 +155,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0x25a: ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[0]]
+// 0x25a: ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x27c: ProcessEvent[Probe[main.condInt16]@c8d88]
-	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc8d88]
+// 0x27c: ProcessEvent[Probe[main.condInt16]@c91b8]
+	Call 43 02 00 00 // ProcessCondition[Probe[main.condInt16]@0xc91b8]
 	PrepareEventRoot db 00 00 00 11 00 00 00 
-	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[0]]
+	Call 5a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	Return 
-// 0x290: ProcessEvent[Probe[main.condInt16]Return@c8de4]
+// 0x290: ProcessEvent[Probe[main.condInt16]Return@c9214]
 	PrepareEventRoot dc 00 00 00 00 00 00 00 
 	Return 
-// 0x29a: ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[0]]
+// 0x29a: ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[1]]
+// 0x2b0: ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x2d2: ProcessEvent[Probe[main.condInt16]@c8d88]
+// 0x2d2: ProcessEvent[Probe[main.condInt16]@c91b8]
 	PrepareEventRoot dd 00 00 00 13 00 00 00 
-	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[0]]
-	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc8d88.expr[1]]
+	Call 9a 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[0]]
+	Call b0 02 00 00 // ProcessExpression[Probe[main.condInt16]@0xc91b8.expr[1]]
 	Return 
-// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@c8de4]
+// 0x2e6: ProcessEvent[Probe[main.condInt16]Return@c9214]
 	PrepareEventRoot de 00 00 00 00 00 00 00 
 	Return 
-// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xc8e28]
+// 0x2f0: ProcessCondition[Probe[main.condInt32]@0xc9258]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -199,22 +199,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x309: ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
+// 0x309: ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x32b: ProcessEvent[Probe[main.condInt32]@c8e28]
-	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc8e28]
+// 0x32b: ProcessEvent[Probe[main.condInt32]@c9258]
+	Call f0 02 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
 	PrepareEventRoot df 00 00 00 11 00 00 00 
-	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
+	Call 09 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	Return 
-// 0x33f: ProcessEvent[Probe[main.condInt32]Return@c8e84]
+// 0x33f: ProcessEvent[Probe[main.condInt32]Return@c92b4]
 	PrepareEventRoot e0 00 00 00 00 00 00 00 
 	Return 
-// 0x349: ProcessCondition[Probe[main.condInt32]@0xc8e28]
+// 0x349: ProcessCondition[Probe[main.condInt32]@0xc9258]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -223,42 +223,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x362: ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
+// 0x362: ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x384: ProcessEvent[Probe[main.condInt32]@c8e28]
-	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc8e28]
+// 0x384: ProcessEvent[Probe[main.condInt32]@c9258]
+	Call 49 03 00 00 // ProcessCondition[Probe[main.condInt32]@0xc9258]
 	PrepareEventRoot e1 00 00 00 11 00 00 00 
-	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
+	Call 62 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	Return 
-// 0x398: ProcessEvent[Probe[main.condInt32]Return@c8e84]
+// 0x398: ProcessEvent[Probe[main.condInt32]Return@c92b4]
 	PrepareEventRoot e2 00 00 00 00 00 00 00 
 	Return 
-// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
+// 0x3a2: ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[1]]
+// 0x3b8: ProcessExpression[Probe[main.condInt32]@0xc9258.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x3da: ProcessEvent[Probe[main.condInt32]@c8e28]
+// 0x3da: ProcessEvent[Probe[main.condInt32]@c9258]
 	PrepareEventRoot e3 00 00 00 15 00 00 00 
-	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[0]]
-	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc8e28.expr[1]]
+	Call a2 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[0]]
+	Call b8 03 00 00 // ProcessExpression[Probe[main.condInt32]@0xc9258.expr[1]]
 	Return 
-// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@c8e84]
+// 0x3ee: ProcessEvent[Probe[main.condInt32]Return@c92b4]
 	PrepareEventRoot e4 00 00 00 00 00 00 00 
 	Return 
-// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xc8ec8]
+// 0x3f8: ProcessCondition[Probe[main.condInt64]@0xc92f8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -267,42 +267,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x415: ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[0]]
+// 0x415: ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x437: ProcessEvent[Probe[main.condInt64]@c8ec8]
-	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc8ec8]
+// 0x437: ProcessEvent[Probe[main.condInt64]@c92f8]
+	Call f8 03 00 00 // ProcessCondition[Probe[main.condInt64]@0xc92f8]
 	PrepareEventRoot e5 00 00 00 11 00 00 00 
-	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[0]]
+	Call 15 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	Return 
-// 0x44b: ProcessEvent[Probe[main.condInt64]Return@c8f24]
+// 0x44b: ProcessEvent[Probe[main.condInt64]Return@c9354]
 	PrepareEventRoot e6 00 00 00 00 00 00 00 
 	Return 
-// 0x455: ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[0]]
+// 0x455: ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x46b: ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[1]]
+// 0x46b: ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x48d: ProcessEvent[Probe[main.condInt64]@c8ec8]
+// 0x48d: ProcessEvent[Probe[main.condInt64]@c92f8]
 	PrepareEventRoot e7 00 00 00 19 00 00 00 
-	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[0]]
-	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc8ec8.expr[1]]
+	Call 55 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[0]]
+	Call 6b 04 00 00 // ProcessExpression[Probe[main.condInt64]@0xc92f8.expr[1]]
 	Return 
-// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@c8f24]
+// 0x4a1: ProcessEvent[Probe[main.condInt64]Return@c9354]
 	PrepareEventRoot e8 00 00 00 00 00 00 00 
 	Return 
-// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xc8cd8]
+// 0x4ab: ProcessCondition[Probe[main.condInt8]@0xc9108]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -311,86 +311,80 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[0]]
+// 0x4c1: ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x4e3: ProcessEvent[Probe[main.condInt8]@c8cd8]
-	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc8cd8]
+// 0x4e3: ProcessEvent[Probe[main.condInt8]@c9108]
+	Call ab 04 00 00 // ProcessCondition[Probe[main.condInt8]@0xc9108]
 	PrepareEventRoot d7 00 00 00 11 00 00 00 
-	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[0]]
+	Call c1 04 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	Return 
-// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@c8d3c]
+// 0x4f7: ProcessEvent[Probe[main.condInt8]Return@c916c]
 	PrepareEventRoot d8 00 00 00 00 00 00 00 
 	Return 
-// 0x501: ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[0]]
+// 0x501: ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x517: ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[1]]
+// 0x517: ProcessExpression[Probe[main.condInt8]@0xc9108.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x539: ProcessEvent[Probe[main.condInt8]@c8cd8]
+// 0x539: ProcessEvent[Probe[main.condInt8]@c9108]
 	PrepareEventRoot d9 00 00 00 12 00 00 00 
-	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[0]]
-	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc8cd8.expr[1]]
+	Call 01 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[0]]
+	Call 17 05 00 00 // ProcessExpression[Probe[main.condInt8]@0xc9108.expr[1]]
 	Return 
-// 0x54d: ProcessEvent[Probe[main.condInt8]Return@c8d3c]
+// 0x54d: ProcessEvent[Probe[main.condInt8]Return@c916c]
 	PrepareEventRoot da 00 00 00 00 00 00 00 
 	Return 
-// 0x557: ProcessCondition[Probe[main.condLine]Line@0xc9888]
+// 0x557: ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
 	ConditionBegin 
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprPushOffset 08 00 00 00 
 	ExprLoadLiteral 08 00 07 00 00 00 00 00 00 00 
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x57a: ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[0]]
+// 0x574: ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x59c: ProcessEvent[Probe[main.condLine]Line@c9888]
-	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9888]
+// 0x596: ProcessEvent[Probe[main.condLine]Line@c9cb4]
+	Call 57 05 00 00 // ProcessCondition[Probe[main.condLine]Line@0xc9cb4]
 	PrepareEventRoot 2b 01 00 00 11 00 00 00 
-	Call 7a 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[0]]
+	Call 74 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	Return 
-// 0x5b0: ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[0]]
+// 0x5aa: ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
 	ExprPrepare 
-	ExprDereferenceCfa 08 00 00 00 08 00 00 00 00 00 00 00 
+	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x5cc: ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[1]]
+// 0x5c0: ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x5ee: ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[2]]
-	ExprPrepare 
-	ExprReadRegister 00 08 00 00 00 00 
-	ExprSave 19 00 00 00 08 00 00 00 02 00 00 00 
+// 0x5e2: ProcessEvent[Probe[main.condLine]Line@c9cb4]
+	PrepareEventRoot 2c 01 00 00 19 00 00 00 
+	Call aa 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[0]]
+	Call c0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9cb4.expr[1]]
 	Return 
-// 0x604: ProcessEvent[Probe[main.condLine]Line@c9888]
-	PrepareEventRoot 2c 01 00 00 21 00 00 00 
-	Call b0 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[0]]
-	Call cc 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[1]]
-	Call ee 05 00 00 // ProcessExpression[Probe[main.condLine]Line@0xc9888.expr[2]]
-	Return 
-// 0x61d: ProcessCondition[Probe[main.condNilPtrStruct]@0xc9688]
+// 0x5f6: ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -400,43 +394,43 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x63f: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[0]]
+// 0x618: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x661: ProcessEvent[Probe[main.condNilPtrStruct]@c9688]
-	Call 1d 06 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9688]
+// 0x63a: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
+	Call f6 05 00 00 // ProcessCondition[Probe[main.condNilPtrStruct]@0xc9ab8]
 	PrepareEventRoot 1f 01 00 00 11 00 00 00 
-	Call 3f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[0]]
+	Call 18 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	Return 
-// 0x675: ProcessEvent[Probe[main.condNilPtrStruct]Return@c96f4]
+// 0x64e: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
 	PrepareEventRoot 20 01 00 00 00 00 00 00 
 	Return 
-// 0x67f: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[0]]
+// 0x658: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ba 13 00 00 // ProcessType[*main.condFields]
+	Call 93 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x69a: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[1]]
+// 0x673: ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x6bc: ProcessEvent[Probe[main.condNilPtrStruct]@c9688]
+// 0x695: ProcessEvent[Probe[main.condNilPtrStruct]@c9ab8]
 	PrepareEventRoot 21 01 00 00 19 00 00 00 
-	Call 7f 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[0]]
-	Call 9a 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9688.expr[1]]
+	Call 58 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[0]]
+	Call 73 06 00 00 // ProcessExpression[Probe[main.condNilPtrStruct]@0xc9ab8.expr[1]]
 	Return 
-// 0x6d0: ProcessEvent[Probe[main.condNilPtrStruct]Return@c96f4]
+// 0x6a9: ProcessEvent[Probe[main.condNilPtrStruct]Return@c9b24]
 	PrepareEventRoot 22 01 00 00 00 00 00 00 
 	Return 
-// 0x6da: ProcessCondition[Probe[main.condOnly]@0xc97d8]
+// 0x6b3: ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -445,48 +439,48 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x6f7: ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[0]]
+// 0x6d0: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x70d: ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[1]]
+// 0x6e6: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x72f: ProcessEvent[Probe[main.condOnly]@c97d8]
-	Call da 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc97d8]
+// 0x708: ProcessEvent[Probe[main.condOnly]@c9c08]
+	Call b3 06 00 00 // ProcessCondition[Probe[main.condOnly]@0xc9c08]
 	PrepareEventRoot 27 01 00 00 19 00 00 00 
-	Call f7 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[0]]
-	Call 0d 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[1]]
+	Call d0 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+	Call e6 06 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
-// 0x748: ProcessEvent[Probe[main.condOnly]Return@c9834]
+// 0x721: ProcessEvent[Probe[main.condOnly]Return@c9c64]
 	PrepareEventRoot 28 01 00 00 00 00 00 00 
 	Return 
-// 0x752: ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[0]]
+// 0x72b: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x768: ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[1]]
+// 0x741: ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x78a: ProcessEvent[Probe[main.condOnly]@c97d8]
+// 0x763: ProcessEvent[Probe[main.condOnly]@c9c08]
 	PrepareEventRoot 29 01 00 00 19 00 00 00 
-	Call 52 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[0]]
-	Call 68 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc97d8.expr[1]]
+	Call 2b 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[0]]
+	Call 41 07 00 00 // ProcessExpression[Probe[main.condOnly]@0xc9c08.expr[1]]
 	Return 
-// 0x79e: ProcessEvent[Probe[main.condOnly]Return@c9834]
+// 0x777: ProcessEvent[Probe[main.condOnly]Return@c9c64]
 	PrepareEventRoot 2a 01 00 00 00 00 00 00 
 	Return 
-// 0x7a8: ProcessCondition[Probe[main.condPtrStructArg]@0xc957c]
+// 0x781: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -496,22 +490,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0x7ca: ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
+// 0x7a3: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x7ec: ProcessEvent[Probe[main.condPtrStructArg]@c957c]
-	Call a8 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc957c]
+// 0x7c5: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
+	Call 81 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	PrepareEventRoot 19 01 00 00 11 00 00 00 
-	Call ca 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
+	Call a3 07 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
-// 0x800: ProcessEvent[Probe[main.condPtrStructArg]Return@c963c]
+// 0x7d9: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 1a 01 00 00 00 00 00 00 
 	Return 
-// 0x80a: ProcessCondition[Probe[main.condPtrStructArg]@0xc957c]
+// 0x7e3: ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -521,43 +515,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x82e: ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
+// 0x807: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x850: ProcessEvent[Probe[main.condPtrStructArg]@c957c]
-	Call 0a 08 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc957c]
+// 0x829: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
+	Call e3 07 00 00 // ProcessCondition[Probe[main.condPtrStructArg]@0xc99ac]
 	PrepareEventRoot 1b 01 00 00 11 00 00 00 
-	Call 2e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
+	Call 07 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	Return 
-// 0x864: ProcessEvent[Probe[main.condPtrStructArg]Return@c963c]
+// 0x83d: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 1c 01 00 00 00 00 00 00 
 	Return 
-// 0x86e: ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
+// 0x847: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call ba 13 00 00 // ProcessType[*main.condFields]
+	Call 93 13 00 00 // ProcessType[*main.condFields]
 	Return 
-// 0x889: ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[1]]
+// 0x862: ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x8ab: ProcessEvent[Probe[main.condPtrStructArg]@c957c]
+// 0x884: ProcessEvent[Probe[main.condPtrStructArg]@c99ac]
 	PrepareEventRoot 1d 01 00 00 19 00 00 00 
-	Call 6e 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[0]]
-	Call 89 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc957c.expr[1]]
+	Call 47 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[0]]
+	Call 62 08 00 00 // ProcessExpression[Probe[main.condPtrStructArg]@0xc99ac.expr[1]]
 	Return 
-// 0x8bf: ProcessEvent[Probe[main.condPtrStructArg]Return@c963c]
+// 0x898: ProcessEvent[Probe[main.condPtrStructArg]Return@c9a6c]
 	PrepareEventRoot 1e 01 00 00 00 00 00 00 
 	Return 
-// 0x8c9: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9738]
+// 0x8a2: ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -566,44 +560,44 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0x8e6: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[0]]
+// 0x8bf: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x8fc: ProcessEvent[Probe[main.condReturnAndLocal]@c9738]
-	Call c9 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9738]
+// 0x8d5: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
+	Call a2 08 00 00 // ProcessCondition[Probe[main.condReturnAndLocal]@0xc9b68]
 	PrepareEventRoot 23 01 00 00 09 00 00 00 
-	Call e6 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[0]]
+	Call bf 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	Return 
-// 0x910: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9794]
+// 0x8e9: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
 	PrepareEventRoot 24 01 00 00 00 00 00 00 
 	Return 
-// 0x91a: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[0]]
+// 0x8f3: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x930: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[1]]
+// 0x909: ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
 	Return 
-// 0x946: ProcessEvent[Probe[main.condReturnAndLocal]@c9738]
+// 0x91f: ProcessEvent[Probe[main.condReturnAndLocal]@c9b68]
 	PrepareEventRoot 25 01 00 00 11 00 00 00 
-	Call 1a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[0]]
-	Call 30 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9738.expr[1]]
+	Call f3 08 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[0]]
+	Call 09 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]@0xc9b68.expr[1]]
 	Return 
-// 0x95a: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9794.expr[0]]
+// 0x933: ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x970: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9794]
+// 0x949: ProcessEvent[Probe[main.condReturnAndLocal]Return@c9bc4]
 	PrepareEventRoot 26 01 00 00 09 00 00 00 
-	Call 5a 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9794.expr[0]]
+	Call 33 09 00 00 // ProcessExpression[Probe[main.condReturnAndLocal]Return@0xc9bc4.expr[0]]
 	Return 
-// 0x97f: ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0x958: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -613,22 +607,22 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9a1: ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+// 0x97a: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x9c3: ProcessEvent[Probe[main.condString]@c93e8]
-	Call 7f 09 00 00 // ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0x99c: ProcessEvent[Probe[main.condString]@c9818]
+	Call 58 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 05 01 00 00 11 00 00 00 
-	Call a1 09 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+	Call 7a 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
-// 0x9d7: ProcessEvent[Probe[main.condString]Return@c9448]
+// 0x9b0: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 06 01 00 00 00 00 00 00 
 	Return 
-// 0x9e1: ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0x9ba: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -638,44 +632,44 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0x9fe: ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+// 0x9d7: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa20: ProcessEvent[Probe[main.condString]@c93e8]
-	Call e1 09 00 00 // ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0x9f9: ProcessEvent[Probe[main.condString]@c9818]
+	Call ba 09 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 07 01 00 00 11 00 00 00 
-	Call fe 09 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+	Call d7 09 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	Return 
-// 0xa34: ProcessEvent[Probe[main.condString]Return@c9448]
+// 0xa0d: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 08 01 00 00 00 00 00 00 
 	Return 
-// 0xa3e: ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+// 0xa17: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa60: ProcessExpression[Probe[main.condString]@0xc93e8.expr[1]]
+// 0xa39: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xa82: ProcessEvent[Probe[main.condString]@c93e8]
+// 0xa5b: ProcessEvent[Probe[main.condString]@c9818]
 	PrepareEventRoot 09 01 00 00 21 00 00 00 
-	Call 3e 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
-	Call 60 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[1]]
+	Call 17 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call 39 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xa96: ProcessEvent[Probe[main.condString]Return@c9448]
+// 0xa6f: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 0a 01 00 00 00 00 00 00 
 	Return 
-// 0xaa0: ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0xa79: ProcessCondition[Probe[main.condString]@0xc9818]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -685,30 +679,30 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xac2: ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
+// 0xa9b: ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xae4: ProcessExpression[Probe[main.condString]@0xc93e8.expr[1]]
+// 0xabd: ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 02 08 00 00 00 00 
 	ExprReadRegister 03 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xb06: ProcessEvent[Probe[main.condString]@c93e8]
-	Call a0 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc93e8]
+// 0xadf: ProcessEvent[Probe[main.condString]@c9818]
+	Call 79 0a 00 00 // ProcessCondition[Probe[main.condString]@0xc9818]
 	PrepareEventRoot 0b 01 00 00 21 00 00 00 
-	Call c2 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[0]]
-	Call e4 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc93e8.expr[1]]
+	Call 9b 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[0]]
+	Call bd 0a 00 00 // ProcessExpression[Probe[main.condString]@0xc9818.expr[1]]
 	Return 
-// 0xb1f: ProcessEvent[Probe[main.condString]Return@c9448]
+// 0xaf8: ProcessEvent[Probe[main.condString]Return@c9878]
 	PrepareEventRoot 0c 01 00 00 00 00 00 00 
 	Return 
-// 0xb29: ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xb02: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -717,22 +711,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xb48: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xb21: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xb6a: ProcessEvent[Probe[main.condStructArg]@c948c]
-	Call 29 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xb43: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 02 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 0d 01 00 00 11 00 00 00 
-	Call 48 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+	Call 21 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xb7e: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xb57: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 0e 01 00 00 00 00 00 00 
 	Return 
-// 0xb88: ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xb61: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 38 00 00 00 01 00 00 00 00 00 00 00 
@@ -741,22 +735,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xba4: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xb7d: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xbc6: ProcessEvent[Probe[main.condStructArg]@c948c]
-	Call 88 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xb9f: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 61 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 0f 01 00 00 11 00 00 00 
-	Call a4 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+	Call 7d 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xbda: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xbb3: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 10 01 00 00 00 00 00 00 
 	Return 
-// 0xbe4: ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xbbd: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 30 00 00 00 08 00 00 00 00 00 00 00 
@@ -765,22 +759,22 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xc07: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xbe0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xc29: ProcessEvent[Probe[main.condStructArg]@c948c]
-	Call e4 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xc02: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call bd 0b 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 11 01 00 00 11 00 00 00 
-	Call 07 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+	Call e0 0b 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc3d: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xc16: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 12 01 00 00 00 00 00 00 
 	Return 
-// 0xc47: ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xc20: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 0c 00 00 00 04 00 00 00 00 00 00 00 
@@ -789,22 +783,22 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xc66: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xc3f: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xc88: ProcessEvent[Probe[main.condStructArg]@c948c]
-	Call 47 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xc61: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 20 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 13 01 00 00 11 00 00 00 
-	Call 66 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+	Call 3f 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xc9c: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xc75: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 14 01 00 00 00 00 00 00 
 	Return 
-// 0xca6: ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xc7f: ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	ConditionBegin 
 	ExprPrepare 
 	ExprDereferenceCfa 40 00 00 00 10 00 00 00 00 00 00 00 
@@ -813,43 +807,43 @@
 	ExprCmpEqString 
 	ConditionCheck 
 	Return 
-// 0xcc7: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xca0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xce9: ProcessEvent[Probe[main.condStructArg]@c948c]
-	Call a6 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc948c]
+// 0xcc2: ProcessEvent[Probe[main.condStructArg]@c98bc]
+	Call 7f 0c 00 00 // ProcessCondition[Probe[main.condStructArg]@0xc98bc]
 	PrepareEventRoot 15 01 00 00 11 00 00 00 
-	Call c7 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+	Call a0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	Return 
-// 0xcfd: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xcd6: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 16 01 00 00 00 00 00 00 
 	Return 
-// 0xd07: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
+// 0xce0: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 50 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 50 00 00 00 00 00 00 00 
-	Call 4a 15 00 00 // ProcessType[main.condFields]
+	Call 23 15 00 00 // ProcessType[main.condFields]
 	Return 
-// 0xd28: ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[1]]
+// 0xd01: ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 51 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xd4a: ProcessEvent[Probe[main.condStructArg]@c948c]
+// 0xd23: ProcessEvent[Probe[main.condStructArg]@c98bc]
 	PrepareEventRoot 17 01 00 00 61 00 00 00 
-	Call 07 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[0]]
-	Call 28 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc948c.expr[1]]
+	Call e0 0c 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[0]]
+	Call 01 0d 00 00 // ProcessExpression[Probe[main.condStructArg]@0xc98bc.expr[1]]
 	Return 
-// 0xd5e: ProcessEvent[Probe[main.condStructArg]Return@c9540]
+// 0xd37: ProcessEvent[Probe[main.condStructArg]Return@c9970]
 	PrepareEventRoot 18 01 00 00 00 00 00 00 
 	Return 
-// 0xd68: ProcessCondition[Probe[main.condUint16]@0xc9018]
+// 0xd41: ProcessCondition[Probe[main.condUint16]@0xc9448]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
@@ -858,42 +852,42 @@
 	ExprCmpEqBase 02 
 	ConditionCheck 
 	Return 
-// 0xd7f: ProcessExpression[Probe[main.condUint16]@0xc9018.expr[0]]
+// 0xd58: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xda1: ProcessEvent[Probe[main.condUint16]@c9018]
-	Call 68 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9018]
+// 0xd7a: ProcessEvent[Probe[main.condUint16]@c9448]
+	Call 41 0d 00 00 // ProcessCondition[Probe[main.condUint16]@0xc9448]
 	PrepareEventRoot ef 00 00 00 11 00 00 00 
-	Call 7f 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9018.expr[0]]
+	Call 58 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	Return 
-// 0xdb5: ProcessEvent[Probe[main.condUint16]Return@c9074]
+// 0xd8e: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f0 00 00 00 00 00 00 00 
 	Return 
-// 0xdbf: ProcessExpression[Probe[main.condUint16]@0xc9018.expr[0]]
+// 0xd98: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 02 00 00 00 00 
 	ExprSave 01 00 00 00 02 00 00 00 00 00 00 00 
 	Return 
-// 0xdd5: ProcessExpression[Probe[main.condUint16]@0xc9018.expr[1]]
+// 0xdae: ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 03 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xdf7: ProcessEvent[Probe[main.condUint16]@c9018]
+// 0xdd0: ProcessEvent[Probe[main.condUint16]@c9448]
 	PrepareEventRoot f1 00 00 00 13 00 00 00 
-	Call bf 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9018.expr[0]]
-	Call d5 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9018.expr[1]]
+	Call 98 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[0]]
+	Call ae 0d 00 00 // ProcessExpression[Probe[main.condUint16]@0xc9448.expr[1]]
 	Return 
-// 0xe0b: ProcessEvent[Probe[main.condUint16]Return@c9074]
+// 0xde4: ProcessEvent[Probe[main.condUint16]Return@c94a4]
 	PrepareEventRoot f2 00 00 00 00 00 00 00 
 	Return 
-// 0xe15: ProcessCondition[Probe[main.condUint32]@0xc90b8]
+// 0xdee: ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
@@ -902,42 +896,42 @@
 	ExprCmpEqBase 04 
 	ConditionCheck 
 	Return 
-// 0xe2e: ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[0]]
+// 0xe07: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xe50: ProcessEvent[Probe[main.condUint32]@c90b8]
-	Call 15 0e 00 00 // ProcessCondition[Probe[main.condUint32]@0xc90b8]
+// 0xe29: ProcessEvent[Probe[main.condUint32]@c94e8]
+	Call ee 0d 00 00 // ProcessCondition[Probe[main.condUint32]@0xc94e8]
 	PrepareEventRoot f3 00 00 00 11 00 00 00 
-	Call 2e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[0]]
+	Call 07 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	Return 
-// 0xe64: ProcessEvent[Probe[main.condUint32]Return@c9114]
+// 0xe3d: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f4 00 00 00 00 00 00 00 
 	Return 
-// 0xe6e: ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[0]]
+// 0xe47: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 04 00 00 00 00 
 	ExprSave 01 00 00 00 04 00 00 00 00 00 00 00 
 	Return 
-// 0xe84: ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[1]]
+// 0xe5d: ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 05 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xea6: ProcessEvent[Probe[main.condUint32]@c90b8]
+// 0xe7f: ProcessEvent[Probe[main.condUint32]@c94e8]
 	PrepareEventRoot f5 00 00 00 15 00 00 00 
-	Call 6e 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[0]]
-	Call 84 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc90b8.expr[1]]
+	Call 47 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[0]]
+	Call 5d 0e 00 00 // ProcessExpression[Probe[main.condUint32]@0xc94e8.expr[1]]
 	Return 
-// 0xeba: ProcessEvent[Probe[main.condUint32]Return@c9114]
+// 0xe93: ProcessEvent[Probe[main.condUint32]Return@c9544]
 	PrepareEventRoot f6 00 00 00 00 00 00 00 
 	Return 
-// 0xec4: ProcessCondition[Probe[main.condUint64]@0xc9158]
+// 0xe9d: ProcessCondition[Probe[main.condUint64]@0xc9588]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
@@ -946,42 +940,42 @@
 	ExprCmpEqBase 08 
 	ConditionCheck 
 	Return 
-// 0xee1: ProcessExpression[Probe[main.condUint64]@0xc9158.expr[0]]
+// 0xeba: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xf03: ProcessEvent[Probe[main.condUint64]@c9158]
-	Call c4 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9158]
+// 0xedc: ProcessEvent[Probe[main.condUint64]@c9588]
+	Call 9d 0e 00 00 // ProcessCondition[Probe[main.condUint64]@0xc9588]
 	PrepareEventRoot f7 00 00 00 11 00 00 00 
-	Call e1 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9158.expr[0]]
+	Call ba 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	Return 
-// 0xf17: ProcessEvent[Probe[main.condUint64]Return@c91b4]
+// 0xef0: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot f8 00 00 00 00 00 00 00 
 	Return 
-// 0xf21: ProcessExpression[Probe[main.condUint64]@0xc9158.expr[0]]
+// 0xefa: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0xf37: ProcessExpression[Probe[main.condUint64]@0xc9158.expr[1]]
+// 0xf10: ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 09 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xf59: ProcessEvent[Probe[main.condUint64]@c9158]
+// 0xf32: ProcessEvent[Probe[main.condUint64]@c9588]
 	PrepareEventRoot f9 00 00 00 19 00 00 00 
-	Call 21 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9158.expr[0]]
-	Call 37 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9158.expr[1]]
+	Call fa 0e 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[0]]
+	Call 10 0f 00 00 // ProcessExpression[Probe[main.condUint64]@0xc9588.expr[1]]
 	Return 
-// 0xf6d: ProcessEvent[Probe[main.condUint64]Return@c91b4]
+// 0xf46: ProcessEvent[Probe[main.condUint64]Return@c95e4]
 	PrepareEventRoot fa 00 00 00 00 00 00 00 
 	Return 
-// 0xf77: ProcessCondition[Probe[main.condUint8]@0xc8f68]
+// 0xf50: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -990,22 +984,22 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xf8d: ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
+// 0xf66: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0xfaf: ProcessEvent[Probe[main.condUint8]@c8f68]
-	Call 77 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc8f68]
+// 0xf88: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call 50 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot e9 00 00 00 11 00 00 00 
-	Call 8d 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
+	Call 66 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0xfc3: ProcessEvent[Probe[main.condUint8]Return@c8fcc]
+// 0xf9c: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ea 00 00 00 00 00 00 00 
 	Return 
-// 0xfcd: ProcessCondition[Probe[main.condUint8]@0xc8f68]
+// 0xfa6: ProcessCondition[Probe[main.condUint8]@0xc9398]
 	ConditionBegin 
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
@@ -1014,573 +1008,573 @@
 	ExprCmpEqBase 01 
 	ConditionCheck 
 	Return 
-// 0xfe3: ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
+// 0xfbc: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1005: ProcessEvent[Probe[main.condUint8]@c8f68]
-	Call cd 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc8f68]
+// 0xfde: ProcessEvent[Probe[main.condUint8]@c9398]
+	Call a6 0f 00 00 // ProcessCondition[Probe[main.condUint8]@0xc9398]
 	PrepareEventRoot eb 00 00 00 11 00 00 00 
-	Call e3 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
+	Call bc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	Return 
-// 0x1019: ProcessEvent[Probe[main.condUint8]Return@c8fcc]
+// 0xff2: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ec 00 00 00 00 00 00 00 
 	Return 
-// 0x1023: ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
+// 0xffc: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 01 00 00 00 00 
 	ExprSave 01 00 00 00 01 00 00 00 00 00 00 00 
 	Return 
-// 0x1039: ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[1]]
+// 0x1012: ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 01 08 00 00 00 00 
 	ExprReadRegister 02 08 08 00 00 00 
 	ExprSave 02 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x105b: ProcessEvent[Probe[main.condUint8]@c8f68]
+// 0x1034: ProcessEvent[Probe[main.condUint8]@c9398]
 	PrepareEventRoot ed 00 00 00 12 00 00 00 
-	Call 23 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[0]]
-	Call 39 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc8f68.expr[1]]
+	Call fc 0f 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[0]]
+	Call 12 10 00 00 // ProcessExpression[Probe[main.condUint8]@0xc9398.expr[1]]
 	Return 
-// 0x106f: ProcessEvent[Probe[main.condUint8]Return@c8fcc]
+// 0x1048: ProcessEvent[Probe[main.condUint8]Return@c93fc]
 	PrepareEventRoot ee 00 00 00 00 00 00 00 
 	Return 
-// 0x1079: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+// 0x1052: ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	ExprPrepare 
 	Return 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x1089: ProcessEvent[Probe[main.inlined]@c8040]
+// 0x1062: ProcessEvent[Probe[main.inlined]@c8040]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 79 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
+	Call 52 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8040.expr[0]]
 	Return 
-// 0x1098: ProcessExpression[Probe[main.inlined]@0xc8aa8.expr[0]]
+// 0x1071: ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10ae: ProcessEvent[Probe[main.inlined]@c8aa8]
+// 0x1087: ProcessEvent[Probe[main.inlined]@c8ed8]
 	PrepareEventRoot 2f 01 00 00 09 00 00 00 
-	Call 98 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8aa8.expr[0]]
+	Call 71 10 00 00 // ProcessExpression[Probe[main.inlined]@0xc8ed8.expr[0]]
 	Return 
-// 0x10bd: ProcessEvent[Probe[main.inlined]Return@c8adc]
+// 0x1096: ProcessEvent[Probe[main.inlined]Return@c8f0c]
 	PrepareEventRoot 30 01 00 00 00 00 00 00 
 	Return 
-// 0x10c7: ProcessExpression[Probe[main.intArg]@0xc87d8.expr[0]]
+// 0x10a0: ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
 	Return 
-// 0x10dd: ProcessEvent[Probe[main.intArg]@c87d8]
+// 0x10b6: ProcessEvent[Probe[main.intArg]@c8c08]
 	PrepareEventRoot c0 00 00 00 09 00 00 00 
-	Call c7 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc87d8.expr[0]]
+	Call a0 10 00 00 // ProcessExpression[Probe[main.intArg]@0xc8c08.expr[0]]
 	Return 
-// 0x10ec: ProcessEvent[Probe[main.intArg]Return@c880c]
+// 0x10c5: ProcessEvent[Probe[main.intArg]Return@c8c3c]
 	PrepareEventRoot c1 00 00 00 00 00 00 00 
 	Return 
-// 0x10f6: ProcessExpression[Probe[main.intArrayArg]@0xc8938.expr[0]]
+// 0x10cf: ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 18 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
 	Return 
-// 0x1112: ProcessEvent[Probe[main.intArrayArg]@c8938]
+// 0x10eb: ProcessEvent[Probe[main.intArrayArg]@c8d68]
 	PrepareEventRoot ca 00 00 00 19 00 00 00 
-	Call f6 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8938.expr[0]]
+	Call cf 10 00 00 // ProcessExpression[Probe[main.intArrayArg]@0xc8d68.expr[0]]
 	Return 
-// 0x1121: ProcessEvent[Probe[main.intArrayArg]Return@c8978]
+// 0x10fa: ProcessEvent[Probe[main.intArrayArg]Return@c8da8]
 	PrepareEventRoot cb 00 00 00 00 00 00 00 
 	Return 
-// 0x112b: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8a80.expr[0]]
+// 0x1104: ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 6a 14 00 00 // ProcessType[[3]string]
+	Call 43 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x114c: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8a80]
+// 0x1125: ProcessEvent[Probe[main.stringArrayArgFrameless]@c8eb0]
 	PrepareEventRoot d0 00 00 00 31 00 00 00 
-	Call 2b 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8a80.expr[0]]
+	Call 04 11 00 00 // ProcessExpression[Probe[main.stringArrayArgFrameless]@0xc8eb0.expr[0]]
 	Return 
-// 0x115b: ProcessExpression[Probe[main.intSliceArg]@0xc88b8.expr[0]]
+// 0x1134: ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call c0 14 00 00 // ProcessType[[]int]
+	Call 99 14 00 00 // ProcessType[[]int]
 	Return 
-// 0x1184: ProcessEvent[Probe[main.intSliceArg]@c88b8]
+// 0x115d: ProcessEvent[Probe[main.intSliceArg]@c8ce8]
 	PrepareEventRoot c8 00 00 00 19 00 00 00 
-	Call 5b 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc88b8.expr[0]]
+	Call 34 11 00 00 // ProcessExpression[Probe[main.intSliceArg]@0xc8ce8.expr[0]]
 	Return 
-// 0x1193: ProcessEvent[Probe[main.intSliceArg]Return@c88f0]
+// 0x116c: ProcessEvent[Probe[main.intSliceArg]Return@c8d20]
 	PrepareEventRoot c9 00 00 00 00 00 00 00 
 	Return 
-// 0x119d: ProcessExpression[Probe[main.stringArg]@0xc8848.expr[0]]
+// 0x1176: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x11bf: ProcessEvent[Probe[main.stringArg]@c8848]
+// 0x1198: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c2 00 00 00 11 00 00 00 
-	Call 9d 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8848.expr[0]]
+	Call 76 11 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	Return 
-// 0x11ce: ProcessEvent[Probe[main.stringArg]Return@c8880]
+// 0x11a7: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c3 00 00 00 00 00 00 00 
 	Return 
-// 0x11d8: ProcessEvent[Probe[main.stringArg]@c8848]
+// 0x11b1: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c4 00 00 00 00 00 00 00 
 	Return 
-// 0x11e2: ProcessEvent[Probe[main.stringArg]Return@c8880]
+// 0x11bb: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c5 00 00 00 00 00 00 00 
 	Return 
-// 0x11ec: ProcessExpression[Probe[main.mapArg]@0xc8b68.expr[0]]
+// 0x11c5: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[string]int]
+	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1207: ProcessExpression[Probe[main.mapArg]@0xc8b68.expr[1]]
+// 0x11e0: ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 09 00 00 00 08 00 00 00 01 00 00 00 
-	Call 8b 15 00 00 // ProcessType[map[string]int]
+	Call 64 15 00 00 // ProcessType[map[string]int]
 	Return 
-// 0x1222: ProcessEvent[Probe[main.mapArg]@c8b68]
+// 0x11fb: ProcessEvent[Probe[main.mapArg]@c8f98]
 	PrepareEventRoot d1 00 00 00 11 00 00 00 
-	Call ec 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8b68.expr[0]]
-	Call 07 12 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8b68.expr[1]]
+	Call c5 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[0]]
+	Call e0 11 00 00 // ProcessExpression[Probe[main.mapArg]@0xc8f98.expr[1]]
 	Return 
-// 0x1236: ProcessEvent[Probe[main.mapArg]Return@c8b94]
+// 0x120f: ProcessEvent[Probe[main.mapArg]Return@c8fc4]
 	PrepareEventRoot d2 00 00 00 00 00 00 00 
 	Return 
-// 0x1240: ProcessEvent[Probe[main.noArgs]@c8c68]
+// 0x1219: ProcessEvent[Probe[main.noArgs]@c9098]
 	PrepareEventRoot d5 00 00 00 00 00 00 00 
 	Return 
-// 0x124a: ProcessEvent[Probe[main.noArgs]Return@c8c9c]
+// 0x1223: ProcessEvent[Probe[main.noArgs]Return@c90cc]
 	PrepareEventRoot d6 00 00 00 00 00 00 00 
 	Return 
-// 0x1254: ProcessExpression[Probe[main.stringArg]@0xc8848.expr[0]]
+// 0x122d: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 01 00 00 00 10 00 00 00 00 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1276: ProcessExpression[Probe[main.stringArg]@0xc8848.expr[1]]
+// 0x124f: ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprSave 11 00 00 00 10 00 00 00 01 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1298: ProcessEvent[Probe[main.stringArg]@c8848]
+// 0x1271: ProcessEvent[Probe[main.stringArg]@c8c78]
 	PrepareEventRoot c6 00 00 00 21 00 00 00 
-	Call 54 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8848.expr[0]]
-	Call 76 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8848.expr[1]]
+	Call 2d 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[0]]
+	Call 4f 12 00 00 // ProcessExpression[Probe[main.stringArg]@0xc8c78.expr[1]]
 	Return 
-// 0x12ac: ProcessEvent[Probe[main.stringArg]Return@c8880]
+// 0x1285: ProcessEvent[Probe[main.stringArg]Return@c8cb0]
 	PrepareEventRoot c7 00 00 00 00 00 00 00 
 	Return 
-// 0x12b6: ProcessExpression[Probe[main.stringArrayArg]@0xc8a28.expr[0]]
+// 0x128f: ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	ExprPrepare 
 	ExprDereferenceCfa 08 00 00 00 30 00 00 00 00 00 00 00 
 	ExprSave 01 00 00 00 30 00 00 00 00 00 00 00 
-	Call 6a 14 00 00 // ProcessType[[3]string]
+	Call 43 14 00 00 // ProcessType[[3]string]
 	Return 
-// 0x12d7: ProcessEvent[Probe[main.stringArrayArg]@c8a28]
+// 0x12b0: ProcessEvent[Probe[main.stringArrayArg]@c8e58]
 	PrepareEventRoot ce 00 00 00 31 00 00 00 
-	Call b6 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8a28.expr[0]]
+	Call 8f 12 00 00 // ProcessExpression[Probe[main.stringArrayArg]@0xc8e58.expr[0]]
 	Return 
-// 0x12e6: ProcessEvent[Probe[main.stringArrayArg]Return@c8a68]
+// 0x12bf: ProcessEvent[Probe[main.stringArrayArg]Return@c8e98]
 	PrepareEventRoot cf 00 00 00 00 00 00 00 
 	Return 
-// 0x12f0: ProcessExpression[Probe[main.stringSliceArg]@0xc89a8.expr[0]]
+// 0x12c9: ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprReadRegister 01 08 08 00 00 00 
 	ExprReadRegister 02 08 10 00 00 00 
 	ExprSave 01 00 00 00 18 00 00 00 00 00 00 00 
-	Call ee 14 00 00 // ProcessType[[]string]
+	Call c7 14 00 00 // ProcessType[[]string]
 	Return 
-// 0x1319: ProcessEvent[Probe[main.stringSliceArg]@c89a8]
+// 0x12f2: ProcessEvent[Probe[main.stringSliceArg]@c8dd8]
 	PrepareEventRoot cc 00 00 00 19 00 00 00 
-	Call f0 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc89a8.expr[0]]
+	Call c9 12 00 00 // ProcessExpression[Probe[main.stringSliceArg]@0xc8dd8.expr[0]]
 	Return 
-// 0x1328: ProcessEvent[Probe[main.stringSliceArg]Return@c89e0]
+// 0x1301: ProcessEvent[Probe[main.stringSliceArg]Return@c8e10]
 	PrepareEventRoot cd 00 00 00 00 00 00 00 
 	Return 
-// 0x1332: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@c9b30]
+// 0x130b: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]@ca740]
 	PrepareEventRoot 2d 01 00 00 00 00 00 00 
 	Return 
-// 0x133c: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc9cac.expr[0]]
+// 0x1315: ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	ExprPrepare 
 	ExprReadRegister 00 08 00 00 00 00 
 	ExprSave 01 00 00 00 08 00 00 00 00 00 00 00 
-	Call 97 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call 70 15 00 00 // ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x1357: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@c9cac]
+// 0x1330: ProcessEvent[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@ca8bc]
 	PrepareEventRoot 2e 01 00 00 09 00 00 00 
-	Call 3c 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xc9cac.expr[0]]
+	Call 15 13 00 00 // ProcessExpression[Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return@0xca8bc.expr[0]]
 	Return 
-// 0x1366: ProcessType[*****int]
+// 0x133f: ProcessType[*****int]
 	ProcessPointer 87 00 00 00 
 	Return 
-// 0x136c: ProcessType[****int]
+// 0x1345: ProcessType[****int]
 	ProcessPointer be 00 00 00 
 	Return 
-// 0x1372: ProcessType[***int]
+// 0x134b: ProcessType[***int]
 	ProcessPointer 88 00 00 00 
 	Return 
-// 0x1378: ProcessType[**int]
+// 0x1351: ProcessType[**int]
 	ProcessPointer 69 00 00 00 
 	Return 
-// 0x137e: ProcessType[*[]runtime.ancestorInfo]
+// 0x1357: ProcessType[*[]runtime.ancestorInfo]
 	ProcessPointer 29 00 00 00 
 	Return 
-// 0x1384: ProcessType[*bool]
+// 0x135d: ProcessType[*bool]
 	ProcessPointer 04 00 00 00 
 	Return 
-// 0x138a: ProcessType[*error]
+// 0x1363: ProcessType[*error]
 	ProcessPointer 0f 00 00 00 
 	Return 
-// 0x1390: ProcessType[*float32]
+// 0x1369: ProcessType[*float32]
 	ProcessPointer 11 00 00 00 
 	Return 
-// 0x1396: ProcessType[*float64]
+// 0x136f: ProcessType[*float64]
 	ProcessPointer 0e 00 00 00 
 	Return 
-// 0x139c: ProcessType[*int]
+// 0x1375: ProcessType[*int]
 	ProcessPointer 07 00 00 00 
 	Return 
-// 0x13a2: ProcessType[*int32]
+// 0x137b: ProcessType[*int32]
 	ProcessPointer 0c 00 00 00 
 	Return 
-// 0x13a8: ProcessType[*int64]
+// 0x1381: ProcessType[*int64]
 	ProcessPointer 0d 00 00 00 
 	Return 
-// 0x13ae: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x1387: ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	ProcessPointer 64 00 00 00 
 	Return 
-// 0x13b4: ProcessType[*main.bigStruct]
+// 0x138d: ProcessType[*main.bigStruct]
 	ProcessPointer a5 00 00 00 
 	Return 
-// 0x13ba: ProcessType[*main.condFields]
+// 0x1393: ProcessType[*main.condFields]
 	ProcessPointer 7e 00 00 00 
 	Return 
-// 0x13c0: ProcessType[*runtime._defer]
+// 0x1399: ProcessType[*runtime._defer]
 	ProcessPointer 1c 00 00 00 
 	Return 
-// 0x13c6: ProcessType[*runtime._panic]
+// 0x139f: ProcessType[*runtime._panic]
 	ProcessPointer 1a 00 00 00 
 	Return 
-// 0x13cc: ProcessType[*runtime.cgoCallers]
+// 0x13a5: ProcessType[*runtime.cgoCallers]
 	ProcessPointer 46 00 00 00 
 	Return 
-// 0x13d2: ProcessType[*runtime.coro]
+// 0x13ab: ProcessType[*runtime.coro]
 	ProcessPointer 31 00 00 00 
 	Return 
-// 0x13d8: ProcessType[*runtime.g]
+// 0x13b1: ProcessType[*runtime.g]
 	ProcessPointer 17 00 00 00 
 	Return 
-// 0x13de: ProcessType[*runtime.m]
+// 0x13b7: ProcessType[*runtime.m]
 	ProcessPointer 1e 00 00 00 
 	Return 
-// 0x13e4: ProcessType[*runtime.p]
+// 0x13bd: ProcessType[*runtime.p]
 	ProcessPointer 8f 00 00 00 
 	Return 
-// 0x13ea: ProcessType[*runtime.sudog]
+// 0x13c3: ProcessType[*runtime.sudog]
 	ProcessPointer 2b 00 00 00 
 	Return 
-// 0x13f0: ProcessType[*runtime.synctestBubble]
+// 0x13c9: ProcessType[*runtime.synctestBubble]
 	ProcessPointer 33 00 00 00 
 	Return 
-// 0x13f6: ProcessType[*runtime.timer]
+// 0x13cf: ProcessType[*runtime.timer]
 	ProcessPointer 2e 00 00 00 
 	Return 
-// 0x13fc: ProcessType[*runtime.traceBuf]
+// 0x13d5: ProcessType[*runtime.traceBuf]
 	ProcessPointer 54 00 00 00 
 	Return 
-// 0x1402: ProcessType[*runtime.xRegState]
+// 0x13db: ProcessType[*runtime.xRegState]
 	ProcessPointer 36 00 00 00 
 	Return 
-// 0x1408: ProcessType[*string]
+// 0x13e1: ProcessType[*string]
 	ProcessPointer 09 00 00 00 
 	Return 
-// 0x140e: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+// 0x13e7: ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessPointer b5 00 00 00 
 	Return 
-// 0x1414: ProcessType[*table<string,int>]
+// 0x13ed: ProcessType[*table<string,int>]
 	ProcessPointer 96 00 00 00 
 	Return 
-// 0x141a: ProcessType[*table<string,main.bigStruct>]
+// 0x13f3: ProcessType[*table<string,main.bigStruct>]
 	ProcessPointer 9e 00 00 00 
 	Return 
-// 0x1420: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x13f9: ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessPointer a8 00 00 00 
 	Return 
-// 0x1426: ProcessType[*uint]
+// 0x13ff: ProcessType[*uint]
 	ProcessPointer 0b 00 00 00 
 	Return 
-// 0x142c: ProcessType[*uint16]
+// 0x1405: ProcessType[*uint16]
 	ProcessPointer 06 00 00 00 
 	Return 
-// 0x1432: ProcessType[*uint32]
+// 0x140b: ProcessType[*uint32]
 	ProcessPointer 02 00 00 00 
 	Return 
-// 0x1438: ProcessType[*uint64]
+// 0x1411: ProcessType[*uint64]
 	ProcessPointer 08 00 00 00 
 	Return 
-// 0x143e: ProcessType[*uint8]
+// 0x1417: ProcessType[*uint8]
 	ProcessPointer 03 00 00 00 
 	Return 
-// 0x1444: ProcessType[*uintptr]
+// 0x141d: ProcessType[*uintptr]
 	ProcessPointer 01 00 00 00 
 	Return 
-// 0x144a: ProcessType[[2]*runtime.traceBuf]
+// 0x1423: ProcessType[[2]*runtime.traceBuf]
 	ProcessArrayDataPrep 10 00 00 00 
-	Call fc 13 00 00 // ProcessType[*runtime.traceBuf]
+	Call d5 13 00 00 // ProcessType[*runtime.traceBuf]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x145a: ProcessType[[2][2]*runtime.traceBuf]
+// 0x1433: ProcessType[[2][2]*runtime.traceBuf]
 	ProcessArrayDataPrep 20 00 00 00 
-	Call 4a 14 00 00 // ProcessType[[2]*runtime.traceBuf]
+	Call 23 14 00 00 // ProcessType[[2]*runtime.traceBuf]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x146a: ProcessType[[3]string]
+// 0x1443: ProcessType[[3]string]
 	ProcessArrayDataPrep 30 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x147a: ProcessType[[]*runtime.p]
+// 0x1453: ProcessType[[]*runtime.p]
 	ProcessSlice 90 00 00 00 08 00 00 00 
 	Return 
-// 0x1484: ProcessType[[]*runtime.p.array]
+// 0x145d: ProcessType[[]*runtime.p.array]
 	ProcessSliceDataPrep 
-	Call e4 13 00 00 // ProcessType[*runtime.p]
+	Call bd 13 00 00 // ProcessType[*runtime.p]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x1490: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
+// 0x1469: ProcessType[[]*table<int,main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 0e 14 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
+	Call e7 13 00 00 // ProcessType[*table<int,main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x149c: ProcessType[[]*table<string,int>.array]
+// 0x1475: ProcessType[[]*table<string,int>.array]
 	ProcessSliceDataPrep 
-	Call 14 14 00 00 // ProcessType[*table<string,int>]
+	Call ed 13 00 00 // ProcessType[*table<string,int>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14a8: ProcessType[[]*table<string,main.bigStruct>.array]
+// 0x1481: ProcessType[[]*table<string,main.bigStruct>.array]
 	ProcessSliceDataPrep 
-	Call 1a 14 00 00 // ProcessType[*table<string,main.bigStruct>]
+	Call f3 13 00 00 // ProcessType[*table<string,main.bigStruct>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14b4: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
+// 0x148d: ProcessType[[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array]
 	ProcessSliceDataPrep 
-	Call 20 14 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call f9 13 00 00 // ProcessType[*table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x14c0: ProcessType[[]int]
+// 0x1499: ProcessType[[]int]
 	ProcessSlice 92 00 00 00 08 00 00 00 
 	Return 
-// 0x14ca: ProcessType[[]noalg.map.group[string]int.array]
+// 0x14a3: ProcessType[[]noalg.map.group[string]int.array]
 	ProcessSliceDataPrep 
-	Call cd 15 00 00 // ProcessType[noalg.map.group[string]int]
+	Call a6 15 00 00 // ProcessType[noalg.map.group[string]int]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14d6: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
+// 0x14af: ProcessType[[]noalg.map.group[string]main.bigStruct.array]
 	ProcessSliceDataPrep 
-	Call d8 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
+	Call b1 15 00 00 // ProcessType[noalg.map.group[string]main.bigStruct]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14e2: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
+// 0x14bb: ProcessType[[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array]
 	ProcessSliceDataPrep 
-	Call e3 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+	Call bc 15 00 00 // ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessSliceDataRepeat 00 00 00 00 
 	Return 
-// 0x14ee: ProcessType[[]string]
+// 0x14c7: ProcessType[[]string]
 	ProcessSlice 94 00 00 00 10 00 00 00 
 	Return 
-// 0x14f8: ProcessType[[]string.array]
+// 0x14d1: ProcessType[[]string.array]
 	ProcessSliceDataPrep 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	ProcessSliceDataRepeat 10 00 00 00 
 	Return 
-// 0x1504: ProcessType[[]uint8]
+// 0x14dd: ProcessType[[]uint8]
 	ProcessSlice 8b 00 00 00 01 00 00 00 
 	Return 
-// 0x150e: ProcessType[[]uintptr]
+// 0x14e7: ProcessType[[]uintptr]
 	ProcessSlice 8d 00 00 00 08 00 00 00 
 	Return 
-// 0x1518: ProcessType[error]
+// 0x14f1: ProcessType[error]
 	ProcessGoInterface 
 	Return 
-// 0x151a: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+// 0x14f3: ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups bd 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x1526: ProcessType[groupReference<string,int>]
+// 0x14ff: ProcessType[groupReference<string,int>]
 	ProcessGoSwissMapGroups 9d 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x1532: ProcessType[groupReference<string,main.bigStruct>]
+// 0x150b: ProcessType[groupReference<string,main.bigStruct>]
 	ProcessGoSwissMapGroups a7 00 00 00 c8 00 00 00 00 08 
 	Return 
-// 0x153e: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1517: ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMapGroups b4 00 00 00 88 00 00 00 00 08 
 	Return 
-// 0x154a: ProcessType[main.condFields]
+// 0x1523: ProcessType[main.condFields]
 	IncrementOutputOffset 38 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1555: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
+// 0x152e: ProcessType[map<int,main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap bc 00 00 00 b8 00 00 00 10 18 
 	Return 
-// 0x1561: ProcessType[map<string,int>]
+// 0x153a: ProcessType[map<string,int>]
 	ProcessGoSwissMap 9c 00 00 00 99 00 00 00 10 18 
 	Return 
-// 0x156d: ProcessType[map<string,main.bigStruct>]
+// 0x1546: ProcessType[map<string,main.bigStruct>]
 	ProcessGoSwissMap a6 00 00 00 a1 00 00 00 10 18 
 	Return 
-// 0x1579: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1552: ProcessType[map<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	ProcessGoSwissMap b3 00 00 00 ab 00 00 00 10 18 
 	Return 
-// 0x1585: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+// 0x155e: ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer b0 00 00 00 
 	Return 
-// 0x158b: ProcessType[map[string]int]
+// 0x1564: ProcessType[map[string]int]
 	ProcessPointer 76 00 00 00 
 	Return 
-// 0x1591: ProcessType[map[string]main.bigStruct]
+// 0x156a: ProcessType[map[string]main.bigStruct]
 	ProcessPointer 7b 00 00 00 
 	Return 
-// 0x1597: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x1570: ProcessType[map[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	ProcessPointer 83 00 00 00 
 	Return 
-// 0x159d: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+// 0x1576: ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call ee 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call c7 15 00 00 // ProcessType[noalg.struct { key string; elem *main.bigStruct }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15ad: ProcessType[noalg.[8]struct { key string; elem int }]
+// 0x1586: ProcessType[noalg.[8]struct { key string; elem int }]
 	ProcessArrayDataPrep c0 00 00 00 
-	Call fe 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
+	Call d7 15 00 00 // ProcessType[noalg.struct { key string; elem int }]
 	ProcessSliceDataRepeat 18 00 00 00 
 	Return 
-// 0x15bd: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x1596: ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessArrayDataPrep 80 00 00 00 
-	Call 04 16 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call dd 15 00 00 // ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	ProcessSliceDataRepeat 08 00 00 00 
 	Return 
-// 0x15cd: ProcessType[noalg.map.group[string]int]
+// 0x15a6: ProcessType[noalg.map.group[string]int]
 	IncrementOutputOffset 08 00 00 00 
-	Call ad 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
+	Call 86 15 00 00 // ProcessType[noalg.[8]struct { key string; elem int }]
 	Return 
-// 0x15d8: ProcessType[noalg.map.group[string]main.bigStruct]
+// 0x15b1: ProcessType[noalg.map.group[string]main.bigStruct]
 	IncrementOutputOffset 08 00 00 00 
-	Call 9d 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
+	Call 76 15 00 00 // ProcessType[noalg.[8]struct { key string; elem *main.bigStruct }]
 	Return 
-// 0x15e3: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
+// 0x15bc: ProcessType[noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument]
 	IncrementOutputOffset 08 00 00 00 
-	Call bd 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+	Call 96 15 00 00 // ProcessType[noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	Return 
-// 0x15ee: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
-	Call 19 17 00 00 // ProcessType[string]
+// 0x15c7: ProcessType[noalg.struct { key string; elem *main.bigStruct }]
+	Call f2 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 10 00 00 00 
-	Call b4 13 00 00 // ProcessType[*main.bigStruct]
+	Call 8d 13 00 00 // ProcessType[*main.bigStruct]
 	Return 
-// 0x15fe: ProcessType[noalg.struct { key string; elem int }]
-	Call 19 17 00 00 // ProcessType[string]
+// 0x15d7: ProcessType[noalg.struct { key string; elem int }]
+	Call f2 16 00 00 // ProcessType[string]
 	Return 
-// 0x1604: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
+// 0x15dd: ProcessType[noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }]
 	IncrementOutputOffset 08 00 00 00 
-	Call 85 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
+	Call 5e 15 00 00 // ProcessType[map[int]main.aStructNotUsedAsAnArgument]
 	Return 
-// 0x160f: ProcessType[runtime.g]
+// 0x15e8: ProcessType[runtime.g]
 	IncrementOutputOffset 20 00 00 00 
-	Call c6 13 00 00 // ProcessType[*runtime._panic]
+	Call 9f 13 00 00 // ProcessType[*runtime._panic]
 	IncrementOutputOffset 08 00 00 00 
-	Call c0 13 00 00 // ProcessType[*runtime._defer]
+	Call 99 13 00 00 // ProcessType[*runtime._defer]
 	IncrementOutputOffset 08 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset b8 00 00 00 
-	Call 04 15 00 00 // ProcessType[[]uint8]
+	Call dd 14 00 00 // ProcessType[[]uint8]
 	IncrementOutputOffset 40 00 00 00 
-	Call 7e 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
+	Call 57 13 00 00 // ProcessType[*[]runtime.ancestorInfo]
 	IncrementOutputOffset 18 00 00 00 
-	Call ea 13 00 00 // ProcessType[*runtime.sudog]
+	Call c3 13 00 00 // ProcessType[*runtime.sudog]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 20 00 00 00 
-	Call f6 13 00 00 // ProcessType[*runtime.timer]
+	Call cf 13 00 00 // ProcessType[*runtime.timer]
 	IncrementOutputOffset 18 00 00 00 
-	Call d2 13 00 00 // ProcessType[*runtime.coro]
+	Call ab 13 00 00 // ProcessType[*runtime.coro]
 	IncrementOutputOffset 08 00 00 00 
-	Call f0 13 00 00 // ProcessType[*runtime.synctestBubble]
+	Call c9 13 00 00 // ProcessType[*runtime.synctestBubble]
 	IncrementOutputOffset 08 00 00 00 
-	Call 13 17 00 00 // ProcessType[runtime.xRegPerG]
+	Call ec 16 00 00 // ProcessType[runtime.xRegPerG]
 	Return 
-// 0x167e: ProcessType[runtime.m]
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+// 0x1657: ProcessType[runtime.m]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 48 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 70 00 00 00 
-	Call d8 13 00 00 // ProcessType[*runtime.g]
+	Call b1 13 00 00 // ProcessType[*runtime.g]
 	IncrementOutputOffset 40 00 00 00 
-	Call 19 17 00 00 // ProcessType[string]
+	Call f2 16 00 00 // ProcessType[string]
 	IncrementOutputOffset 30 00 00 00 
-	Call 7a 14 00 00 // ProcessType[[]*runtime.p]
+	Call 53 14 00 00 // ProcessType[[]*runtime.p]
 	IncrementOutputOffset 28 00 00 00 
-	Call cc 13 00 00 // ProcessType[*runtime.cgoCallers]
+	Call a5 13 00 00 // ProcessType[*runtime.cgoCallers]
 	IncrementOutputOffset 10 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 48 01 00 00 
-	Call f2 16 00 00 // ProcessType[runtime.mLockProfile]
+	Call cb 16 00 00 // ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 30 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	IncrementOutputOffset 38 00 00 00 
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	IncrementOutputOffset 08 00 00 00 
-	Call fd 16 00 00 // ProcessType[runtime.mTraceState]
+	Call d6 16 00 00 // ProcessType[runtime.mTraceState]
 	IncrementOutputOffset d0 03 00 00 
-	Call 0d 17 00 00 // ProcessType[runtime.mWeakPointer]
+	Call e6 16 00 00 // ProcessType[runtime.mWeakPointer]
 	Return 
-// 0x16f2: ProcessType[runtime.mLockProfile]
+// 0x16cb: ProcessType[runtime.mLockProfile]
 	IncrementOutputOffset 08 00 00 00 
-	Call 0e 15 00 00 // ProcessType[[]uintptr]
+	Call e7 14 00 00 // ProcessType[[]uintptr]
 	Return 
-// 0x16fd: ProcessType[runtime.mTraceState]
+// 0x16d6: ProcessType[runtime.mTraceState]
 	IncrementOutputOffset 08 00 00 00 
-	Call 5a 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
-	Call de 13 00 00 // ProcessType[*runtime.m]
+	Call 33 14 00 00 // ProcessType[[2][2]*runtime.traceBuf]
+	Call b7 13 00 00 // ProcessType[*runtime.m]
 	Return 
-// 0x170d: ProcessType[runtime.mWeakPointer]
-	Call ae 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
+// 0x16e6: ProcessType[runtime.mWeakPointer]
+	Call 87 13 00 00 // ProcessType[*internal/runtime/atomic.Pointer[runtime.m]]
 	Return 
-// 0x1713: ProcessType[runtime.xRegPerG]
-	Call 02 14 00 00 // ProcessType[*runtime.xRegState]
+// 0x16ec: ProcessType[runtime.xRegPerG]
+	Call db 13 00 00 // ProcessType[*runtime.xRegState]
 	Return 
-// 0x1719: ProcessType[string]
+// 0x16f2: ProcessType[string]
 	ProcessString 89 00 00 00 
 	Return 
-// 0x171f: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
+// 0x16f8: ProcessType[table<int,main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 1a 15 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
+	Call f3 14 00 00 // ProcessType[groupReference<int,main.aStructNotUsedAsAnArgument>]
 	Return 
-// 0x172a: ProcessType[table<string,int>]
+// 0x1703: ProcessType[table<string,int>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 26 15 00 00 // ProcessType[groupReference<string,int>]
+	Call ff 14 00 00 // ProcessType[groupReference<string,int>]
 	Return 
-// 0x1735: ProcessType[table<string,main.bigStruct>]
+// 0x170e: ProcessType[table<string,main.bigStruct>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 32 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
+	Call 0b 15 00 00 // ProcessType[groupReference<string,main.bigStruct>]
 	Return 
-// 0x1740: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+// 0x1719: ProcessType[table<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	IncrementOutputOffset 10 00 00 00 
-	Call 3e 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
+	Call 17 15 00 00 // ProcessType[groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>]
 	Return 
 // Extra illegal ops to simplify code bound checks
 	Illegal 
@@ -1848,32 +1842,32 @@ ID: 1 Len: 8 Enqueue: 0
 ID: 2 Len: 4 Enqueue: 0
 ID: 3 Len: 1 Enqueue: 0
 ID: 4 Len: 1 Enqueue: 0
-ID: 5 Len: 8 Enqueue: 5182
+ID: 5 Len: 8 Enqueue: 5143
 ID: 6 Len: 2 Enqueue: 0
 ID: 7 Len: 8 Enqueue: 0
 ID: 8 Len: 8 Enqueue: 0
-ID: 9 Len: 16 Enqueue: 5913
-ID: 10 Len: 8 Enqueue: 4996
+ID: 9 Len: 16 Enqueue: 5874
+ID: 10 Len: 8 Enqueue: 4957
 ID: 11 Len: 8 Enqueue: 0
 ID: 12 Len: 4 Enqueue: 0
 ID: 13 Len: 8 Enqueue: 0
 ID: 14 Len: 8 Enqueue: 0
-ID: 15 Len: 16 Enqueue: 5400
+ID: 15 Len: 16 Enqueue: 5361
 ID: 16 Len: 8 Enqueue: 0
 ID: 17 Len: 4 Enqueue: 0
 ID: 18 Len: 16 Enqueue: 0
 ID: 19 Len: 1 Enqueue: 0
-ID: 20 Len: 8 Enqueue: 5188
-ID: 21 Len: 8 Enqueue: 5026
-ID: 22 Len: 8 Enqueue: 5170
-ID: 23 Len: 456 Enqueue: 5647
+ID: 20 Len: 8 Enqueue: 5149
+ID: 21 Len: 8 Enqueue: 4987
+ID: 22 Len: 8 Enqueue: 5131
+ID: 23 Len: 456 Enqueue: 5608
 ID: 24 Len: 16 Enqueue: 0
-ID: 25 Len: 8 Enqueue: 5062
+ID: 25 Len: 8 Enqueue: 5023
 ID: 26 Len: 8 Enqueue: 0
-ID: 27 Len: 8 Enqueue: 5056
+ID: 27 Len: 8 Enqueue: 5017
 ID: 28 Len: 8 Enqueue: 0
-ID: 29 Len: 8 Enqueue: 5086
-ID: 30 Len: 1824 Enqueue: 5758
+ID: 29 Len: 8 Enqueue: 5047
+ID: 30 Len: 1824 Enqueue: 5719
 ID: 31 Len: 48 Enqueue: 0
 ID: 32 Len: 8 Enqueue: 0
 ID: 33 Len: 4 Enqueue: 0
@@ -1882,51 +1876,51 @@ ID: 35 Len: 1 Enqueue: 0
 ID: 36 Len: 1 Enqueue: 0
 ID: 37 Len: 1 Enqueue: 0
 ID: 38 Len: 8 Enqueue: 0
-ID: 39 Len: 24 Enqueue: 5380
-ID: 40 Len: 8 Enqueue: 4990
+ID: 39 Len: 24 Enqueue: 5341
+ID: 40 Len: 8 Enqueue: 4951
 ID: 41 Len: 8 Enqueue: 0
-ID: 42 Len: 8 Enqueue: 5098
+ID: 42 Len: 8 Enqueue: 5059
 ID: 43 Len: 8 Enqueue: 0
-ID: 44 Len: 24 Enqueue: 5390
-ID: 45 Len: 8 Enqueue: 5110
+ID: 44 Len: 24 Enqueue: 5351
+ID: 45 Len: 8 Enqueue: 5071
 ID: 46 Len: 8 Enqueue: 0
 ID: 47 Len: 4 Enqueue: 0
-ID: 48 Len: 8 Enqueue: 5074
+ID: 48 Len: 8 Enqueue: 5035
 ID: 49 Len: 8 Enqueue: 0
-ID: 50 Len: 8 Enqueue: 5104
+ID: 50 Len: 8 Enqueue: 5065
 ID: 51 Len: 8 Enqueue: 0
-ID: 52 Len: 8 Enqueue: 5907
-ID: 53 Len: 8 Enqueue: 5122
+ID: 52 Len: 8 Enqueue: 5868
+ID: 53 Len: 8 Enqueue: 5083
 ID: 54 Len: 8 Enqueue: 0
 ID: 55 Len: 32 Enqueue: 0
 ID: 56 Len: 32 Enqueue: 0
 ID: 57 Len: 12 Enqueue: 0
 ID: 58 Len: 16 Enqueue: 0
-ID: 59 Len: 8 Enqueue: 5080
+ID: 59 Len: 8 Enqueue: 5041
 ID: 60 Len: 40 Enqueue: 0
 ID: 61 Len: 8 Enqueue: 0
 ID: 62 Len: 48 Enqueue: 0
 ID: 63 Len: 8 Enqueue: 0
 ID: 64 Len: 8 Enqueue: 0
 ID: 65 Len: 4 Enqueue: 0
-ID: 66 Len: 24 Enqueue: 5242
+ID: 66 Len: 24 Enqueue: 5203
 ID: 67 Len: 8 Enqueue: 0
-ID: 68 Len: 8 Enqueue: 5092
-ID: 69 Len: 8 Enqueue: 5068
+ID: 68 Len: 8 Enqueue: 5053
+ID: 69 Len: 8 Enqueue: 5029
 ID: 70 Len: 8 Enqueue: 0
 ID: 71 Len: 8 Enqueue: 0
 ID: 72 Len: 16 Enqueue: 0
 ID: 73 Len: 256 Enqueue: 0
 ID: 74 Len: 16 Enqueue: 0
-ID: 75 Len: 56 Enqueue: 5874
+ID: 75 Len: 56 Enqueue: 5835
 ID: 76 Len: 8 Enqueue: 0
 ID: 77 Len: 0 Enqueue: 0
 ID: 78 Len: 8 Enqueue: 0
 ID: 79 Len: 1 Enqueue: 0
-ID: 80 Len: 72 Enqueue: 5885
-ID: 81 Len: 32 Enqueue: 5210
-ID: 82 Len: 16 Enqueue: 5194
-ID: 83 Len: 8 Enqueue: 5116
+ID: 80 Len: 72 Enqueue: 5846
+ID: 81 Len: 32 Enqueue: 5171
+ID: 82 Len: 16 Enqueue: 5155
+ID: 83 Len: 8 Enqueue: 5077
 ID: 84 Len: 8 Enqueue: 0
 ID: 85 Len: 0 Enqueue: 0
 ID: 86 Len: 392 Enqueue: 0
@@ -1941,45 +1935,45 @@ ID: 94 Len: 32 Enqueue: 0
 ID: 95 Len: 160 Enqueue: 0
 ID: 96 Len: 16 Enqueue: 0
 ID: 97 Len: 8 Enqueue: 0
-ID: 98 Len: 8 Enqueue: 5901
-ID: 99 Len: 8 Enqueue: 5038
+ID: 98 Len: 8 Enqueue: 5862
+ID: 99 Len: 8 Enqueue: 4999
 ID: 100 Len: 8 Enqueue: 0
-ID: 101 Len: 8 Enqueue: 5128
+ID: 101 Len: 8 Enqueue: 5089
 ID: 102 Len: 2 Enqueue: 0
 ID: 103 Len: 8 Enqueue: 0
-ID: 104 Len: 8 Enqueue: 5014
-ID: 105 Len: 8 Enqueue: 5020
-ID: 106 Len: 8 Enqueue: 5176
-ID: 107 Len: 8 Enqueue: 5032
-ID: 108 Len: 8 Enqueue: 5002
-ID: 109 Len: 8 Enqueue: 5008
-ID: 110 Len: 8 Enqueue: 5158
-ID: 111 Len: 8 Enqueue: 5164
-ID: 112 Len: 24 Enqueue: 5312
+ID: 104 Len: 8 Enqueue: 4975
+ID: 105 Len: 8 Enqueue: 4981
+ID: 106 Len: 8 Enqueue: 5137
+ID: 107 Len: 8 Enqueue: 4993
+ID: 108 Len: 8 Enqueue: 4963
+ID: 109 Len: 8 Enqueue: 4969
+ID: 110 Len: 8 Enqueue: 5119
+ID: 111 Len: 8 Enqueue: 5125
+ID: 112 Len: 24 Enqueue: 5273
 ID: 113 Len: 24 Enqueue: 0
-ID: 114 Len: 24 Enqueue: 5358
-ID: 115 Len: 48 Enqueue: 5226
-ID: 116 Len: 8 Enqueue: 5515
+ID: 114 Len: 24 Enqueue: 5319
+ID: 115 Len: 48 Enqueue: 5187
+ID: 116 Len: 8 Enqueue: 5476
 ID: 117 Len: 8 Enqueue: 0
-ID: 118 Len: 48 Enqueue: 5473
+ID: 118 Len: 48 Enqueue: 5434
 ID: 119 Len: 8 Enqueue: 0
-ID: 120 Len: 8 Enqueue: 5140
-ID: 121 Len: 8 Enqueue: 5521
+ID: 120 Len: 8 Enqueue: 5101
+ID: 121 Len: 8 Enqueue: 5482
 ID: 122 Len: 8 Enqueue: 0
-ID: 123 Len: 48 Enqueue: 5485
+ID: 123 Len: 48 Enqueue: 5446
 ID: 124 Len: 8 Enqueue: 0
-ID: 125 Len: 8 Enqueue: 5146
-ID: 126 Len: 80 Enqueue: 5450
+ID: 125 Len: 8 Enqueue: 5107
+ID: 126 Len: 80 Enqueue: 5411
 ID: 127 Len: 6 Enqueue: 0
-ID: 128 Len: 8 Enqueue: 5050
-ID: 129 Len: 8 Enqueue: 5527
+ID: 128 Len: 8 Enqueue: 5011
+ID: 129 Len: 8 Enqueue: 5488
 ID: 130 Len: 8 Enqueue: 0
-ID: 131 Len: 48 Enqueue: 5497
+ID: 131 Len: 48 Enqueue: 5458
 ID: 132 Len: 8 Enqueue: 0
-ID: 133 Len: 8 Enqueue: 5152
-ID: 134 Len: 8 Enqueue: 4966
-ID: 135 Len: 8 Enqueue: 4972
-ID: 136 Len: 8 Enqueue: 4984
+ID: 133 Len: 8 Enqueue: 5113
+ID: 134 Len: 8 Enqueue: 4927
+ID: 135 Len: 8 Enqueue: 4933
+ID: 136 Len: 8 Enqueue: 4945
 ID: 137 Len: 1 Enqueue: 0
 ID: 138 Len: 8 Enqueue: 0
 ID: 139 Len: 1 Enqueue: 0
@@ -1987,53 +1981,53 @@ ID: 140 Len: 8 Enqueue: 0
 ID: 141 Len: 8 Enqueue: 0
 ID: 142 Len: 8 Enqueue: 0
 ID: 143 Len: 8 Enqueue: 0
-ID: 144 Len: 8 Enqueue: 5252
+ID: 144 Len: 8 Enqueue: 5213
 ID: 145 Len: 8 Enqueue: 0
 ID: 146 Len: 8 Enqueue: 0
 ID: 147 Len: 8 Enqueue: 0
-ID: 148 Len: 16 Enqueue: 5368
+ID: 148 Len: 16 Enqueue: 5329
 ID: 149 Len: 8 Enqueue: 0
-ID: 150 Len: 32 Enqueue: 5930
-ID: 151 Len: 16 Enqueue: 5414
+ID: 150 Len: 32 Enqueue: 5891
+ID: 151 Len: 16 Enqueue: 5375
 ID: 152 Len: 8 Enqueue: 0
-ID: 153 Len: 200 Enqueue: 5581
-ID: 154 Len: 192 Enqueue: 5549
-ID: 155 Len: 24 Enqueue: 5630
-ID: 156 Len: 8 Enqueue: 5276
-ID: 157 Len: 200 Enqueue: 5322
-ID: 158 Len: 32 Enqueue: 5941
-ID: 159 Len: 16 Enqueue: 5426
+ID: 153 Len: 200 Enqueue: 5542
+ID: 154 Len: 192 Enqueue: 5510
+ID: 155 Len: 24 Enqueue: 5591
+ID: 156 Len: 8 Enqueue: 5237
+ID: 157 Len: 200 Enqueue: 5283
+ID: 158 Len: 32 Enqueue: 5902
+ID: 159 Len: 16 Enqueue: 5387
 ID: 160 Len: 8 Enqueue: 0
-ID: 161 Len: 200 Enqueue: 5592
-ID: 162 Len: 192 Enqueue: 5533
-ID: 163 Len: 24 Enqueue: 5614
-ID: 164 Len: 8 Enqueue: 5044
+ID: 161 Len: 200 Enqueue: 5553
+ID: 162 Len: 192 Enqueue: 5494
+ID: 163 Len: 24 Enqueue: 5575
+ID: 164 Len: 8 Enqueue: 5005
 ID: 165 Len: 184 Enqueue: 0
-ID: 166 Len: 8 Enqueue: 5288
-ID: 167 Len: 200 Enqueue: 5334
-ID: 168 Len: 32 Enqueue: 5952
-ID: 169 Len: 16 Enqueue: 5438
+ID: 166 Len: 8 Enqueue: 5249
+ID: 167 Len: 200 Enqueue: 5295
+ID: 168 Len: 32 Enqueue: 5913
+ID: 169 Len: 16 Enqueue: 5399
 ID: 170 Len: 8 Enqueue: 0
-ID: 171 Len: 136 Enqueue: 5603
-ID: 172 Len: 128 Enqueue: 5565
-ID: 173 Len: 16 Enqueue: 5636
-ID: 174 Len: 8 Enqueue: 5509
+ID: 171 Len: 136 Enqueue: 5564
+ID: 172 Len: 128 Enqueue: 5526
+ID: 173 Len: 16 Enqueue: 5597
+ID: 174 Len: 8 Enqueue: 5470
 ID: 175 Len: 8 Enqueue: 0
-ID: 176 Len: 48 Enqueue: 5461
+ID: 176 Len: 48 Enqueue: 5422
 ID: 177 Len: 8 Enqueue: 0
-ID: 178 Len: 8 Enqueue: 5134
-ID: 179 Len: 8 Enqueue: 5300
-ID: 180 Len: 136 Enqueue: 5346
-ID: 181 Len: 32 Enqueue: 5919
-ID: 182 Len: 16 Enqueue: 5402
+ID: 178 Len: 8 Enqueue: 5095
+ID: 179 Len: 8 Enqueue: 5261
+ID: 180 Len: 136 Enqueue: 5307
+ID: 181 Len: 32 Enqueue: 5880
+ID: 182 Len: 16 Enqueue: 5363
 ID: 183 Len: 8 Enqueue: 0
 ID: 184 Len: 136 Enqueue: 0
 ID: 185 Len: 128 Enqueue: 0
 ID: 186 Len: 16 Enqueue: 0
 ID: 187 Len: 8 Enqueue: 0
-ID: 188 Len: 8 Enqueue: 5264
+ID: 188 Len: 8 Enqueue: 5225
 ID: 189 Len: 136 Enqueue: 0
-ID: 190 Len: 8 Enqueue: 4978
+ID: 190 Len: 8 Enqueue: 4939
 ID: 191 Len: 128 Enqueue: 0
 ID: 192 Len: 9 Enqueue: 0
 ID: 193 Len: 0 Enqueue: 0
@@ -2143,7 +2137,7 @@ ID: 296 Len: 0 Enqueue: 0
 ID: 297 Len: 25 Enqueue: 0
 ID: 298 Len: 0 Enqueue: 0
 ID: 299 Len: 17 Enqueue: 0
-ID: 300 Len: 33 Enqueue: 0
+ID: 300 Len: 25 Enqueue: 0
 ID: 301 Len: 0 Enqueue: 0
 ID: 302 Len: 9 Enqueue: 0
 ID: 303 Len: 9 Enqueue: 0

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -324,11 +324,15 @@ func (s *message) init(
 		if whenDSL == "" {
 			whenDSL = "@when"
 		}
+		msg := "error evaluating condition"
+		if header.Condition_eval_error == 2 {
+			msg = "nil pointer encountered evaluating condition"
+		}
 		s.Debugger.EvaluationErrors = append(
 			s.Debugger.EvaluationErrors,
 			evaluationError{
 				Expression: whenDSL,
-				Message:    "error evaluating condition",
+				Message:    msg,
 			},
 		)
 	}
@@ -361,11 +365,15 @@ func (s *message) init(
 			if whenDSL == "" {
 				whenDSL = "@when"
 			}
+			msg := "error evaluating condition"
+			if returnHeader.Condition_eval_error == 2 {
+				msg = "nil pointer encountered evaluating condition"
+			}
 			s.Debugger.EvaluationErrors = append(
 				s.Debugger.EvaluationErrors,
 				evaluationError{
 					Expression: whenDSL,
-					Message:    "error evaluating condition",
+					Message:    msg,
 				},
 			)
 		}

--- a/pkg/dyninst/decode/decoder.go
+++ b/pkg/dyninst/decode/decoder.go
@@ -326,7 +326,7 @@ func (s *message) init(
 		}
 		msg := "error evaluating condition"
 		if header.Condition_eval_error == 2 {
-			msg = "nil pointer encountered evaluating condition"
+			msg = errNilPointerEvaluating.Error()
 		}
 		s.Debugger.EvaluationErrors = append(
 			s.Debugger.EvaluationErrors,
@@ -367,7 +367,7 @@ func (s *message) init(
 			}
 			msg := "error evaluating condition"
 			if returnHeader.Condition_eval_error == 2 {
-				msg = "nil pointer encountered evaluating condition"
+				msg = errNilPointerEvaluating.Error()
 			}
 			s.Debugger.EvaluationErrors = append(
 				s.Debugger.EvaluationErrors,

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -1547,3 +1547,75 @@ func TestDecoderMissingReturnEventEvaluationError(t *testing.T) {
 		})
 	}
 }
+
+// TestDecoderNilPointerCaptureExpression tests that a nil pointer dereference
+// during expression evaluation is reported as an evaluation error for captures.
+func TestDecoderNilPointerCaptureExpression(t *testing.T) {
+	irProg := generateIrForProbes(t, "simple", goVersionHmap, "stringArg")
+	decoder, err := NewDecoder(irProg, &noopTypeNameResolver{}, time.Now())
+	require.NoError(t, err)
+	input := simpleStringArgEvent(t, irProg)
+
+	// Flip bitset so expression 0 (the argument capture) has nil-deref
+	// instead of present. Original bitset = 0b00000101 (bit 0 and bit 2 set).
+	// We want: expr 0 not-present + nil-deref (bit 0=0, bit 1=1),
+	//          expr 1 present (bit 2=1).
+	// Result: 0b00000110 = 6
+	bitsetOffset := int(unsafe.Sizeof(output.EventHeader{}) + unsafe.Sizeof(output.DataItemHeader{}))
+	input[bitsetOffset] = 6
+
+	buf, probe, err := decoder.Decode(Event{
+		EntryOrLine: output.Event(input),
+		ServiceName: "foo",
+	}, &noopSymbolicator{}, nil, []byte{})
+	require.NoError(t, err)
+	require.Equal(t, "stringArg", probe.GetID())
+
+	var e eventCaptures
+	require.NoError(t, json.Unmarshal(buf, &e))
+
+	// The argument should not appear in captures (it was skipped).
+	require.Nil(t, e.Debugger.Snapshot.Captures.Entry.Arguments)
+
+	// An evaluation error should be reported for the nil pointer.
+	require.NotEmpty(t, e.Debugger.EvaluationErrors)
+	found := false
+	for _, evalErr := range e.Debugger.EvaluationErrors {
+		if evalErr.Message == "nil pointer dereference" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected nil pointer evaluation error, got: %+v", e.Debugger.EvaluationErrors)
+}
+
+// TestDecoderNilPointerTemplateExpression tests that a nil pointer dereference
+// during template expression evaluation is formatted as an error in the message.
+func TestDecoderNilPointerTemplateExpression(t *testing.T) {
+	irProg := generateIrForProbes(t, "simple", goVersionHmap, "stringArg")
+	decoder, err := NewDecoder(irProg, &noopTypeNameResolver{}, time.Now())
+	require.NoError(t, err)
+	input := simpleStringArgEvent(t, irProg)
+
+	// Flip bitset so expression 1 (the template segment) has nil-deref.
+	// Original bitset = 0b00000101 (bit 0 and bit 2 set).
+	// We want: expr 0 present (bit 0=1),
+	//          expr 1 not-present + nil-deref (bit 2=0, bit 3=1).
+	// Result: 0b00001001 = 9
+	bitsetOffset := int(unsafe.Sizeof(output.EventHeader{}) + unsafe.Sizeof(output.DataItemHeader{}))
+	input[bitsetOffset] = 9
+
+	buf, probe, err := decoder.Decode(Event{
+		EntryOrLine: output.Event(input),
+		ServiceName: "foo",
+	}, &noopSymbolicator{}, nil, []byte{})
+	require.NoError(t, err)
+	require.Equal(t, "stringArg", probe.GetID())
+
+	var e eventCaptures
+	require.NoError(t, json.Unmarshal(buf, &e))
+
+	// The template message should contain the error, not {nil}.
+	require.Contains(t, e.Message, "nil pointer dereference")
+	require.NotContains(t, e.Message, "{nil}")
+}

--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -269,7 +269,7 @@ func simpleStringArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	item = append(item, unsafe.Slice(
 		(*byte)(unsafe.Pointer(&dataItem0)), unsafe.Sizeof(dataItem0))...,
 	)
-	item = append(item, 3) // bitset: bit 0 (argument) and bit 1 (template_segment) set
+	item = append(item, 5) // bitset: bit 0 (expr 0 present) and bit 2 (expr 1 present)
 	// First expression (argument) at offset 1
 	item = binary.NativeEndian.AppendUint64(item, 0xdeadbeef)
 	item = binary.NativeEndian.AppendUint64(item, 16)
@@ -363,7 +363,7 @@ func simpleMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	rootData := make([]byte, rootLen)
 	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
 	if eventType.PresenceBitsetSize > 0 {
-		rootData[0] = 3 // bits 0 and 1 set
+		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
 	// First expression (argument) at offset 1
 	ptrOff := int(eventType.Expressions[0].Offset)
@@ -556,7 +556,7 @@ func simpleSwissMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	// Build root data item
 	rootData := make([]byte, rootLen)
 	if eventType.PresenceBitsetSize > 0 {
-		rootData[0] = 3 // bits 0 and 1 set
+		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
 	ptrOff := int(eventType.Expressions[0].Offset)
 	binary.NativeEndian.PutUint64(rootData[ptrOff:ptrOff+8], headerAddr)
@@ -775,7 +775,7 @@ func simpleSwissMapTablesArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	// Build root data item
 	rootData := make([]byte, rootLen)
 	if eventType.PresenceBitsetSize > 0 {
-		rootData[0] = 3 // bits 0 and 1 set
+		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
 	ptrOff := int(eventType.Expressions[0].Offset)
 	binary.NativeEndian.PutUint64(rootData[ptrOff:ptrOff+8], headerAddr)
@@ -1009,7 +1009,7 @@ func simpleBigMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	rootData := make([]byte, rootLen)
 	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
 	if eventType.PresenceBitsetSize > 0 {
-		rootData[0] = 3 // bits 0 and 1 set
+		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
 	// First expression (argument) at offset 1
 	ptrOff := int(eventType.Expressions[0].Offset)
@@ -1131,7 +1131,7 @@ func simplePointerChainArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	rootData := make([]byte, rootLen)
 	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
 	if eventType.PresenceBitsetSize > 0 {
-		rootData[0] = 3 // bits 0 and 1 set
+		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
 	// Build a fully captured pointer chain *****int → int(17)
 	argType := eventType.Expressions[0].Expression.Type

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -161,15 +161,14 @@ func (m *messageData) processJSONSegment(
 	}
 	if !presenceBitSet.get(2 * exprIdx) {
 		// Expression evaluation failed. Check if it was due to nil pointer.
-		msg := formatUnavailable
 		if presenceBitSet.get(2*exprIdx + 1) {
-			msg = formatNilDeref
+			return errNilPointerEvaluating
 		}
-		if !limits.canWrite(len(msg)) {
+		if !limits.canWrite(len(formatUnavailable)) {
 			return nil
 		}
-		result.WriteString(msg)
-		limits.consume(len(msg))
+		result.WriteString(formatUnavailable)
+		limits.consume(len(formatUnavailable))
 		return nil
 	}
 
@@ -328,6 +327,26 @@ func (ce *captureEvent) init(
 	ce.rootData = rootData
 	ce.skippedIndices.reset(len(rootType.Expressions))
 	ce.evaluationErrors = evalErrors
+
+	// Pre-scan presence bits for nil pointer dereferences. Mark those
+	// expressions as skipped and record evaluation errors up front so the
+	// serialization loop never needs to restart for them.
+	if rootType.PresenceBitsetSize > 0 && int(rootType.PresenceBitsetSize) <= len(rootData) {
+		presenceBits := bitset(rootData[:rootType.PresenceBitsetSize])
+		for i, expr := range rootType.Expressions {
+			if 2*i+1 >= int(rootType.PresenceBitsetSize)*8 {
+				break
+			}
+			if !presenceBits.get(2*i) && presenceBits.get(2*i+1) {
+				ce.skippedIndices.set(i)
+				*ce.evaluationErrors = append(*ce.evaluationErrors, evaluationError{
+					Expression: expr.Name,
+					Message:    errNilPointerEvaluating.Error(),
+				})
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -340,6 +359,7 @@ func (ddDebuggerSource) MarshalJSONTo(enc *jsontext.Encoder) error {
 }
 
 var errEvaluation = errors.New("evaluation error")
+var errNilPointerEvaluating = errors.New("nil pointer dereference")
 
 // processExpression processes a single expression from the root type expressions
 func (ce *captureEvent) processExpression(
@@ -366,17 +386,14 @@ func (ce *captureEvent) processExpression(
 		return err
 	}
 	if !presenceBitSet.get(2*expressionIndex) && parameterSize != 0 {
-		// Set not capture reason. Distinguish nil from unavailable.
-		reason := tokenNotCapturedReasonUnavailable
-		if presenceBitSet.get(2*expressionIndex + 1) {
-			reason = tokenNotCapturedReasonNil
-		}
+		// Nil-deref expressions are already handled in init() and marked
+		// as skipped, so we only reach here for genuinely unavailable data.
 		if err := writeTokens(enc,
 			jsontext.BeginObject,
 			jsontext.String("type"),
 			jsontext.String(parameterType.GetName()),
 			tokenNotCapturedReason,
-			reason,
+			tokenNotCapturedReasonUnavailable,
 			jsontext.EndObject,
 		); err != nil {
 			return err

--- a/pkg/dyninst/decode/marshal.go
+++ b/pkg/dyninst/decode/marshal.go
@@ -156,16 +156,20 @@ func (m *messageData) processJSONSegment(
 		return errors.New("presence bitset is out of bounds")
 	}
 	presenceBitSet := bitset(ev.rootData[:presenceBitsetSize])
-	if exprIdx >= int(presenceBitsetSize)*8 {
+	if 2*exprIdx >= int(presenceBitsetSize)*8 {
 		return errors.New("expression index out of bounds")
 	}
-	if !presenceBitSet.get(exprIdx) {
-		// Expression evaluation failed.
-		if !limits.canWrite(len(formatUnavailable)) {
+	if !presenceBitSet.get(2 * exprIdx) {
+		// Expression evaluation failed. Check if it was due to nil pointer.
+		msg := formatUnavailable
+		if presenceBitSet.get(2*exprIdx + 1) {
+			msg = formatNilDeref
+		}
+		if !limits.canWrite(len(msg)) {
 			return nil
 		}
-		result.WriteString(formatUnavailable)
-		limits.consume(len(formatUnavailable))
+		result.WriteString(msg)
+		limits.consume(len(msg))
 		return nil
 	}
 
@@ -361,14 +365,18 @@ func (ce *captureEvent) processExpression(
 	if err := writeTokens(enc, jsontext.String(expr.Name)); err != nil {
 		return err
 	}
-	if !presenceBitSet.get(expressionIndex) && parameterSize != 0 {
-		// Set not capture reason.
+	if !presenceBitSet.get(2*expressionIndex) && parameterSize != 0 {
+		// Set not capture reason. Distinguish nil from unavailable.
+		reason := tokenNotCapturedReasonUnavailable
+		if presenceBitSet.get(2*expressionIndex + 1) {
+			reason = tokenNotCapturedReasonNil
+		}
 		if err := writeTokens(enc,
 			jsontext.BeginObject,
 			jsontext.String("type"),
 			jsontext.String(parameterType.GetName()),
 			tokenNotCapturedReason,
-			tokenNotCapturedReasonUnavailable,
+			reason,
 			jsontext.EndObject,
 		); err != nil {
 			return err

--- a/pkg/dyninst/decode/not_captured_reason.go
+++ b/pkg/dyninst/decode/not_captured_reason.go
@@ -17,6 +17,7 @@ var (
 	tokenNotCapturedReasonCollectionSize = jsontext.String("collectionSize")
 	tokenNotCapturedReasonPruned         = jsontext.String("pruned")
 	tokenNotCapturedReasonUnavailable    = jsontext.String("unavailable")
+	tokenNotCapturedReasonNil            = jsontext.String("nil")
 	tokenNotCapturedReasonUnimplemented  = jsontext.String("unimplemented")
 	tokenNotCapturedReasonCycle          = jsontext.String("circular reference")
 	// This is used when we're missing the type information for a value

--- a/pkg/dyninst/decode/not_captured_reason.go
+++ b/pkg/dyninst/decode/not_captured_reason.go
@@ -17,7 +17,6 @@ var (
 	tokenNotCapturedReasonCollectionSize = jsontext.String("collectionSize")
 	tokenNotCapturedReasonPruned         = jsontext.String("pruned")
 	tokenNotCapturedReasonUnavailable    = jsontext.String("unavailable")
-	tokenNotCapturedReasonNil            = jsontext.String("nil")
 	tokenNotCapturedReasonUnimplemented  = jsontext.String("unimplemented")
 	tokenNotCapturedReasonCycle          = jsontext.String("circular reference")
 	// This is used when we're missing the type information for a value

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -43,7 +43,6 @@ const (
 const (
 	formatUnavailable     = "{unavailable}"
 	formatNil             = "nil"
-	formatNilDeref        = "{nil}"
 	formatCycle           = "{cycle}"
 	formatTruncated       = "{truncated}"
 	formatEllipsis        = "..."

--- a/pkg/dyninst/decode/types.go
+++ b/pkg/dyninst/decode/types.go
@@ -43,6 +43,7 @@ const (
 const (
 	formatUnavailable     = "{unavailable}"
 	formatNil             = "nil"
+	formatNilDeref        = "{nil}"
 	formatCycle           = "{cycle}"
 	formatTruncated       = "{truncated}"
 	formatEllipsis        = "..."

--- a/pkg/dyninst/ebpf/context.h
+++ b/pkg/dyninst/ebpf/context.h
@@ -81,6 +81,10 @@ typedef struct stack_machine {
   // exits early (e.g. nil pointer dereference), this flag remains set to
   // signal that the condition could not be fully evaluated.
   bool condition_eval_error;
+  // Set to true when a nil pointer dereference causes an expression or
+  // condition evaluation to abort. Used together with condition_eval_error
+  // to distinguish nil-caused failures from other evaluation errors.
+  bool condition_nil_deref;
 
   // Temporary data, stored here to save on stack space.
   uint64_t value_0;
@@ -107,6 +111,7 @@ static stack_machine_t* stack_machine_ctx_load(const probe_params_t* probe_param
   stack_machine->data_stack_pointer = 0;
   stack_machine->condition_failed = false;
   stack_machine->condition_eval_error = false;
+  stack_machine->condition_nil_deref = false;
   chased_pointers_trie_init(&stack_machine->chased);
   chased_slices_init(&stack_machine->chased_slices);
   stack_machine->pointer_chasing_ttl = probe_params->pointer_chasing_limit;

--- a/pkg/dyninst/ebpf/event.c
+++ b/pkg/dyninst/ebpf/event.c
@@ -224,7 +224,7 @@ probe_run(uint64_t start_ns, const probe_params_t* params, struct pt_regs* regs)
     process_steps = stack_machine_process_frame(&global_ctx, &frame_data,
                                                 params->stack_machine_pc);
   }
-  header->condition_eval_error = global_ctx.stack_machine->condition_eval_error ? 1 : 0;
+  header->condition_eval_error = global_ctx.stack_machine->condition_eval_error ? (global_ctx.stack_machine->condition_nil_deref ? 2 : 1) : 0;
   if (global_ctx.stack_machine->condition_failed) {
     LOG(4, "probe_run: condition failed, skipping event");
     if (params->kind == EVENT_KIND_RETURN) {

--- a/pkg/dyninst/ebpf/stack_machine.h
+++ b/pkg/dyninst/ebpf/stack_machine.h
@@ -12,6 +12,10 @@
 #include "queue.h"
 #include "chased_pointers_trie.h"
 
+// Sentinel value for nil_bit_idx indicating no nil bit should be set
+// (used by condition expressions which report nil via condition_eval_error).
+#define NIL_BIT_IDX_NONE 0xFFFFFFFF
+
 const int32_t defaultCollectionSizeBytesLimit = 512;
 
 DEFINE_BINARY_SEARCH(
@@ -915,13 +919,23 @@ static long sm_loop(__maybe_unused unsigned long i, void* _ctx) {
     LOG(4, "EXPR_DEREFERENCE_PTR: starting");
     uint32_t bias = sm_read_program_uint32(sm);
     uint32_t byte_len = sm_read_program_uint32(sm);
+    uint32_t nil_bit_idx = sm_read_program_uint32(sm);
     buf_offset_t value_offset = sm->offset;
     if (!scratch_buf_bounds_check(&value_offset, sizeof(target_ptr_t))) {
       return 1;
     }
     target_ptr_t addr = *(target_ptr_t*)&((*buf)[value_offset]);
     if (addr == 0) {
-      // NULL pointer: abort expression evaluation.
+      // NULL pointer: set nil bit in presence bitset if applicable.
+      if (nil_bit_idx != NIL_BIT_IDX_NONE) {
+        buf_offset_t nil_byte_offset = sm->expr_results_offset + nil_bit_idx / 8;
+        uint32_t nil_bit = nil_bit_idx % 8;
+        if (scratch_buf_bounds_check(&nil_byte_offset, 1)) {
+          (*buf)[nil_byte_offset] |= (1 << nil_bit);
+        }
+      }
+      sm->condition_nil_deref = true;
+      // Abort expression evaluation.
       scratch_buf_set_len(buf, sm->expr_results_end_offset);
       if (!sm_return(sm)) {
         return 1;
@@ -1540,6 +1554,7 @@ stack_machine_process_frame(global_ctx_t* ctx, frame_data_t* frame_data,
   ctx->stack_machine->frame_data = *frame_data;
   ctx->stack_machine->condition_failed = false;
   ctx->stack_machine->condition_eval_error = false;
+  ctx->stack_machine->condition_nil_deref = false;
   return sm_run(ctx);
 }
 
@@ -1549,6 +1564,7 @@ stack_machine_chase_pointers(global_ctx_t* ctx) {
   ctx->stack_machine->offset = scratch_buf_len(ctx->buf);
   ctx->stack_machine->condition_failed = false;
   ctx->stack_machine->condition_eval_error = false;
+  ctx->stack_machine->condition_nil_deref = false;
   return sm_run(ctx);
 }
 

--- a/pkg/dyninst/exprlang/exprlang.go
+++ b/pkg/dyninst/exprlang/exprlang.go
@@ -53,6 +53,20 @@ type LiteralExpr struct {
 
 func (le *LiteralExpr) expr() {}
 
+// LenExpr represents a len() call on a collection (string, slice, map).
+type LenExpr struct {
+	Operand Expr
+}
+
+func (le *LenExpr) expr() {}
+
+// IsEmptyExpr represents an isEmpty() call on a collection (string, slice, map).
+type IsEmptyExpr struct {
+	Operand Expr
+}
+
+func (ie *IsEmptyExpr) expr() {}
+
 // UnsupportedExpr represents an expression type that is not yet supported.
 type UnsupportedExpr struct {
 	Operation string
@@ -275,6 +289,24 @@ func Parse(dslJSON []byte) (Expr, error) {
 		}
 
 		return &GetMemberExpr{Base: baseExpr, Member: memberName}, nil
+	case "len", "isEmpty":
+		// Read the argument value and parse it recursively.
+		argJSON, err := dec.ReadValue()
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to read %s argument: %w", operation, err)
+		}
+		arg, err := Parse(argJSON)
+		if err != nil {
+			return nil, fmt.Errorf("parse error: failed to parse %s argument: %w", operation, err)
+		}
+		if err := readClosingBrace(); err != nil {
+			return nil, err
+		}
+		if operation == "len" {
+			return &LenExpr{Operand: arg}, nil
+		}
+		return &IsEmptyExpr{Operand: arg}, nil
+
 	default:
 		// Read the argument for unsupported operations.
 		// We track the offset before and after reading the argument value

--- a/pkg/dyninst/exprlang/exprlang_test.go
+++ b/pkg/dyninst/exprlang/exprlang_test.go
@@ -135,6 +135,9 @@ var testCases = []struct {
 	{name: "literal float", input: `3.14`},
 	{name: "literal false", input: `false`},
 	{name: "literal null", input: `null`},
+	// Test len/isEmpty inside eq
+	{name: "eq with len", input: `{"eq": [{"len": {"ref": "s"}}, 5]}`},
+	{name: "eq with isEmpty", input: `{"eq": [{"isEmpty": {"ref": "s"}}, true]}`},
 }
 
 // exprResult represents the result of parsing an expression for storage in JSON.
@@ -162,6 +165,12 @@ func exprToResult(expr Expr, err error) exprResult {
 		baseJSON, _ := json.Marshal(e.Base)
 		argJSON, _ := json.Marshal([]interface{}{json.RawMessage(baseJSON), e.Member})
 		return exprResult{Type: "unsupported", Operation: "getmember", Argument: json.RawMessage(argJSON)}
+	case *LenExpr:
+		operand := exprToResult(e.Operand, nil)
+		return exprResult{Type: "len", Left: &operand}
+	case *IsEmptyExpr:
+		operand := exprToResult(e.Operand, nil)
+		return exprResult{Type: "isEmpty", Left: &operand}
 	case *EqExpr:
 		left := exprToResult(e.Left, nil)
 		right := exprToResult(e.Right, nil)
@@ -271,6 +280,10 @@ func TestParse(t *testing.T) {
 			switch expr.(type) {
 			case *RefExpr:
 				require.Equal(t, expectedResult.Ref, actualResult.Ref, "ref value mismatch")
+			case *LenExpr, *IsEmptyExpr:
+				actualJSON, _ := json.Marshal(actualResult)
+				expectedJSON, _ := json.Marshal(expectedResult)
+				require.JSONEq(t, string(expectedJSON), string(actualJSON), "len/isEmpty expression mismatch")
 			case *EqExpr:
 				actualJSON, _ := json.Marshal(actualResult)
 				expectedJSON, _ := json.Marshal(expectedResult)

--- a/pkg/dyninst/exprlang/testdata/eq_with_isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_isEmpty.json
@@ -1,0 +1,22 @@
+{
+  "type": "eq",
+  "operation": "",
+  "left": {
+    "type": "isEmpty",
+    "operation": "",
+    "left": {
+      "type": "ref",
+      "ref": "s",
+      "operation": "",
+      "error": ""
+    },
+    "error": ""
+  },
+  "right": {
+    "type": "literal",
+    "operation": "",
+    "value": true,
+    "error": ""
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/eq_with_len.json
+++ b/pkg/dyninst/exprlang/testdata/eq_with_len.json
@@ -1,0 +1,22 @@
+{
+  "type": "eq",
+  "operation": "",
+  "left": {
+    "type": "len",
+    "operation": "",
+    "left": {
+      "type": "ref",
+      "ref": "s",
+      "operation": "",
+      "error": ""
+    },
+    "error": ""
+  },
+  "right": {
+    "type": "literal",
+    "operation": "",
+    "value": 5,
+    "error": ""
+  },
+  "error": ""
+}

--- a/pkg/dyninst/exprlang/testdata/isEmpty.json
+++ b/pkg/dyninst/exprlang/testdata/isEmpty.json
@@ -1,8 +1,11 @@
 {
-  "type": "unsupported",
-  "operation": "isEmpty",
-  "argument": {
-    "ref": "empty_str"
+  "type": "isEmpty",
+  "operation": "",
+  "left": {
+    "type": "ref",
+    "ref": "empty_str",
+    "operation": "",
+    "error": ""
   },
   "error": ""
 }

--- a/pkg/dyninst/exprlang/testdata/len_of_filter.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_filter.json
@@ -1,8 +1,10 @@
 {
-  "type": "unsupported",
-  "operation": "len",
-  "argument": {
-    "filter": [
+  "type": "len",
+  "operation": "",
+  "left": {
+    "type": "unsupported",
+    "operation": "filter",
+    "argument": [
       {
         "ref": "collection"
       },
@@ -14,7 +16,8 @@
           1
         ]
       }
-    ]
+    ],
+    "error": ""
   },
   "error": ""
 }

--- a/pkg/dyninst/exprlang/testdata/len_of_getmember.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_getmember.json
@@ -1,13 +1,16 @@
 {
-  "type": "unsupported",
-  "operation": "len",
-  "argument": {
-    "getmember": [
+  "type": "len",
+  "operation": "",
+  "left": {
+    "type": "unsupported",
+    "operation": "getmember",
+    "argument": [
       {
-        "ref": "self"
+        "Ref": "self"
       },
       "collectionField"
-    ]
+    ],
+    "error": ""
   },
   "error": ""
 }

--- a/pkg/dyninst/exprlang/testdata/len_of_ref.json
+++ b/pkg/dyninst/exprlang/testdata/len_of_ref.json
@@ -1,8 +1,11 @@
 {
-  "type": "unsupported",
-  "operation": "len",
-  "argument": {
-    "ref": "payload"
+  "type": "len",
+  "operation": "",
+  "left": {
+    "type": "ref",
+    "ref": "payload",
+    "operation": "",
+    "error": ""
   },
   "error": ""
 }

--- a/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
+++ b/pkg/dyninst/exprlang/testdata/nested_filter_with_any.json
@@ -1,8 +1,10 @@
 {
-  "type": "unsupported",
-  "operation": "len",
-  "argument": {
-    "filter": [
+  "type": "len",
+  "operation": "",
+  "left": {
+    "type": "unsupported",
+    "operation": "filter",
+    "argument": [
       {
         "ref": "collection"
       },
@@ -21,7 +23,8 @@
           }
         ]
       }
-    ]
+    ],
+    "error": ""
   },
   "error": ""
 }

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -116,6 +116,38 @@ LocatePC: 0x4a80a0
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0x4a8112
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4a8400
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0x4a84a2
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0x4a8560
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0x4a860d
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0x4a86c0
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0x4a8755
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0x4a8800
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0x4a8889
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0x4a8920
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0x4a8a0a
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0x4a8b00
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0x4a8bc6
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0x4a8ca0
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0x4a8d35
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0x4a8de0
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0x4a8e7e
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0x4a8f20
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0x4a9012

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.out
@@ -1,149 +1,149 @@
-LocatePC: 0x4a67a0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4a67d1
+LocatePC: 0x4a6d80
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0x4a6db1
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4a6820
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0x4a6858
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0x4a6e00
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0x4a6e38
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0x4a68a0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0x4a68dd
-	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0x4a6920
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0x4a6953
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4a69a0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0x4a69dd
-	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0x4a6a20
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0x4a6a53
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0x4a6aa0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4a6aa0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4a6b80
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0x4a6bab
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0x4a6be0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0x4a6c3d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0x4a6ca0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0x4a6cc9
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0x4a6d00
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0x4a6d54
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0x4a6dc0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0x4a6e14
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
 LocatePC: 0x4a6e80
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0x4a6ed3
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0x4a6f40
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0x4a6f94
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0x4a7000
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0x4a7054
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0x4a70c0
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0x4a7114
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
-LocatePC: 0x4a7180
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0x4a71d3
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0x4a7240
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0x4a7294
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0x4a7300
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0x4a735d
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0x4a73c0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0x4a741d
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0x4a7480
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0x4a74d4
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0x4a7540
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0x4a759b
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0x4a7600
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0x4a769d
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0x4a7740
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0x4a77e9
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0x4a78a0
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0x4a78fe
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0x4a7960
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0x4a79ac
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0x4a7a00
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0x4a7a54
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0x4a7ac0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0x4a7b32
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0x4a7e00
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0x4a7ef2
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0x4a6ac0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0x4a6af1
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0x4a6ebd
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0x4a6f00
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0x4a6f33
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0x4a6f80
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0x4a6fbd
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0x4a7000
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0x4a7033
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0x4a7080
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4a7080
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4a7160
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0x4a718b
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0x4a71c0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0x4a721d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0x4a7280
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0x4a72a9
+	fmt.Println@fmt/print.go:314
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0x4a72e0
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0x4a7334
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0x4a73a0
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0x4a73f4
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0x4a7460
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0x4a74b3
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0x4a7520
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0x4a7574
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0x4a75e0
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0x4a7634
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0x4a76a0
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0x4a76f4
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0x4a7760
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0x4a77b3
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0x4a7820
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0x4a7874
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0x4a78e0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0x4a793d
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0x4a79a0
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0x4a79fd
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0x4a7a60
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0x4a7ab4
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0x4a7b20
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0x4a7b7b
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0x4a7be0
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0x4a7c7d
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0x4a7d20
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0x4a7dc9
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0x4a7e80
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0x4a7ede
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0x4a7f40
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0x4a7f8c
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0x4a7fe0
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0x4a8034
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0x4a80a0
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0x4a8112
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4a8f20
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0x4a9012
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0x4a70a0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0x4a70d1
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0x4a5eee
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a5f16
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a6126
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a6145
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a6170
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4a618d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4a6170
 	fmt.Println
@@ -154,11 +154,11 @@ FunctionLines: 0x4a6170
 		[0x4a5d7d, 0x4a5d84) fmt.Scanln@fmt/scan.go:70
 		[0x4a5d85, 0x4a5d98) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a6126, 0x4a613d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0x4a6126, 0x4a613d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0x4a6170, 0x4a6187) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0x4a6170, 0x4a6187) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0x4a5eee, 0x4a5f1c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4a5eee, 0x4a5f1c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0x4a5d60, 0x4a5d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4a5d84, 0x4a5d85) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -231,5 +231,34 @@ FunctionLines: 0x4a6170
 		[0x4a66d0, 0x4a670a) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
 		[0x4a670a, 0x4a6752) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 		[0x4a6752, 0x4a6785) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0x4a6785, 0x4a678e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0x4a678e, 0x4a6798) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a6785, 0x4a67a5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0x4a67a5, 0x4a67ba) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0x4a67ba, 0x4a6815) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0x4a6815, 0x4a682d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0x4a682d, 0x4a691d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0x4a691d, 0x4a6930) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0x4a6930, 0x4a6956) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0x4a6956, 0x4a6967) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0x4a6967, 0x4a6982) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0x4a6982, 0x4a6993) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0x4a6993, 0x4a69fd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0x4a69fd, 0x4a6a56) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0x4a6a56, 0x4a6aa1) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4a6aa1, 0x4a6adc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0x4a6adc, 0x4a6af4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4a6af4, 0x4a6b45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0x4a6b45, 0x4a6b90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4a6b90, 0x4a6bb1) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0x4a6bb1, 0x4a6bcd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4a6bcd, 0x4a6c1e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0x4a6c1e, 0x4a6c4b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4a6c4b, 0x4a6ca1) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0x4a6ca1, 0x4a6cb9) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0x4a6cb9, 0x4a6cd2) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4a6cd2, 0x4a6cff) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4a6cff, 0x4a6d0f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0x4a6d0f, 0x4a6d28) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4a6d28, 0x4a6d3e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4a6d3e, 0x4a6d6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0x4a6d6c, 0x4a6d75) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0x4a6d75, 0x4a6d7f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -1,149 +1,149 @@
-LocatePC: 0x4a8780
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4a87b1
+LocatePC: 0x4a8d80
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0x4a8db1
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4a8800
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0x4a8838
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0x4a8e00
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0x4a8e38
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0x4a8880
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0x4a88bd
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0x4a8e80
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0x4a8ebd
 	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0x4a8900
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0x4a8933
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4a8980
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0x4a89bd
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0x4a8f00
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0x4a8f33
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0x4a8f80
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0x4a8fbd
 	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0x4a8a00
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0x4a8a33
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0x4a8a80
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4a8a80
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4a8b60
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0x4a8b8b
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0x4a8bc0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0x4a8c1d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0x4a8c80
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0x4a8ca9
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0x4a8ce0
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0x4a8d34
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0x4a8da0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0x4a8df4
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0x4a8e60
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0x4a8eb3
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0x4a8f20
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0x4a8f74
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0x4a8fe0
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0x4a9034
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0x4a90a0
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0x4a90f4
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0x4a9000
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0x4a9033
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0x4a9080
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4a9080
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
 LocatePC: 0x4a9160
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0x4a91b3
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0x4a9220
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0x4a9274
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0x4a92e0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0x4a9337
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0x4a93a0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0x4a93f7
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0x4a9460
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0x4a94b4
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0x4a9520
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0x4a957b
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0x4a95e0
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0x4a967a
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0x4a9720
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0x4a97c9
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0x4a9880
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0x4a98de
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0x4a9940
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0x4a998c
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0x4a99e0
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0x4a9a34
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0x4a9aa0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0x4a9b12
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0x4a9de0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0x4a9ed7
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0x4a8aa0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0x4a8ad1
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0x4a918b
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0x4a91c0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0x4a921d
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0x4a9280
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0x4a92a9
+	fmt.Println@fmt/print.go:314
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0x4a92e0
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0x4a9334
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0x4a93a0
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0x4a93f4
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0x4a9460
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0x4a94b3
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0x4a9520
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0x4a9574
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0x4a95e0
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0x4a9634
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0x4a96a0
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0x4a96f4
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0x4a9760
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0x4a97b3
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0x4a9820
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0x4a9874
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0x4a98e0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0x4a9937
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0x4a99a0
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0x4a99f7
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0x4a9a60
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0x4a9ab4
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0x4a9b20
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0x4a9b7b
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0x4a9be0
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0x4a9c7a
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0x4a9d20
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0x4a9dc9
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0x4a9e80
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0x4a9ede
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0x4a9f40
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0x4a9f8c
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0x4a9fe0
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0x4aa034
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0x4aa0a0
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0x4aa112
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4aaf20
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0x4ab017
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0x4a90a0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0x4a90d1
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0x4a7eee
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a7f16
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4a8126
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a8145
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4a8170
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4a818d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4a8170
 	fmt.Println
@@ -154,11 +154,11 @@ FunctionLines: 0x4a8170
 		[0x4a7d7d, 0x4a7d84) fmt.Scanln@fmt/scan.go:70
 		[0x4a7d85, 0x4a7d98) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4a8126, 0x4a813d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0x4a8126, 0x4a813d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0x4a8170, 0x4a8187) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0x4a8170, 0x4a8187) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0x4a7eee, 0x4a7f1c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4a7eee, 0x4a7f1c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0x4a7d60, 0x4a7d7d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4a7d84, 0x4a7d85) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -231,5 +231,34 @@ FunctionLines: 0x4a8170
 		[0x4a86b0, 0x4a86ea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
 		[0x4a86ea, 0x4a8732) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 		[0x4a8732, 0x4a8765) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0x4a8765, 0x4a876e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0x4a876e, 0x4a8778) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4a8765, 0x4a8785) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0x4a8785, 0x4a879a) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0x4a879a, 0x4a87f5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0x4a87f5, 0x4a880d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0x4a880d, 0x4a8913) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0x4a8913, 0x4a8926) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0x4a8926, 0x4a894c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0x4a894c, 0x4a895d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0x4a895d, 0x4a8971) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0x4a8971, 0x4a8985) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0x4a8985, 0x4a89f2) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0x4a89f2, 0x4a8a4c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0x4a8a4c, 0x4a8a97) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4a8a97, 0x4a8ad2) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0x4a8ad2, 0x4a8aea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4a8aea, 0x4a8b3b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0x4a8b3b, 0x4a8b86) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4a8b86, 0x4a8b98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0x4a8b98, 0x4a8bb4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4a8bb4, 0x4a8c05) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0x4a8c05, 0x4a8c32) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4a8c32, 0x4a8c88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0x4a8c88, 0x4a8ca0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0x4a8ca0, 0x4a8cb9) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4a8cb9, 0x4a8ce6) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4a8ce6, 0x4a8cf6) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0x4a8cf6, 0x4a8d0f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4a8d0f, 0x4a8d25) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4a8d25, 0x4a8d65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0x4a8d65, 0x4a8d6e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0x4a8d6e, 0x4a8d78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.out
@@ -116,6 +116,38 @@ LocatePC: 0x4aa0a0
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0x4aa112
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4aa400
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0x4aa4a2
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0x4aa560
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0x4aa60d
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0x4aa6c0
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0x4aa755
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0x4aa800
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0x4aa889
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0x4aa920
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0x4aaa0a
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0x4aab00
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0x4aabc6
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0x4aaca0
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0x4aad35
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0x4aade0
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0x4aae7e
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0x4aaf20
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0x4ab017

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -116,6 +116,38 @@ LocatePC: 0x4b0680
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0x4b06ec
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4b09c0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0x4b0a5b
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0x4b0b00
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0x4b0ba6
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0x4b0c60
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0x4b0ced
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0x4b0d80
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0x4b0e03
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0x4b0ea0
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0x4b0f8a
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0x4b1080
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0x4b113e
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0x4b1200
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0x4b128d
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0x4b1320
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0x4b13be
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0x4b1460
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0x4b155b

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.out
@@ -1,150 +1,150 @@
-LocatePC: 0x4aed80
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4aedb1
+LocatePC: 0x4af360
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0x4af391
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4aee00
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0x4aee38
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0x4af3e0
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0x4af418
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0x4aee80
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0x4aeebd
-	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0x4aef00
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0x4aef33
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4aef80
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0x4aefbd
-	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0x4af000
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0x4af033
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0x4af080
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4af080
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4af160
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0x4af18b
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0x4af1c0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0x4af21d
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0x4af280
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0x4af2a9
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0x4af2e0
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0x4af334
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0x4af3a0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0x4af3f4
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
 LocatePC: 0x4af460
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0x4af4b3
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0x4af520
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0x4af574
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0x4af5e0
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0x4af634
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0x4af6a0
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0x4af6f4
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
-LocatePC: 0x4af760
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0x4af7b3
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0x4af820
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0x4af874
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0x4af8e0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0x4af937
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0x4af9a0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0x4af9f7
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0x4afa60
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0x4afab4
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0x4afb20
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0x4afb7b
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0x4afbe0
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0x4afc7a
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0x4afd20
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0x4afdc9
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0x4afe80
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0x4afede
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0x4aff40
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0x4aff8c
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0x4affe0
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0x4b0034
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0x4b00a0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0x4b010c
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0x4b03c0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0x4b04bb
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0x4af0a0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0x4af0d1
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0x4af49d
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0x4af4e0
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0x4af513
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0x4af560
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0x4af59d
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0x4af5e0
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0x4af613
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0x4af660
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4af660
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4af740
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0x4af76b
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0x4af7a0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0x4af7fd
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0x4af860
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0x4af889
+	fmt.Println@fmt/print.go:314
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0x4af8c0
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0x4af914
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0x4af980
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0x4af9d4
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0x4afa40
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0x4afa93
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0x4afb00
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0x4afb54
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0x4afbc0
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0x4afc14
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0x4afc80
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0x4afcd4
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0x4afd40
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0x4afd93
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0x4afe00
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0x4afe54
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0x4afec0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0x4aff17
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0x4aff80
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0x4affd7
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0x4b0040
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0x4b0094
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0x4b0100
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0x4b015b
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0x4b01c0
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0x4b025a
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0x4b0300
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0x4b03a9
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0x4b0460
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0x4b04be
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0x4b0520
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0x4b056c
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0x4b05c0
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0x4b0614
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0x4b0680
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0x4b06ec
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4b1460
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0x4b155b
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0x4af680
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0x4af6b1
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0x4ae4ee
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4ae50e
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4ae726
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4ae745
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4ae770
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4ae78d
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4ae770
 	fmt.Println
@@ -155,11 +155,11 @@ FunctionLines: 0x4ae770
 		[0x4ae37d, 0x4ae384) fmt.Scanln@fmt/scan.go:70
 		[0x4ae385, 0x4ae398) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4ae726, 0x4ae73d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0x4ae726, 0x4ae73d) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0x4ae770, 0x4ae787) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0x4ae770, 0x4ae787) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0x4ae4ee, 0x4ae50c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4ae4ee, 0x4ae50c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0x4ae360, 0x4ae37d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4ae384, 0x4ae385) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -232,5 +232,34 @@ FunctionLines: 0x4ae770
 		[0x4aecb0, 0x4aecea) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
 		[0x4aecea, 0x4aed32) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 		[0x4aed32, 0x4aed65) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0x4aed65, 0x4aed6e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0x4aed6e, 0x4aed78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4aed65, 0x4aed85) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0x4aed85, 0x4aed9a) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0x4aed9a, 0x4aedf5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0x4aedf5, 0x4aee0d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0x4aee0d, 0x4aef13) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0x4aef13, 0x4aef26) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0x4aef26, 0x4aef4c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0x4aef4c, 0x4aef5d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0x4aef5d, 0x4aef71) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0x4aef71, 0x4aef85) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0x4aef85, 0x4aefef) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0x4aefef, 0x4af045) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0x4af045, 0x4af090) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4af090, 0x4af0cb) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0x4af0cb, 0x4af0e3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4af0e3, 0x4af134) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0x4af134, 0x4af17f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4af17f, 0x4af191) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0x4af191, 0x4af1ad) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4af1ad, 0x4af1fe) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0x4af1fe, 0x4af22b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4af22b, 0x4af281) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0x4af281, 0x4af299) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0x4af299, 0x4af2b2) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4af2b2, 0x4af2df) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4af2df, 0x4af2ef) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0x4af2ef, 0x4af308) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4af308, 0x4af31e) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4af31e, 0x4af34c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0x4af34c, 0x4af355) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0x4af355, 0x4af35f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.out
@@ -1,150 +1,150 @@
-LocatePC: 0x4c25c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0x4c25f1
+LocatePC: 0x4c2b80
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0x4c2bb1
 	fmt.Println@fmt/print.go:315
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0x4c2640
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0x4c2678
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0x4c2c00
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0x4c2c38
 	fmt.Println@fmt/print.go:315
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0x4c26c0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0x4c26fd
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0x4c2c80
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0x4c2cbd
 	fmt.Println@fmt/print.go:315
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0x4c2740
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0x4c2773
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0x4c27c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0x4c27fd
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0x4c2d00
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0x4c2d33
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0x4c2d80
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0x4c2dbd
 	fmt.Println@fmt/print.go:315
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0x4c2840
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0x4c2873
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0x4c28c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4c28c0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0x4c29a0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0x4c29cb
-	fmt.Println@fmt/print.go:315
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0x4c2a00
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0x4c2a3b
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0x4c2a80
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0x4c2aa9
-	fmt.Println@fmt/print.go:315
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0x4c2ae0
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0x4c2b34
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0x4c2ba0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0x4c2bf5
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0x4c2c60
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0x4c2cb4
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0x4c2d20
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0x4c2d75
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0x4c2de0
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0x4c2e34
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0x4c2ea0
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0x4c2ef5
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0x4c2e00
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0x4c2e33
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0x4c2e80
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0x4c2e80
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
 LocatePC: 0x4c2f60
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0x4c2fb4
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0x4c3020
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0x4c3075
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0x4c30e0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0x4c313d
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0x4c31a0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0x4c31fd
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0x4c3260
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0x4c32b4
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0x4c3320
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0x4c337f
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0x4c33e0
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0x4c347a
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0x4c3520
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0x4c35c2
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0x4c3680
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0x4c36de
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0x4c3740
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0x4c378f
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0x4c37e0
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0x4c3835
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0x4c38a0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0x4c390c
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0x4c3be0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0x4c3cd9
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0x4c28e0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0x4c2911
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0x4c2f8b
 	fmt.Println@fmt/print.go:315
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0x4c2fc0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0x4c2ffb
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0x4c3040
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0x4c3069
+	fmt.Println@fmt/print.go:315
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0x4c30a0
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0x4c30f4
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0x4c3160
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0x4c31b5
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0x4c3220
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0x4c3274
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0x4c32e0
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0x4c3335
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0x4c33a0
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0x4c33f4
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0x4c3460
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0x4c34b5
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0x4c3520
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0x4c3574
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0x4c35e0
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0x4c3635
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0x4c36a0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0x4c36fd
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0x4c3760
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0x4c37bd
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0x4c3820
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0x4c3874
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0x4c38e0
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0x4c393f
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0x4c39a0
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0x4c3a3a
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0x4c3ae0
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0x4c3b82
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0x4c3c40
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0x4c3c9e
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0x4c3d00
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0x4c3d4f
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0x4c3da0
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0x4c3df5
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0x4c3e60
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0x4c3ecc
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4c4c80
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0x4c4d79
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0x4c2ea0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0x4c2ed1
+	fmt.Println@fmt/print.go:315
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0x4c1c4a
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4c1c6a
 	fmt.Println@fmt/print.go:315
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
 LocatePC: 0x4c1f34
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4c1f51
 	fmt.Println@fmt/print.go:315
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
 LocatePC: 0x4c1f79
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 LocatePC: 0x4c1f96
 	fmt.Println@fmt/print.go:315
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
 FunctionLines: 0x4c1f79
 	fmt.Println
@@ -155,11 +155,11 @@ FunctionLines: 0x4c1f79
 		[0x4c1abd, 0x4c1ac4) fmt.Scanln@fmt/scan.go:70
 		[0x4c1ac5, 0x4c1ad8) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0x4c1f34, 0x4c1f4b) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0x4c1f34, 0x4c1f4b) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0x4c1f79, 0x4c1f90) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0x4c1f79, 0x4c1f90) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0x4c1c4a, 0x4c1c68) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4c1c4a, 0x4c1c68) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0x4c1aa0, 0x4c1abd) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0x4c1ac4, 0x4c1ac5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -232,5 +232,34 @@ FunctionLines: 0x4c1f79
 		[0x4c24ba, 0x4c2500) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
 		[0x4c2500, 0x4c2548) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
 		[0x4c2548, 0x4c2593) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0x4c2593, 0x4c259c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0x4c259c, 0x4c25aa) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0x4c2593, 0x4c25ae) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0x4c25ae, 0x4c25c5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0x4c25c5, 0x4c2625) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0x4c2625, 0x4c263d) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0x4c263d, 0x4c273f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0x4c273f, 0x4c2752) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0x4c2752, 0x4c2782) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0x4c2782, 0x4c2793) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0x4c2793, 0x4c27b1) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0x4c27b1, 0x4c27c5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0x4c27c5, 0x4c2843) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0x4c2843, 0x4c2899) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0x4c2899, 0x4c28d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4c28d8, 0x4c2913) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0x4c2913, 0x4c292b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0x4c292b, 0x4c296f) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0x4c296f, 0x4c29ae) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4c29ae, 0x4c29c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0x4c29c0, 0x4c29dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0x4c29dc, 0x4c2a25) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0x4c2a25, 0x4c2a45) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4c2a45, 0x4c2a9b) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0x4c2a9b, 0x4c2ab3) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0x4c2ab3, 0x4c2ac5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0x4c2ac5, 0x4c2ae5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4c2ae5, 0x4c2af5) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0x4c2af5, 0x4c2b06) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0x4c2b06, 0x4c2b1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0x4c2b1c, 0x4c2b67) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0x4c2b67, 0x4c2b70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0x4c2b70, 0x4c2b7a) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.out
@@ -116,6 +116,38 @@ LocatePC: 0x4c3e60
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0x4c3ecc
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0x4c41c0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0x4c425b
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0x4c4300
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0x4c43a7
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0x4c4460
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0x4c44ee
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0x4c4580
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0x4c4604
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0x4c46a0
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0x4c4782
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0x4c4880
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0x4c493e
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0x4c4a00
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0x4c4a8e
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0x4c4b20
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0x4c4bcb
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:475
 LocatePC: 0x4c4c80
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0x4c4d79

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -1,175 +1,175 @@
-LocatePC: 0xb59f0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb5a28
-	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb5a60
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0xb5aa0
-	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0xb5ae0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0xb5b28
-	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0xb5b70
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0xb5bb0
-	fmt.Println@fmt/print.go:314
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb5bf0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0xb5c38
-	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0xb5c80
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0xb5cc0
-	fmt.Println@fmt/print.go:314
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0xb5d00
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb5d08
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb5dd0
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0xb5e08
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0xb5e40
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
 LocatePC: 0xb5ea0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0xb5f00
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0xb5f38
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0xb5ed8
 	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0xb5f70
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0xb5fc8
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0xb5f10
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0xb5f50
+	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0xb5f90
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0xb5fd8
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
 LocatePC: 0xb6020
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0xb6078
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0xb6060
 	fmt.Println@fmt/print.go:314
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0xb60d0
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0xb6128
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0xb60a0
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0xb60e8
 	fmt.Println@fmt/print.go:314
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0xb6180
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0xb61d8
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0xb6130
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0xb6170
 	fmt.Println@fmt/print.go:314
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0xb6230
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0xb6288
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0xb62e0
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0xb6338
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0xb61b0
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb61b8
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb6280
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0xb62b8
 	fmt.Println@fmt/print.go:314
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
-LocatePC: 0xb6390
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0xb62f0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0xb6350
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0xb63b0
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
 LocatePC: 0xb63e8
 	fmt.Println@fmt/print.go:314
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0xb6440
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0xb6498
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0xb6420
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0xb6478
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0xb64d0
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0xb6528
 	fmt.Println@fmt/print.go:314
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0xb64f0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0xb6548
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0xb65a0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0xb65f8
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0xb6650
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0xb66a8
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0xb6700
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0xb6760
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0xb6580
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0xb65d8
 	fmt.Println@fmt/print.go:314
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0xb67c0
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0xb6850
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0xb68e0
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0xb6978
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0xb6a10
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0xb6a70
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0xb6ad0
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0xb6b20
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0xb6b70
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0xb6bc8
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0xb6630
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0xb6688
 	fmt.Println@fmt/print.go:314
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0xb6c20
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0xb6c88
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0xb6f00
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0xb6fd8
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0xb5d10
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0xb5d48
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0xb66e0
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0xb6738
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0xb6790
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0xb67e8
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0xb6840
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0xb6898
+	fmt.Println@fmt/print.go:314
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0xb68f0
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0xb6948
+	fmt.Println@fmt/print.go:314
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0xb69a0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0xb69f8
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0xb6a50
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0xb6aa8
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0xb6b00
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0xb6b58
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0xb6bb0
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0xb6c10
+	fmt.Println@fmt/print.go:314
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0xb6c70
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0xb6d00
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0xb6d90
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0xb6e28
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0xb6ec0
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0xb6f20
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0xb6f80
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0xb6fd0
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0xb7020
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0xb7078
+	fmt.Println@fmt/print.go:314
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0xb70d0
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0xb7138
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xb7cd0
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0xb7da8
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0xb61c0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0xb61f8
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0xb52a4
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb52c4
+LocatePC: 0xb52c6
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb5490
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+LocatePC: 0xb5494
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb54a8
+LocatePC: 0xb54ac
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb54c8
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+LocatePC: 0xb54cc
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb54e0
+LocatePC: 0xb54e4
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb54c8
+FunctionLines: 0xb54cc
 	fmt.Println
-		[0xb52c0, 0xb52e4) fmt.Println@fmt/print.go:314
-		[0xb54a0, 0xb54c0) fmt.Println@fmt/print.go:314
-		[0xb54d8, 0xb54f8) fmt.Println@fmt/print.go:314
+		[0xb52c4, 0xb52e8) fmt.Println@fmt/print.go:314
+		[0xb54a4, 0xb54c4) fmt.Println@fmt/print.go:314
+		[0xb54dc, 0xb54fc) fmt.Println@fmt/print.go:314
 	fmt.Scanln
 		[0xb5120, 0xb5128) fmt.Scanln@fmt/scan.go:70
 		[0xb512c, 0xb5144) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb5490, 0xb54a0) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0xb5494, 0xb54a4) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0xb54c8, 0xb54d8) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0xb54cc, 0xb54dc) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0xb52a4, 0xb52c0) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb52a4, 0xb52c4) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0xb5100, 0xb5120) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb5128, 0xb512c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -183,64 +183,93 @@ FunctionLines: 0xb54c8
 		[0xb5238, 0xb526c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
 		[0xb526c, 0xb52a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
 		[0xb52a0, 0xb52a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb52e4, 0xb52f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb52f0, 0xb5324) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb5324, 0xb53a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb53a8, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb53c0, 0xb53f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb53f4, 0xb5428) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb5428, 0xb545c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb545c, 0xb548c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb548c, 0xb5490) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb54c0, 0xb54c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb54f8, 0xb54fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb54fc, 0xb5500) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb5500, 0xb5514) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
-		[0xb5514, 0xb5528) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-		[0xb5528, 0xb553c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-		[0xb553c, 0xb5550) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-		[0xb5550, 0xb5564) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-		[0xb5564, 0xb5578) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
-		[0xb5578, 0xb558c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-		[0xb558c, 0xb55a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-		[0xb55a0, 0xb55b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-		[0xb55b4, 0xb55c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-		[0xb55c8, 0xb55dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
-		[0xb55dc, 0xb55f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-		[0xb55f0, 0xb5604) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-		[0xb5604, 0xb5618) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-		[0xb5618, 0xb562c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-		[0xb562c, 0xb5640) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
-		[0xb5640, 0xb5658) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-		[0xb5658, 0xb566c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-		[0xb566c, 0xb5684) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-		[0xb5684, 0xb5698) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-		[0xb5698, 0xb56ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
-		[0xb56ac, 0xb56c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-		[0xb56c0, 0xb56dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-		[0xb56dc, 0xb56f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-		[0xb56f8, 0xb5728) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-		[0xb5728, 0xb5758) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-		[0xb5758, 0xb5770) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb5770, 0xb5790) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-		[0xb5790, 0xb57b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-		[0xb57b0, 0xb57dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-		[0xb57dc, 0xb57ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb57ec, 0xb5804) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb5804, 0xb5824) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
-		[0xb5824, 0xb5844) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
-		[0xb5844, 0xb5874) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
-		[0xb5874, 0xb5888) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb5888, 0xb5894) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
-		[0xb5894, 0xb58a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
-		[0xb58a0, 0xb58b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
-		[0xb58b4, 0xb58c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-		[0xb58c8, 0xb58dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
-		[0xb58dc, 0xb58f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
-		[0xb58f0, 0xb5914) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-		[0xb5914, 0xb5928) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
-		[0xb5928, 0xb5960) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
-		[0xb5960, 0xb59a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
-		[0xb59a0, 0xb59d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0xb59d0, 0xb59dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0xb59dc, 0xb59f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb52e8, 0xb52f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb52f4, 0xb5328) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb5328, 0xb53ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb53ac, 0xb53c4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb53c4, 0xb53f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb53f8, 0xb542c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb542c, 0xb5460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb5460, 0xb5490) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5490, 0xb5494) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb54c4, 0xb54cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb54fc, 0xb5500) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb5500, 0xb5504) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb5504, 0xb5518) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
+		[0xb5518, 0xb552c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+		[0xb552c, 0xb5540) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+		[0xb5540, 0xb5554) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+		[0xb5554, 0xb5568) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
+		[0xb5568, 0xb557c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
+		[0xb557c, 0xb5590) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+		[0xb5590, 0xb55a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+		[0xb55a4, 0xb55b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+		[0xb55b8, 0xb55cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
+		[0xb55cc, 0xb55e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
+		[0xb55e0, 0xb55f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+		[0xb55f4, 0xb5608) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+		[0xb5608, 0xb561c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+		[0xb561c, 0xb5630) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
+		[0xb5630, 0xb5644) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
+		[0xb5644, 0xb565c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+		[0xb565c, 0xb5670) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+		[0xb5670, 0xb5688) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+		[0xb5688, 0xb569c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
+		[0xb569c, 0xb56b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
+		[0xb56b0, 0xb56c4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+		[0xb56c4, 0xb56e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+		[0xb56e0, 0xb56fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+		[0xb56fc, 0xb572c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+		[0xb572c, 0xb575c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb575c, 0xb5774) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb5774, 0xb5794) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+		[0xb5794, 0xb57b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+		[0xb57b4, 0xb57e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
+		[0xb57e0, 0xb57f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb57f0, 0xb5808) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb5808, 0xb5828) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
+		[0xb5828, 0xb5848) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
+		[0xb5848, 0xb5878) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
+		[0xb5878, 0xb588c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb588c, 0xb5898) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
+		[0xb5898, 0xb58a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
+		[0xb58a4, 0xb58b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
+		[0xb58b8, 0xb58cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+		[0xb58cc, 0xb58e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
+		[0xb58e0, 0xb58f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
+		[0xb58f4, 0xb5918) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb5918, 0xb592c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb592c, 0xb5964) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb5964, 0xb59a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb59a4, 0xb59d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb59d4, 0xb59f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0xb59f0, 0xb5a08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0xb5a08, 0xb5a48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0xb5a48, 0xb5a64) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0xb5a64, 0xb5b20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0xb5b20, 0xb5b34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0xb5b34, 0xb5b58) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0xb5b58, 0xb5b64) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0xb5b64, 0xb5b78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0xb5b78, 0xb5b88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0xb5b88, 0xb5be8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0xb5be8, 0xb5c34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0xb5c34, 0xb5c80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb5c80, 0xb5ca4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0xb5ca4, 0xb5cb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb5cb0, 0xb5ce8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0xb5ce8, 0xb5d34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb5d34, 0xb5d40) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0xb5d40, 0xb5d4c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb5d4c, 0xb5d84) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0xb5d84, 0xb5da8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb5da8, 0xb5de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0xb5de0, 0xb5dec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0xb5dec, 0xb5dfc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb5dfc, 0xb5e20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb5e20, 0xb5e28) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0xb5e28, 0xb5e3c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb5e3c, 0xb5e50) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb5e50, 0xb5e80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0xb5e80, 0xb5e8c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0xb5e8c, 0xb5ea0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.out
@@ -126,6 +126,38 @@ LocatePC: 0xb70d0
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0xb7138
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xb73c0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0xb7448
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0xb74d0
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0xb7560
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0xb75f0
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0xb7678
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0xb7700
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0xb7780
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0xb7800
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0xb78b0
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0xb7960
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0xb7a08
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0xb7ab0
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0xb7b30
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0xb7bb0
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0xb7c40
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0xb7cd0
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0xb7da8

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -1,167 +1,167 @@
-LocatePC: 0xb5870
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb58a8
+LocatePC: 0xb5d20
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0xb5d58
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb58e0
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0xb5920
-	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0xb5960
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0xb59a0
-	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0xb59e0
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0xb5a20
-	fmt.Println@fmt/print.go:314
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb5a60
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0xb5aa0
-	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0xb5ae0
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0xb5b20
-	fmt.Println@fmt/print.go:314
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0xb5b60
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb5b68
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb5c30
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0xb5c68
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0xb5ca0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0xb5d00
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0xb5d60
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0xb5d98
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0xb5d90
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
 LocatePC: 0xb5dd0
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0xb5e28
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0xb5e80
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
+	fmt.Println@fmt/print.go:314
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0xb5e10
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0xb5e50
+	fmt.Println@fmt/print.go:314
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0xb5e90
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
 LocatePC: 0xb5ed0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0xb5f20
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0xb5f70
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0xb5fc0
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
+	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0xb5f10
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0xb5f50
+	fmt.Println@fmt/print.go:314
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0xb5f90
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0xb5fd0
+	fmt.Println@fmt/print.go:314
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
 LocatePC: 0xb6010
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0xb6060
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0xb60b8
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0xb6110
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0xb6160
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb6018
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb60e0
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0xb6118
+	fmt.Println@fmt/print.go:314
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0xb6150
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
 LocatePC: 0xb61b0
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0xb6200
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0xb6250
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0xb62a0
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0xb62f0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0xb6348
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0xb63a0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0xb63f8
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0xb6450
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0xb64a8
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0xb6500
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0xb6558
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0xb65b0
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0xb6638
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0xb66c0
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0xb6210
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0xb6248
+	fmt.Println@fmt/print.go:314
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0xb6280
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0xb62d8
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0xb6330
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0xb6380
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0xb63d0
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0xb6420
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0xb6470
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0xb64c0
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0xb6510
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0xb6568
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0xb65c0
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0xb6610
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0xb6660
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0xb66b0
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0xb6700
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
 LocatePC: 0xb6750
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0xb67e0
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0xb6840
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0xb68a0
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0xb68f0
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0xb6940
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0xb6990
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0xb69e0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0xb6a48
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0xb6cb0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0xb6d90
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0xb5b70
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0xb5ba8
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0xb67a0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0xb67f8
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0xb6850
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0xb68a8
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0xb6900
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0xb6958
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0xb69b0
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0xb6a08
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0xb6a60
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0xb6ae8
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0xb6b70
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0xb6c00
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0xb6c90
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0xb6cf0
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0xb6d50
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0xb6da0
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0xb6df0
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0xb6e40
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0xb6e90
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0xb6ef8
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xb7a20
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0xb7b00
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0xb6020
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0xb6058
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0xb5130
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb514e
+LocatePC: 0xb5150
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb5310
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+LocatePC: 0xb5314
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5328
+LocatePC: 0xb532c
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb5348
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+LocatePC: 0xb534c
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb5360
+LocatePC: 0xb5364
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb5348
+FunctionLines: 0xb534c
 	fmt.Println
-		[0xb514c, 0xb516c) fmt.Println@fmt/print.go:314
-		[0xb5320, 0xb5340) fmt.Println@fmt/print.go:314
-		[0xb5358, 0xb5378) fmt.Println@fmt/print.go:314
+		[0xb5150, 0xb5170) fmt.Println@fmt/print.go:314
+		[0xb5324, 0xb5344) fmt.Println@fmt/print.go:314
+		[0xb535c, 0xb537c) fmt.Println@fmt/print.go:314
 	fmt.Scanln
 		[0xb4fb0, 0xb4fb8) fmt.Scanln@fmt/scan.go:70
 		[0xb4fbc, 0xb4fd4) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb5310, 0xb5320) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0xb5314, 0xb5324) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0xb5348, 0xb5358) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0xb534c, 0xb535c) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0xb5130, 0xb514c) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb5130, 0xb5150) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0xb4f90, 0xb4fb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb4fb8, 0xb4fbc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -175,64 +175,93 @@ FunctionLines: 0xb5348
 		[0xb50c4, 0xb50f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
 		[0xb50f8, 0xb512c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
 		[0xb512c, 0xb5130) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb516c, 0xb5178) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb5178, 0xb51ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb51ac, 0xb5228) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb5228, 0xb5240) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb5240, 0xb5274) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb5274, 0xb52a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb52a8, 0xb52dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb52dc, 0xb530c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb530c, 0xb5310) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb5340, 0xb5348) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb5378, 0xb537c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb537c, 0xb5380) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb5380, 0xb5394) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
-		[0xb5394, 0xb53a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-		[0xb53a8, 0xb53bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-		[0xb53bc, 0xb53d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-		[0xb53d0, 0xb53e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-		[0xb53e4, 0xb53f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
-		[0xb53f8, 0xb540c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-		[0xb540c, 0xb5420) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-		[0xb5420, 0xb5434) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-		[0xb5434, 0xb5448) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-		[0xb5448, 0xb545c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
-		[0xb545c, 0xb5470) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-		[0xb5470, 0xb5484) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-		[0xb5484, 0xb5498) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-		[0xb5498, 0xb54ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-		[0xb54ac, 0xb54c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
-		[0xb54c0, 0xb54d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-		[0xb54d8, 0xb54ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-		[0xb54ec, 0xb5504) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-		[0xb5504, 0xb5518) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-		[0xb5518, 0xb552c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
-		[0xb552c, 0xb5540) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-		[0xb5540, 0xb555c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-		[0xb555c, 0xb5578) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-		[0xb5578, 0xb55a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-		[0xb55a8, 0xb55d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-		[0xb55d8, 0xb55f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb55f0, 0xb5610) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-		[0xb5610, 0xb5630) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-		[0xb5630, 0xb565c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-		[0xb565c, 0xb566c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb566c, 0xb5684) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb5684, 0xb56a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
-		[0xb56a4, 0xb56c4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
-		[0xb56c4, 0xb56f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
-		[0xb56f4, 0xb5708) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb5708, 0xb5714) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
-		[0xb5714, 0xb5720) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
-		[0xb5720, 0xb5734) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
-		[0xb5734, 0xb5748) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-		[0xb5748, 0xb575c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
-		[0xb575c, 0xb5770) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
-		[0xb5770, 0xb5794) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-		[0xb5794, 0xb57a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
-		[0xb57a8, 0xb57e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
-		[0xb57e0, 0xb5820) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
-		[0xb5820, 0xb5850) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0xb5850, 0xb585c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0xb585c, 0xb5870) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb5170, 0xb517c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb517c, 0xb51b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb51b0, 0xb522c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb522c, 0xb5244) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb5244, 0xb5278) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb5278, 0xb52ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb52ac, 0xb52e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb52e0, 0xb5310) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb5310, 0xb5314) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb5344, 0xb534c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb537c, 0xb5380) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb5380, 0xb5384) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb5384, 0xb5398) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
+		[0xb5398, 0xb53ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+		[0xb53ac, 0xb53c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+		[0xb53c0, 0xb53d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+		[0xb53d4, 0xb53e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
+		[0xb53e8, 0xb53fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
+		[0xb53fc, 0xb5410) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+		[0xb5410, 0xb5424) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+		[0xb5424, 0xb5438) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+		[0xb5438, 0xb544c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
+		[0xb544c, 0xb5460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
+		[0xb5460, 0xb5474) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+		[0xb5474, 0xb5488) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+		[0xb5488, 0xb549c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+		[0xb549c, 0xb54b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
+		[0xb54b0, 0xb54c4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
+		[0xb54c4, 0xb54dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+		[0xb54dc, 0xb54f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+		[0xb54f0, 0xb5508) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+		[0xb5508, 0xb551c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
+		[0xb551c, 0xb5530) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
+		[0xb5530, 0xb5544) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+		[0xb5544, 0xb5560) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+		[0xb5560, 0xb557c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+		[0xb557c, 0xb55ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+		[0xb55ac, 0xb55dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb55dc, 0xb55f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb55f4, 0xb5614) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+		[0xb5614, 0xb5634) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+		[0xb5634, 0xb5660) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
+		[0xb5660, 0xb5670) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb5670, 0xb5688) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb5688, 0xb56a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
+		[0xb56a8, 0xb56c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
+		[0xb56c8, 0xb56f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
+		[0xb56f8, 0xb570c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb570c, 0xb5718) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
+		[0xb5718, 0xb5724) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
+		[0xb5724, 0xb5738) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
+		[0xb5738, 0xb574c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+		[0xb574c, 0xb5760) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
+		[0xb5760, 0xb5774) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
+		[0xb5774, 0xb5798) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb5798, 0xb57ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb57ac, 0xb57e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb57e4, 0xb5824) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb5824, 0xb5854) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb5854, 0xb5870) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0xb5870, 0xb5888) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0xb5888, 0xb58c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0xb58c8, 0xb58e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0xb58e4, 0xb59ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0xb59ac, 0xb59c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0xb59c0, 0xb59e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0xb59e4, 0xb59f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0xb59f0, 0xb5a00) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0xb5a00, 0xb5a10) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0xb5a10, 0xb5a70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0xb5a70, 0xb5abc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0xb5abc, 0xb5b08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb5b08, 0xb5b2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0xb5b2c, 0xb5b38) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb5b38, 0xb5b70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0xb5b70, 0xb5bbc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb5bbc, 0xb5bc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0xb5bc4, 0xb5bd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb5bd0, 0xb5c08) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0xb5c08, 0xb5c2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb5c2c, 0xb5c64) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0xb5c64, 0xb5c70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0xb5c70, 0xb5c80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb5c80, 0xb5ca4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb5ca4, 0xb5cac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0xb5cac, 0xb5cc0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb5cc0, 0xb5cd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb5cd4, 0xb5d04) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0xb5d04, 0xb5d10) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0xb5d10, 0xb5d20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.out
@@ -118,6 +118,38 @@ LocatePC: 0xb6e90
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0xb6ef8
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xb7170
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0xb71f0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0xb7270
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0xb72f8
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0xb7380
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0xb7408
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0xb7490
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0xb7508
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0xb7580
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0xb7628
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0xb76d0
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0xb7770
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0xb7810
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0xb7890
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0xb7910
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0xb7998
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0xb7a20
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0xb7b00

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -1,174 +1,174 @@
-LocatePC: 0xb83f0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xb8428
+LocatePC: 0xb8890
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0xb88c8
 	fmt.Println@fmt/print.go:314
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xb8460
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0xb8498
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0xb8900
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0xb8938
 	fmt.Println@fmt/print.go:314
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0xb84d0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0xb8510
-	fmt.Println@fmt/print.go:314
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0xb8550
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0xb8588
-	fmt.Println@fmt/print.go:314
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xb85c0
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0xb8600
-	fmt.Println@fmt/print.go:314
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0xb8640
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0xb8678
-	fmt.Println@fmt/print.go:314
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0xb86b0
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb86b8
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xb8780
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0xb87b8
-	fmt.Println@fmt/print.go:314
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0xb87f0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0xb8848
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:182
-LocatePC: 0xb88a0
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0xb88d8
-	fmt.Println@fmt/print.go:314
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0xb8910
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0xb8960
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0xb8970
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
 LocatePC: 0xb89b0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
-LocatePC: 0xb8a00
 	fmt.Println@fmt/print.go:314
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0xb8a50
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0xb89f0
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0xb8a28
+	fmt.Println@fmt/print.go:314
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
+LocatePC: 0xb8a60
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
 LocatePC: 0xb8aa0
 	fmt.Println@fmt/print.go:314
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
-LocatePC: 0xb8af0
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0xb8b40
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0xb8ae0
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0xb8b18
 	fmt.Println@fmt/print.go:314
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0xb8b90
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0xb8be0
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0xb8c30
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0xb8c80
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
+LocatePC: 0xb8b50
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb8b58
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xb8c20
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0xb8c58
 	fmt.Println@fmt/print.go:314
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
-LocatePC: 0xb8cd0
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
-LocatePC: 0xb8d20
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0xb8c90
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0xb8ce8
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:221
+LocatePC: 0xb8d40
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0xb8d78
 	fmt.Println@fmt/print.go:314
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0xb8d70
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0xb8dc0
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
+LocatePC: 0xb8db0
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0xb8e00
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0xb8e50
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0xb8ea0
 	fmt.Println@fmt/print.go:314
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0xb8e10
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0xb8e60
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0xb8eb0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0xb8f00
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0xb8f50
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0xb8fa0
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0xb8ff0
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0xb9040
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0xb9090
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0xb9108
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0xb9180
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0xb9208
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0xb9290
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0xb92e8
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0xb9340
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0xb9388
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0xb93d0
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0xb9420
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0xb8ef0
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0xb8f40
 	fmt.Println@fmt/print.go:314
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0xb9470
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0xb94d0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0xb9710
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
-LocatePC: 0xb97e8
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0xb86c0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0xb86f8
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0xb8f90
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0xb8fe0
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0xb9030
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0xb9080
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0xb90d0
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0xb9120
+	fmt.Println@fmt/print.go:314
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0xb9170
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0xb91c0
+	fmt.Println@fmt/print.go:314
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0xb9210
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0xb9260
+	fmt.Println@fmt/print.go:314
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0xb92b0
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0xb9300
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0xb9350
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0xb93a0
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0xb93f0
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0xb9440
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0xb9490
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0xb94e0
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0xb9530
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0xb95a8
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0xb9620
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0xb96a8
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0xb9730
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0xb9788
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0xb97e0
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0xb9828
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
+LocatePC: 0xb9870
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0xb98c0
+	fmt.Println@fmt/print.go:314
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0xb9910
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0xb9970
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xba370
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0xba448
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0xb8b60
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0xb8b98
+	fmt.Println@fmt/print.go:314
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0xb7cd0
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7cea
+LocatePC: 0xb7cec
 	fmt.Println@fmt/print.go:314
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xb7ea8
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+LocatePC: 0xb7eb0
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7ebe
+LocatePC: 0xb7ec8
 	fmt.Println@fmt/print.go:314
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xb7edc
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+LocatePC: 0xb7ee8
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xb7ef2
+LocatePC: 0xb7f00
 	fmt.Println@fmt/print.go:314
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xb7edc
+FunctionLines: 0xb7ee8
 	fmt.Println
-		[0xb7ce4, 0xb7d04) fmt.Println@fmt/print.go:314
-		[0xb7eb4, 0xb7ed4) fmt.Println@fmt/print.go:314
-		[0xb7ee8, 0xb7f08) fmt.Println@fmt/print.go:314
+		[0xb7ce8, 0xb7d08) fmt.Println@fmt/print.go:314
+		[0xb7ec0, 0xb7ee0) fmt.Println@fmt/print.go:314
+		[0xb7ef8, 0xb7f18) fmt.Println@fmt/print.go:314
 	fmt.Scanln
 		[0xb7b60, 0xb7b68) fmt.Scanln@fmt/scan.go:70
 		[0xb7b6c, 0xb7b84) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xb7ea8, 0xb7eb4) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0xb7eb0, 0xb7ec0) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0xb7edc, 0xb7ee8) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0xb7ee8, 0xb7ef8) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0xb7cd0, 0xb7ce4) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb7cd0, 0xb7ce8) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0xb7b40, 0xb7b60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xb7b68, 0xb7b6c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -182,64 +182,93 @@ FunctionLines: 0xb7edc
 		[0xb7c64, 0xb7c98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
 		[0xb7c98, 0xb7ccc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
 		[0xb7ccc, 0xb7cd0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xb7d04, 0xb7d10) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xb7d10, 0xb7d44) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xb7d44, 0xb7dc0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xb7dc0, 0xb7dd8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xb7dd8, 0xb7e0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xb7e0c, 0xb7e40) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xb7e40, 0xb7e74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xb7e74, 0xb7ea4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xb7ea4, 0xb7ea8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xb7ed4, 0xb7edc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xb7f08, 0xb7f0c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xb7f0c, 0xb7f10) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xb7f10, 0xb7f24) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
-		[0xb7f24, 0xb7f38) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-		[0xb7f38, 0xb7f4c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-		[0xb7f4c, 0xb7f60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-		[0xb7f60, 0xb7f74) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-		[0xb7f74, 0xb7f88) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
-		[0xb7f88, 0xb7f9c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-		[0xb7f9c, 0xb7fb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-		[0xb7fb0, 0xb7fc4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-		[0xb7fc4, 0xb7fd8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-		[0xb7fd8, 0xb7fec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
-		[0xb7fec, 0xb8000) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-		[0xb8000, 0xb8014) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-		[0xb8014, 0xb8028) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-		[0xb8028, 0xb803c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-		[0xb803c, 0xb8050) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
-		[0xb8050, 0xb8068) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-		[0xb8068, 0xb807c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-		[0xb807c, 0xb8094) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-		[0xb8094, 0xb80a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-		[0xb80a8, 0xb80bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
-		[0xb80bc, 0xb80d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-		[0xb80d0, 0xb80ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-		[0xb80ec, 0xb8108) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-		[0xb8108, 0xb8138) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-		[0xb8138, 0xb8168) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-		[0xb8168, 0xb8180) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb8180, 0xb81a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-		[0xb81a0, 0xb81c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-		[0xb81c0, 0xb81e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-		[0xb81e8, 0xb81f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xb81f8, 0xb8210) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb8210, 0xb8230) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
-		[0xb8230, 0xb8250) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
-		[0xb8250, 0xb827c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
-		[0xb827c, 0xb8290) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xb8290, 0xb829c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
-		[0xb829c, 0xb82a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
-		[0xb82a8, 0xb82bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
-		[0xb82bc, 0xb82d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-		[0xb82d0, 0xb82e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
-		[0xb82e4, 0xb82f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
-		[0xb82f8, 0xb831c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-		[0xb831c, 0xb8330) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
-		[0xb8330, 0xb8364) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
-		[0xb8364, 0xb83a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
-		[0xb83a4, 0xb83d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0xb83d4, 0xb83e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0xb83e0, 0xb83f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xb7d08, 0xb7d14) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xb7d14, 0xb7d48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xb7d48, 0xb7dc8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xb7dc8, 0xb7de0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xb7de0, 0xb7e14) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xb7e14, 0xb7e48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xb7e48, 0xb7e7c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xb7e7c, 0xb7eac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xb7eac, 0xb7eb0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xb7ee0, 0xb7ee8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xb7f18, 0xb7f1c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xb7f1c, 0xb7f20) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xb7f20, 0xb7f34) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
+		[0xb7f34, 0xb7f48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+		[0xb7f48, 0xb7f5c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+		[0xb7f5c, 0xb7f70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+		[0xb7f70, 0xb7f84) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
+		[0xb7f84, 0xb7f98) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
+		[0xb7f98, 0xb7fac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+		[0xb7fac, 0xb7fc0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+		[0xb7fc0, 0xb7fd4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+		[0xb7fd4, 0xb7fe8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
+		[0xb7fe8, 0xb7ffc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
+		[0xb7ffc, 0xb8010) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+		[0xb8010, 0xb8024) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+		[0xb8024, 0xb8038) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+		[0xb8038, 0xb804c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
+		[0xb804c, 0xb8060) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
+		[0xb8060, 0xb8078) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+		[0xb8078, 0xb808c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+		[0xb808c, 0xb80a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+		[0xb80a4, 0xb80b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
+		[0xb80b8, 0xb80cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
+		[0xb80cc, 0xb80e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+		[0xb80e0, 0xb80fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+		[0xb80fc, 0xb8118) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+		[0xb8118, 0xb8148) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+		[0xb8148, 0xb8178) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xb8178, 0xb8190) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb8190, 0xb81b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+		[0xb81b0, 0xb81d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+		[0xb81d0, 0xb81fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
+		[0xb81fc, 0xb820c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xb820c, 0xb8224) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb8224, 0xb8244) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
+		[0xb8244, 0xb8264) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
+		[0xb8264, 0xb8294) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
+		[0xb8294, 0xb82a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xb82a8, 0xb82b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
+		[0xb82b4, 0xb82c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
+		[0xb82c0, 0xb82d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
+		[0xb82d4, 0xb82e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+		[0xb82e8, 0xb82fc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
+		[0xb82fc, 0xb8310) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
+		[0xb8310, 0xb8334) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xb8334, 0xb8348) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xb8348, 0xb837c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xb837c, 0xb83bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xb83bc, 0xb83ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xb83ec, 0xb8408) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0xb8408, 0xb8420) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0xb8420, 0xb8458) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0xb8458, 0xb8474) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0xb8474, 0xb853c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0xb853c, 0xb8550) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0xb8550, 0xb8570) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0xb8570, 0xb857c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0xb857c, 0xb858c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0xb858c, 0xb859c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0xb859c, 0xb85f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0xb85f0, 0xb863c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0xb863c, 0xb8688) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb8688, 0xb86a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0xb86a0, 0xb86a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xb86a8, 0xb86e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0xb86e0, 0xb872c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb872c, 0xb8734) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0xb8734, 0xb873c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xb873c, 0xb8774) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0xb8774, 0xb8798) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb8798, 0xb87cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0xb87cc, 0xb87d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0xb87d8, 0xb87e8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xb87e8, 0xb880c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb880c, 0xb8814) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0xb8814, 0xb8828) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xb8828, 0xb883c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xb883c, 0xb886c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0xb886c, 0xb8878) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0xb8878, 0xb8890) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.out
@@ -125,6 +125,38 @@ LocatePC: 0xb9910
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0xb9970
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xb9bc0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0xb9c30
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0xb9ca0
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0xb9d18
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0xb9d90
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0xb9e08
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0xb9e80
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0xb9ee8
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0xb9f50
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0xb9fe8
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0xba080
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0xba108
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0xba190
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0xba200
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0xba270
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0xba2f0
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0xba370
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0xba448

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.out
@@ -120,6 +120,38 @@ LocatePC: 0xc9c90
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
 LocatePC: 0xc9cf0
 	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xc9f50
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:416
+LocatePC: 0xc9fc0
+	main.lenString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:418
+LocatePC: 0xca030
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:422
+LocatePC: 0xca0a8
+	main.lenSlice@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:424
+LocatePC: 0xca120
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:428
+LocatePC: 0xca198
+	main.lenMap@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:430
+LocatePC: 0xca210
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:434
+LocatePC: 0xca280
+	main.lenPtrString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:436
+LocatePC: 0xca2f0
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:452
+LocatePC: 0xca388
+	main.lenStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:454
+LocatePC: 0xca420
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:458
+LocatePC: 0xca4b0
+	main.lenPtrStructFields@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:460
+LocatePC: 0xca540
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:466
+LocatePC: 0xca5b0
+	main.lenErrInt@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:468
+LocatePC: 0xca620
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:474
+LocatePC: 0xca6a0
+	main.lenErrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:476
 LocatePC: 0xca720
 	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
 LocatePC: 0xca800

--- a/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/gosym/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.out
@@ -1,169 +1,169 @@
-LocatePC: 0xc87c0
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
-LocatePC: 0xc87f8
+LocatePC: 0xc8bf0
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:160
+LocatePC: 0xc8c28
 	fmt.Println@fmt/print.go:315
-	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
-LocatePC: 0xc8830
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
-LocatePC: 0xc8868
+	main.intArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:161
+LocatePC: 0xc8c60
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
+LocatePC: 0xc8c98
 	fmt.Println@fmt/print.go:315
-	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
-LocatePC: 0xc88a0
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:131
-LocatePC: 0xc88e0
+	main.stringArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:166
+LocatePC: 0xc8cd0
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:170
+LocatePC: 0xc8d10
 	fmt.Println@fmt/print.go:315
-	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:132
-LocatePC: 0xc8920
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
-LocatePC: 0xc8958
+	main.intSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:171
+LocatePC: 0xc8d50
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:175
+LocatePC: 0xc8d88
 	fmt.Println@fmt/print.go:315
-	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
-LocatePC: 0xc8990
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
-LocatePC: 0xc89d0
-	fmt.Println@fmt/print.go:315
-	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:142
-LocatePC: 0xc8a10
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
-LocatePC: 0xc8a48
-	fmt.Println@fmt/print.go:315
-	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
-LocatePC: 0xc8a80
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xc8a88
-	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:152
-LocatePC: 0xc8b50
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:164
-LocatePC: 0xc8b88
-	fmt.Println@fmt/print.go:315
-	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:165
-LocatePC: 0xc8bc0
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
-LocatePC: 0xc8c08
-	fmt.Println@fmt/print.go:315
-	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
-LocatePC: 0xc8c50
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:198
-LocatePC: 0xc8c88
-	fmt.Println@fmt/print.go:315
-	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:199
-LocatePC: 0xc8cc0
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:228
-LocatePC: 0xc8d18
-	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
-LocatePC: 0xc8d70
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
+	main.intArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:176
 LocatePC: 0xc8dc0
-	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:234
-LocatePC: 0xc8e10
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
-LocatePC: 0xc8e60
-	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:239
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:180
+LocatePC: 0xc8e00
+	fmt.Println@fmt/print.go:315
+	main.stringSliceArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:181
+LocatePC: 0xc8e40
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:185
+LocatePC: 0xc8e78
+	fmt.Println@fmt/print.go:315
+	main.stringArrayArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:186
 LocatePC: 0xc8eb0
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:243
-LocatePC: 0xc8f00
-	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:244
-LocatePC: 0xc8f50
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:248
-LocatePC: 0xc8fa8
-	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:249
-LocatePC: 0xc9000
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:253
-LocatePC: 0xc9050
-	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:254
-LocatePC: 0xc90a0
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:258
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xc8eb8
+	main.stringArrayArgFrameless@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:191
+LocatePC: 0xc8f80
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:203
+LocatePC: 0xc8fb8
+	fmt.Println@fmt/print.go:315
+	main.mapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:204
+LocatePC: 0xc8ff0
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:220
+LocatePC: 0xc9038
+	fmt.Println@fmt/print.go:315
+	main.bigMapArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:225
+LocatePC: 0xc9080
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:237
+LocatePC: 0xc90b8
+	fmt.Println@fmt/print.go:315
+	main.noArgs@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:238
 LocatePC: 0xc90f0
-	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:259
-LocatePC: 0xc9140
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:263
-LocatePC: 0xc9190
-	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:264
-LocatePC: 0xc91e0
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
-LocatePC: 0xc9230
-	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:269
-LocatePC: 0xc9280
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
-LocatePC: 0xc92d0
-	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:274
-LocatePC: 0xc9320
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
-LocatePC: 0xc9378
-	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:279
-LocatePC: 0xc93d0
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
-LocatePC: 0xc9420
-	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:284
-LocatePC: 0xc9470
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:291
-LocatePC: 0xc94e8
-	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
-LocatePC: 0xc9560
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:299
-LocatePC: 0xc95e8
-	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:300
-LocatePC: 0xc9670
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:309
-LocatePC: 0xc96c8
-	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:310
-LocatePC: 0xc9720
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
-LocatePC: 0xc9770
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:267
+LocatePC: 0xc9148
+	main.condInt8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:268
+LocatePC: 0xc91a0
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:272
+LocatePC: 0xc91f0
+	main.condInt16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:273
+LocatePC: 0xc9240
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:277
+LocatePC: 0xc9290
+	main.condInt32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:278
+LocatePC: 0xc92e0
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:282
+LocatePC: 0xc9330
+	main.condInt64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:283
+LocatePC: 0xc9380
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:287
+LocatePC: 0xc93d8
+	main.condUint8@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:288
+LocatePC: 0xc9430
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:292
+LocatePC: 0xc9480
+	main.condUint16@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:293
+LocatePC: 0xc94d0
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:297
+LocatePC: 0xc9520
+	main.condUint32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:298
+LocatePC: 0xc9570
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:302
+LocatePC: 0xc95c0
+	main.condUint64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:303
+LocatePC: 0xc9610
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:307
+LocatePC: 0xc9660
+	main.condFloat32@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:308
+LocatePC: 0xc96b0
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:312
+LocatePC: 0xc9700
+	main.condFloat64@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:313
+LocatePC: 0xc9750
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:317
+LocatePC: 0xc97a8
+	main.condBool@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:318
+LocatePC: 0xc9800
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:322
+LocatePC: 0xc9850
+	main.condString@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:323
+LocatePC: 0xc98a0
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
+LocatePC: 0xc9918
+	main.condStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
+LocatePC: 0xc9990
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:338
+LocatePC: 0xc9a18
+	main.condPtrStructArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
+LocatePC: 0xc9aa0
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:348
+LocatePC: 0xc9af8
+	main.condNilPtrStruct@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:349
+LocatePC: 0xc9b50
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:357
+LocatePC: 0xc9ba0
 	fmt.Println@fmt/print.go:315
-	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:320
-LocatePC: 0xc97c0
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:330
-LocatePC: 0xc9810
-	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:331
-LocatePC: 0xc9860
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:339
-LocatePC: 0xc98c0
-	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:343
-LocatePC: 0xc9b10
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:377
+	main.condReturnAndLocal@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:359
 LocatePC: 0xc9bf0
-	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:383
-LocatePC: 0xc8a90
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:154
-LocatePC: 0xc8ac8
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:369
+LocatePC: 0xc9c40
+	main.condOnly@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:370
+LocatePC: 0xc9c90
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:378
+LocatePC: 0xc9cf0
+	main.condLine@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:382
+LocatePC: 0xca720
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:488
+LocatePC: 0xca800
+	main.usesMapsOfMapsThatDoNotAppearAsArguments@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:494
+LocatePC: 0xc8ec0
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:193
+LocatePC: 0xc8ef8
 	fmt.Println@fmt/print.go:315
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 LocatePC: 0xc8040
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xc805a
+LocatePC: 0xc805c
 	fmt.Println@fmt/print.go:315
-	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+	main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-LocatePC: 0xc8264
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+LocatePC: 0xc826c
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xc827a
+LocatePC: 0xc8284
 	fmt.Println@fmt/print.go:315
-	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+	main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-LocatePC: 0xc8298
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+LocatePC: 0xc82a4
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-LocatePC: 0xc82ae
+LocatePC: 0xc82bc
 	fmt.Println@fmt/print.go:315
-	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+	main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-FunctionLines: 0xc8298
+FunctionLines: 0xc82a4
 	fmt.Println
-		[0xc8054, 0xc8074) fmt.Println@fmt/print.go:315
-		[0xc8270, 0xc8290) fmt.Println@fmt/print.go:315
-		[0xc82a4, 0xc82c4) fmt.Println@fmt/print.go:315
+		[0xc8058, 0xc8078) fmt.Println@fmt/print.go:315
+		[0xc827c, 0xc829c) fmt.Println@fmt/print.go:315
+		[0xc82b4, 0xc82d4) fmt.Println@fmt/print.go:315
 	fmt.Scanln
 		[0xc7ec0, 0xc7ec8) fmt.Scanln@fmt/scan.go:70
 		[0xc7ecc, 0xc7ee4) fmt.Scanln@fmt/scan.go:70
 	main.PointerChainArg
-		[0xc8264, 0xc8270) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:190
+		[0xc826c, 0xc827c) main.PointerChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:229
 	main.PointerSmallChainArg
-		[0xc8298, 0xc82a4) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
+		[0xc82a4, 0xc82b4) main.PointerSmallChainArg@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:233
 	main.inlined
-		[0xc8040, 0xc8054) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xc8040, 0xc8058) main.inlined@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:194
 	main.main
 		[0xc7ea0, 0xc7ec0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
 		[0xc7ec8, 0xc7ecc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:15
@@ -177,64 +177,93 @@ FunctionLines: 0xc8298
 		[0xc7fd4, 0xc8008) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:24
 		[0xc8008, 0xc803c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:25
 		[0xc803c, 0xc8040) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:26
-		[0xc8074, 0xc8080) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
-		[0xc8080, 0xc80b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
-		[0xc80b4, 0xc815c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
-		[0xc815c, 0xc8174) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
-		[0xc8174, 0xc81b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
-		[0xc81b0, 0xc81ec) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
-		[0xc81ec, 0xc8228) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
-		[0xc8228, 0xc8260) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
-		[0xc8260, 0xc8264) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
-		[0xc8290, 0xc8298) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
-		[0xc82c4, 0xc82c8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
-		[0xc82c8, 0xc82cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
-		[0xc82cc, 0xc82e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
-		[0xc82e0, 0xc82f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
-		[0xc82f4, 0xc8308) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
-		[0xc8308, 0xc831c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
-		[0xc831c, 0xc8330) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
-		[0xc8330, 0xc8344) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
-		[0xc8344, 0xc8358) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
-		[0xc8358, 0xc836c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
-		[0xc836c, 0xc8380) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
-		[0xc8380, 0xc8394) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
-		[0xc8394, 0xc83a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
-		[0xc83a8, 0xc83bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
-		[0xc83bc, 0xc83d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
-		[0xc83d0, 0xc83e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
-		[0xc83e4, 0xc83f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
-		[0xc83f8, 0xc840c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
-		[0xc840c, 0xc8424) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
-		[0xc8424, 0xc8438) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
-		[0xc8438, 0xc8450) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
-		[0xc8450, 0xc8464) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
-		[0xc8464, 0xc8478) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
-		[0xc8478, 0xc848c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
-		[0xc848c, 0xc84a8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
-		[0xc84a8, 0xc84c4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
-		[0xc84c4, 0xc84f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
-		[0xc84f8, 0xc852c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
-		[0xc852c, 0xc8544) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xc8544, 0xc8564) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
-		[0xc8564, 0xc8584) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
-		[0xc8584, 0xc85ac) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
-		[0xc85ac, 0xc85b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
-		[0xc85b8, 0xc85d0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xc85d0, 0xc85f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
-		[0xc85f0, 0xc8610) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
-		[0xc8610, 0xc863c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
-		[0xc863c, 0xc864c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
-		[0xc864c, 0xc8658) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
-		[0xc8658, 0xc8664) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
-		[0xc8664, 0xc8678) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
-		[0xc8678, 0xc868c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
-		[0xc868c, 0xc86a0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
-		[0xc86a0, 0xc86b4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
-		[0xc86b4, 0xc86e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
-		[0xc86e0, 0xc86f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
-		[0xc86f4, 0xc8730) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
-		[0xc8730, 0xc8770) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
-		[0xc8770, 0xc87a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
-		[0xc87a4, 0xc87b0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:118
-		[0xc87b0, 0xc87c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14
+		[0xc8078, 0xc8084) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:28
+		[0xc8084, 0xc80b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:29
+		[0xc80b8, 0xc8164) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:30
+		[0xc8164, 0xc817c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:31
+		[0xc817c, 0xc81b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:32
+		[0xc81b8, 0xc81f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:33
+		[0xc81f4, 0xc8230) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:34
+		[0xc8230, 0xc8268) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:35
+		[0xc8268, 0xc826c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:37
+		[0xc829c, 0xc82a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:38
+		[0xc82d4, 0xc82d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:39
+		[0xc82d8, 0xc82dc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:40
+		[0xc82dc, 0xc82f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:46
+		[0xc82f0, 0xc8304) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:47
+		[0xc8304, 0xc8318) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:48
+		[0xc8318, 0xc832c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:49
+		[0xc832c, 0xc8340) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:50
+		[0xc8340, 0xc8354) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:51
+		[0xc8354, 0xc8368) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:52
+		[0xc8368, 0xc837c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:53
+		[0xc837c, 0xc8390) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:54
+		[0xc8390, 0xc83a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:55
+		[0xc83a4, 0xc83b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:56
+		[0xc83b8, 0xc83cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:57
+		[0xc83cc, 0xc83e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:58
+		[0xc83e0, 0xc83f4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:59
+		[0xc83f4, 0xc8408) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:60
+		[0xc8408, 0xc841c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:61
+		[0xc841c, 0xc8434) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:62
+		[0xc8434, 0xc8448) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:63
+		[0xc8448, 0xc8460) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:64
+		[0xc8460, 0xc8474) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:65
+		[0xc8474, 0xc8488) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:66
+		[0xc8488, 0xc849c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:67
+		[0xc849c, 0xc84b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:68
+		[0xc84b8, 0xc84d4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:69
+		[0xc84d4, 0xc8508) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:73
+		[0xc8508, 0xc853c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:78
+		[0xc853c, 0xc8554) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xc8554, 0xc8574) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:86
+		[0xc8574, 0xc8594) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:87
+		[0xc8594, 0xc85c0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:88
+		[0xc85c0, 0xc85cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:85
+		[0xc85cc, 0xc85e4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xc85e4, 0xc8604) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:91
+		[0xc8604, 0xc8624) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:92
+		[0xc8624, 0xc8654) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:93
+		[0xc8654, 0xc8664) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:90
+		[0xc8664, 0xc8670) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:97
+		[0xc8670, 0xc867c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:98
+		[0xc867c, 0xc8690) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:101
+		[0xc8690, 0xc86a4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:102
+		[0xc86a4, 0xc86b8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:105
+		[0xc86b8, 0xc86cc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:106
+		[0xc86cc, 0xc86f8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:111
+		[0xc86f8, 0xc870c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:112
+		[0xc870c, 0xc8748) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:115
+		[0xc8748, 0xc8788) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:116
+		[0xc8788, 0xc87bc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:117
+		[0xc87bc, 0xc87d8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:121
+		[0xc87d8, 0xc87f0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:122
+		[0xc87f0, 0xc8828) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:123
+		[0xc8828, 0xc8844) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:124
+		[0xc8844, 0xc890c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:125
+		[0xc890c, 0xc8920) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:126
+		[0xc8920, 0xc8948) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:127
+		[0xc8948, 0xc8954) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:128
+		[0xc8954, 0xc896c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:129
+		[0xc896c, 0xc897c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:130
+		[0xc897c, 0xc89e0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:133
+		[0xc89e0, 0xc8a2c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:134
+		[0xc8a2c, 0xc8a50) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xc8a50, 0xc8a68) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:136
+		[0xc8a68, 0xc8a70) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:137
+		[0xc8a70, 0xc8a9c) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:135
+		[0xc8a9c, 0xc8ac0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xc8ac0, 0xc8ac8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:140
+		[0xc8ac8, 0xc8ad0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:141
+		[0xc8ad0, 0xc8afc) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:139
+		[0xc8afc, 0xc8b14) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xc8b14, 0xc8b48) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:146
+		[0xc8b48, 0xc8b54) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:147
+		[0xc8b54, 0xc8b60) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:145
+		[0xc8b60, 0xc8b78) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xc8b78, 0xc8b80) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:151
+		[0xc8b80, 0xc8b90) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:149
+		[0xc8b90, 0xc8ba4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:155
+		[0xc8ba4, 0xc8bd8) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:156
+		[0xc8bd8, 0xc8be4) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:157
+		[0xc8be4, 0xc8bf0) main.main@github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go:14

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -1,22 +1,22 @@
-- offset: "0x0000fdc0"
+- offset: "0x0000fe60"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006100"
+  ptrToThis: "0x00006160"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001b8e0"
+- offset: "0x0001ba80"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006140"
+  ptrToThis: "0x000061a0"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x0001d0e0"
+- offset: "0x0001d280"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x000060c0"
+  ptrToThis: "0x000060e0"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001a580"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006120"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00011640"
+- offset: "0x00011700"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006ac0"
+  ptrToThis: "0x00006b40"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001dfe0"
+- offset: "0x0001e1a0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006b00"
+  ptrToThis: "0x00006b80"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x0001fb80"
+- offset: "0x0001fd40"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x00006a80"
+  ptrToThis: "0x00006ac0"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001cba0"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006b00"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00012080"
+- offset: "0x00012120"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006e40"
+  ptrToThis: "0x00006ea0"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001f380"
+- offset: "0x0001f520"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006e80"
+  ptrToThis: "0x00006ee0"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x00021140"
+- offset: "0x000212e0"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x00006e00"
+  ptrToThis: "0x00006e20"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001de40"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006e60"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00013080"
+- offset: "0x00013140"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00007520"
+  ptrToThis: "0x000075a0"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x00021060"
+- offset: "0x00021220"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00007560"
+  ptrToThis: "0x000075e0"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x00022de0"
+- offset: "0x00022fa0"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x000074e0"
+  ptrToThis: "0x00007520"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001f7e0"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00007560"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -1,22 +1,22 @@
-- offset: "0x0000fd40"
+- offset: "0x0000fde0"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x000060e0"
+  ptrToThis: "0x00006140"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001b860"
+- offset: "0x0001ba00"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006120"
+  ptrToThis: "0x00006180"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x0001d060"
+- offset: "0x0001d200"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x000060a0"
+  ptrToThis: "0x000060c0"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001a500"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006100"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -1,22 +1,22 @@
-- offset: "0x000115c0"
+- offset: "0x00011680"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006aa0"
+  ptrToThis: "0x00006b20"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001df60"
+- offset: "0x0001e120"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006ae0"
+  ptrToThis: "0x00006b60"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x0001fb00"
+- offset: "0x0001fcc0"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x00006a60"
+  ptrToThis: "0x00006aa0"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001cb20"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006ae0"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00012000"
+- offset: "0x000120a0"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x00006e20"
+  ptrToThis: "0x00006e80"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x0001f300"
+- offset: "0x0001f4a0"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00006e60"
+  ptrToThis: "0x00006ec0"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x000210c0"
+- offset: "0x00021260"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x00006de0"
+  ptrToThis: "0x00006e00"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001ddc0"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00006e40"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/gotype/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -1,22 +1,22 @@
-- offset: "0x00012fe0"
+- offset: "0x00013080"
   size: 8
   kind: struct
   nameEntry: main.aStructNotUsedAsAnArgument
   name: main.aStructNotUsedAsAnArgument
   pkg: main
-  ptrToThis: "0x000074e0"
+  ptrToThis: "0x00007540"
   struct:
     fields:
         - name: a
           type: int
           offset: 0
-- offset: "0x00020fc0"
+- offset: "0x00021160"
   size: 184
   kind: struct
   nameEntry: main.bigStruct
   name: main.bigStruct
   pkg: main
-  ptrToThis: "0x00007520"
+  ptrToThis: "0x00007580"
   struct:
     fields:
         - name: Field1 (exported)
@@ -43,13 +43,13 @@
         - name: data
           type: '[128]uint8'
           offset: 56
-- offset: "0x00022d40"
+- offset: "0x00022ee0"
   size: 80
   kind: struct
   nameEntry: main.condFields
   name: main.condFields
   pkg: main
-  ptrToThis: "0x000074a0"
+  ptrToThis: "0x000074c0"
   struct:
     fields:
         - name: I8 (exported)
@@ -91,3 +91,30 @@
         - name: arr
           type: '[3]int16'
           offset: 72
+- offset: "0x0001f720"
+  size: 72
+  kind: struct
+  nameEntry: main.lenFields
+  name: main.lenFields
+  pkg: main
+  ptrToThis: "0x00007500"
+  struct:
+    fields:
+        - name: S (exported)
+          type: string
+          offset: 0
+        - name: Items (exported)
+          type: '[]int'
+          offset: 16
+        - name: Dict (exported)
+          type: map[string]int
+          offset: 40
+        - name: PtrStr (exported)
+          type: '*string'
+          offset: 48
+        - name: PtrSlice (exported)
+          type: '*[]int'
+          offset: 56
+        - name: pad
+          type: '[3]int16'
+          offset: 64

--- a/pkg/dyninst/integration_test.go
+++ b/pkg/dyninst/integration_test.go
@@ -245,7 +245,7 @@ func testDyninst(
 		}
 	}
 
-	timeout := time.Second
+	timeout := 5 * time.Second
 	if !rewriteEnabled {
 		// In CI the machines seem to get very overloaded and this takes a
 		// shocking amount of time. Given we don't wait for this timeout in

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -4407,7 +4407,10 @@ func disassembleAmd64Function(
 		}
 		if !frameless &&
 			instruction.Op == x86asm.POP && instruction.Args[0] == x86asm.RBP &&
-			prevInst.Op == x86asm.ADD && prevInst.Args[0] == x86asm.RSP {
+			// Sometimes we see negative subtractions instead of additions,
+			// but at the time of writing, not sure why.
+			((prevInst.Op == x86asm.ADD || prevInst.Op == x86asm.SUB) &&
+				prevInst.Args[0] == x86asm.RSP) {
 
 			epilogueStart := addr + uint64(offset) - uint64(prevInst.Len)
 			maybeRet, err := x86asm.Decode(body[offset+instruction.Len:], 64)
@@ -4438,9 +4441,9 @@ func disassembleAmd64Function(
 					}
 				}
 			}
-			offset += nopLen + instruction.Len
 			instruction = maybeRet
 			if instruction.Op == x86asm.RET && collectReturnLocations {
+				offset += nopLen + instruction.Len
 				returnLocations = append(returnLocations, ir.InjectionPoint{
 					PC:                  epilogueStart,
 					Frameless:           frameless,

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -3433,6 +3433,10 @@ func exploreLenExprTypes(
 	// from StructureType to GoStringHeaderType etc. by completeGoTypes).
 	resolvedType = tc.typesByID[resolvedType.GetID()]
 
+	// Unwrap GoMapType to its header type (maps are pointers to headers).
+	_, isMap := resolvedType.(*ir.GoMapType)
+	resolvedType = unwrapMapType(resolvedType, tc)
+
 	// If result is a pointer, dereference to get the collection type.
 	if ptrType, ok := resolvedType.(*ir.PointerType); ok {
 		pointee := ptrType.Pointee
@@ -3457,6 +3461,12 @@ func exploreLenExprTypes(
 	f, err := field(tc, structType, fieldName)
 	if err != nil {
 		return nil, fmt.Errorf("len field lookup failed: %w", err)
+	}
+
+	// Normalize map count types to uint64 for consistency across
+	// Go versions and architectures.
+	if isMap && tc.uint64Type != 0 {
+		return tc.typesByID[tc.uint64Type], nil
 	}
 	return f.Type, nil
 }
@@ -3488,6 +3498,17 @@ func lenFieldInfo(typ ir.Type) (*ir.StructureType, string, error) {
 			typ.GetName(), kindString,
 		)
 	}
+}
+
+// unwrapMapType returns the map's header type if typ is a GoMapType, otherwise
+// returns typ unchanged. GoMapType is an IR-level wrapper that hides the
+// pointer-to-header representation of Go maps; callers that need the header
+// (e.g. len/isEmpty) must see through it.
+func unwrapMapType(typ ir.Type, tc *typeCatalog) ir.Type {
+	if m, ok := typ.(*ir.GoMapType); ok {
+		return tc.typesByID[m.HeaderType.GetID()]
+	}
+	return typ
 }
 
 // resolveExpression resolves an expression AST to an IR Expression.
@@ -3676,7 +3697,12 @@ func resolveExpression(
 		return resolveLenExpression(e.Operand, rootVar, tc)
 
 	case *exprlang.IsEmptyExpr:
-		return resolveLenExpression(e.Operand, rootVar, tc)
+		// isEmpty is only supported as a standalone condition (resolved via
+		// resolveIsEmptyCondition). In expression context it would need to
+		// produce a boolean, which the eBPF stack machine cannot compute.
+		return ir.Expression{}, fmt.Errorf(
+			"isEmpty() is only supported as a condition, not as an expression",
+		)
 
 	default:
 		return ir.Expression{}, fmt.Errorf(
@@ -3700,6 +3726,18 @@ func resolveLenExpression(
 
 	currentType := tc.typesByID[baseExpr.Type.GetID()]
 	operations := baseExpr.Operations
+
+	// GoMapType is a pointer to a map header; unwrap and dereference.
+	isMap := false
+	if m, ok := currentType.(*ir.GoMapType); ok {
+		isMap = true
+		headerType := tc.typesByID[m.HeaderType.GetID()]
+		operations = append(operations, &ir.DereferenceOp{
+			Bias:     0,
+			ByteSize: headerType.GetByteSize(),
+		})
+		currentType = headerType
+	}
 
 	// If the resolved type is a pointer to a collection, dereference it.
 	if _, ok := currentType.(*ir.PointerType); ok {
@@ -3741,8 +3779,17 @@ func resolveLenExpression(
 		}
 	}
 
+	// Map count fields have varying types across Go versions and architectures
+	// (int vs uint64 etc.). Normalize to uint64 so that snapshots and
+	// downstream consumers see a consistent type. Note that it's only for the
+	// old hmap's that its an int and not a uint64.
+	exprType := f.Type
+	if isMap && tc.uint64Type != 0 {
+		exprType = tc.typesByID[tc.uint64Type]
+	}
+
 	return ir.Expression{
-		Type:       f.Type,
+		Type:       exprType,
 		Operations: operations,
 	}, nil
 }

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -528,6 +528,8 @@ func extractRootVariableName(expr exprlang.Expr) (string, bool) {
 			expr = e.Operand
 		case *exprlang.IsEmptyExpr:
 			expr = e.Operand
+		case *exprlang.EqExpr:
+			expr = e.Left
 		default:
 			return "", false
 		}
@@ -925,6 +927,7 @@ func newTemplate(td ir.TemplateDefinition) *ir.Template {
 				case *exprlang.GetMemberExpr:
 				case *exprlang.LenExpr:
 				case *exprlang.IsEmptyExpr:
+				case *exprlang.EqExpr:
 				case *exprlang.UnsupportedExpr:
 					msg := "unsupported operation: " + expr.Operation
 					addInvalid(segment, msg)
@@ -3697,12 +3700,21 @@ func resolveExpression(
 		return resolveLenExpression(e.Operand, rootVar, tc)
 
 	case *exprlang.IsEmptyExpr:
-		// isEmpty is only supported as a standalone condition (resolved via
-		// resolveIsEmptyCondition). In expression context it would need to
-		// produce a boolean, which the eBPF stack machine cannot compute.
-		return ir.Expression{}, fmt.Errorf(
-			"isEmpty() is only supported as a condition, not as an expression",
-		)
+		return resolveIsEmptyComparison(e, rootVar, tc)
+
+	case *exprlang.EqExpr:
+		lhsExpr, err := resolveExpression(e.Left, rootVar, tc)
+		if err != nil {
+			return ir.Expression{}, fmt.Errorf("failed to resolve eq LHS: %w", err)
+		}
+		litExpr, ok := e.Right.(*exprlang.LiteralExpr)
+		if !ok {
+			return ir.Expression{}, fmt.Errorf(
+				"unsupported eq RHS type: %T (only literals are supported)",
+				e.Right,
+			)
+		}
+		return resolveEqComparison(lhsExpr, litExpr, tc)
 
 	default:
 		return ir.Expression{}, fmt.Errorf(
@@ -3983,6 +3995,98 @@ func coerceLiteral(value any, targetKind reflect.Kind, byteSize uint32) ([]byte,
 	return litData, nil
 }
 
+// resolveEqComparison builds comparison ops for an equality check.
+// Returns a bool-typed Expression without ConditionCheckOp.
+func resolveEqComparison(
+	lhsExpr ir.Expression,
+	litExpr *exprlang.LiteralExpr,
+	tc *typeCatalog,
+) (ir.Expression, error) {
+	lhsType := lhsExpr.Type
+	ops := lhsExpr.Operations
+
+	// Check if LHS is a string type.
+	if _, isString := lhsType.(*ir.GoStringHeaderType); isString {
+		// String equality comparison.
+		litStr, ok := litExpr.Value.(string)
+		if !ok {
+			return ir.Expression{}, fmt.Errorf(
+				"eq: string variable compared with non-string literal %T",
+				litExpr.Value,
+			)
+		}
+		if len(litStr) > ir.MaxStringLiteralLength {
+			return ir.Expression{}, fmt.Errorf(
+				"eq: string literal too long (%d bytes, max %d)",
+				len(litStr), ir.MaxStringLiteralLength,
+			)
+		}
+
+		// Read the string content from userspace.
+		ops = append(ops, &ir.ExprReadStringOp{MaxLen: ir.MaxStringLiteralLength})
+
+		// Load the literal as [u32 len][bytes...].
+		litData := make([]byte, 4+len(litStr))
+		binary.LittleEndian.PutUint32(litData[:4], uint32(len(litStr)))
+		copy(litData[4:], litStr)
+		ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
+
+		// Compare strings.
+		ops = append(ops, &ir.ExprCmpEqStringOp{})
+	} else if baseType, isBase := lhsType.(*ir.BaseType); isBase {
+		// Base type equality comparison.
+		byteSize := baseType.GetByteSize()
+		if byteSize > 8 {
+			return ir.Expression{}, fmt.Errorf(
+				"eq: base type too large for comparison (%d bytes)",
+				byteSize,
+			)
+		}
+
+		// Push LHS offset and advance.
+		ops = append(ops, &ir.ExprPushOffsetOp{ByteSize: uint32(byteSize)})
+
+		// Determine target kind for coercion.
+		targetKind := reflect.Invalid
+		if goKind, ok := baseType.GetGoKind(); ok {
+			targetKind = goKind
+		}
+
+		// Encode the literal value with type coercion.
+		litData, err := coerceLiteral(litExpr.Value, targetKind, byteSize)
+		if err != nil {
+			return ir.Expression{}, err
+		}
+		ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
+
+		// Compare base values.
+		ops = append(ops, &ir.ExprCmpEqBaseOp{ByteSize: uint8(byteSize)})
+	} else {
+		return ir.Expression{}, fmt.Errorf(
+			"eq: unsupported LHS type %T for equality comparison",
+			lhsType,
+		)
+	}
+
+	boolType := tc.typesByID[tc.boolType]
+	return ir.Expression{Type: boolType, Operations: ops}, nil
+}
+
+// resolveIsEmptyComparison resolves isEmpty(x) as len(x) == 0, returning a
+// bool-typed Expression without ConditionCheckOp.
+func resolveIsEmptyComparison(
+	ie *exprlang.IsEmptyExpr,
+	rootVar *ir.Variable,
+	tc *typeCatalog,
+) (ir.Expression, error) {
+	lenExpr, err := resolveLenExpression(ie.Operand, rootVar, tc)
+	if err != nil {
+		return ir.Expression{}, fmt.Errorf("failed to resolve isEmpty operand: %w", err)
+	}
+	zeroLit := &exprlang.LiteralExpr{Value: int64(0)}
+	return resolveEqComparison(lenExpr, zeroLit, tc)
+}
+
 // resolveCondition resolves a condition expression AST into an IR Expression
 // that evaluates to bool. Only eq comparisons with literal values are supported.
 func resolveCondition(
@@ -4015,79 +4119,12 @@ func resolveCondition(
 		)
 	}
 
-	lhsType := lhsExpr.Type
-	ops := lhsExpr.Operations
-
-	// Check if LHS is a string type.
-	if _, isString := lhsType.(*ir.GoStringHeaderType); isString {
-		// String equality comparison.
-		litStr, ok := litExpr.Value.(string)
-		if !ok {
-			return nil, fmt.Errorf(
-				"condition: string variable compared with non-string literal %T",
-				litExpr.Value,
-			)
-		}
-		if len(litStr) > ir.MaxStringLiteralLength {
-			return nil, fmt.Errorf(
-				"condition: string literal too long (%d bytes, max %d)",
-				len(litStr), ir.MaxStringLiteralLength,
-			)
-		}
-
-		// Read the string content from userspace.
-		ops = append(ops, &ir.ExprReadStringOp{MaxLen: ir.MaxStringLiteralLength})
-
-		// Load the literal as [u32 len][bytes...].
-		litData := make([]byte, 4+len(litStr))
-		binary.LittleEndian.PutUint32(litData[:4], uint32(len(litStr)))
-		copy(litData[4:], litStr)
-		ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
-
-		// Compare strings.
-		ops = append(ops, &ir.ExprCmpEqStringOp{})
-	} else if baseType, isBase := lhsType.(*ir.BaseType); isBase {
-		// Base type equality comparison.
-		byteSize := baseType.GetByteSize()
-		if byteSize > 8 {
-			return nil, fmt.Errorf(
-				"condition: base type too large for comparison (%d bytes)",
-				byteSize,
-			)
-		}
-
-		// Push LHS offset and advance.
-		ops = append(ops, &ir.ExprPushOffsetOp{ByteSize: uint32(byteSize)})
-
-		// Determine target kind for coercion.
-		targetKind := reflect.Invalid
-		if goKind, ok := baseType.GetGoKind(); ok {
-			targetKind = goKind
-		}
-
-		// Encode the literal value with type coercion.
-		litData, err := coerceLiteral(litExpr.Value, targetKind, byteSize)
-		if err != nil {
-			return nil, err
-		}
-		ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
-
-		// Compare base values.
-		ops = append(ops, &ir.ExprCmpEqBaseOp{ByteSize: uint8(byteSize)})
-	} else {
-		return nil, fmt.Errorf(
-			"condition: unsupported LHS type %T for equality comparison",
-			lhsType,
-		)
+	expr, err := resolveEqComparison(lhsExpr, litExpr, tc)
+	if err != nil {
+		return nil, err
 	}
-
-	// Check the result.
-	ops = append(ops, &ir.ConditionCheckOp{})
-
-	return &ir.Expression{
-		Type:       lhsType,
-		Operations: ops,
-	}, nil
+	expr.Operations = append(expr.Operations, &ir.ConditionCheckOp{})
+	return &expr, nil
 }
 
 // resolveIsEmptyCondition resolves an isEmpty condition: semantically len(x) == 0.
@@ -4096,37 +4133,12 @@ func resolveIsEmptyCondition(
 	rootVar *ir.Variable,
 	tc *typeCatalog,
 ) (*ir.Expression, error) {
-	// Resolve the operand to get the length value.
-	lenExpr, err := resolveLenExpression(ie.Operand, rootVar, tc)
+	expr, err := resolveIsEmptyComparison(ie, rootVar, tc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to resolve isEmpty operand: %w", err)
+		return nil, err
 	}
-
-	baseType, ok := lenExpr.Type.(*ir.BaseType)
-	if !ok {
-		return nil, fmt.Errorf("isEmpty: resolved len type is %T, expected BaseType", lenExpr.Type)
-	}
-
-	byteSize := baseType.GetByteSize()
-	ops := lenExpr.Operations
-
-	// Push offset for the length value.
-	ops = append(ops, &ir.ExprPushOffsetOp{ByteSize: uint32(byteSize)})
-
-	// Load literal zero of the same size.
-	litData := make([]byte, byteSize)
-	ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
-
-	// Compare: len == 0.
-	ops = append(ops, &ir.ExprCmpEqBaseOp{ByteSize: uint8(byteSize)})
-
-	// Check the result.
-	ops = append(ops, &ir.ConditionCheckOp{})
-
-	return &ir.Expression{
-		Type:       lenExpr.Type,
-		Operations: ops,
-	}, nil
+	expr.Operations = append(expr.Operations, &ir.ConditionCheckOp{})
+	return &expr, nil
 }
 
 func populateProbeEventsExpressions(

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -4183,7 +4183,7 @@ func populateEventExpressions(
 			Expression: resolvedExpr,
 		})
 	}
-	presenceBitsetSize := uint32((len(expressions) + 7) / 8)
+	presenceBitsetSize := uint32((2*len(expressions) + 7) / 8)
 	byteSize := uint64(presenceBitsetSize)
 	for _, e := range expressions {
 		e.Offset = uint32(byteSize)

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -524,6 +524,10 @@ func extractRootVariableName(expr exprlang.Expr) (string, bool) {
 			return e.Ref, true
 		case *exprlang.GetMemberExpr:
 			expr = e.Base
+		case *exprlang.LenExpr:
+			expr = e.Operand
+		case *exprlang.IsEmptyExpr:
+			expr = e.Operand
 		default:
 			return "", false
 		}
@@ -827,14 +831,19 @@ func analyzeAllProbes(
 					Message: fmt.Sprintf("failed to parse condition: %v", err),
 				}
 			}
-			eqExpr, ok := condExpr.(*exprlang.EqExpr)
-			if !ok {
+			var rootExpr exprlang.Expr
+			switch ce := condExpr.(type) {
+			case *exprlang.EqExpr:
+				rootExpr = ce.Left
+			case *exprlang.IsEmptyExpr:
+				rootExpr = ce.Operand
+			default:
 				return nil, ir.Issue{
 					Kind:    ir.IssueKindUnsupportedFeature,
 					Message: fmt.Sprintf("unsupported condition expression type: %T", condExpr),
 				}
 			}
-			rootVarName, ok := extractRootVariableName(eqExpr.Left)
+			rootVarName, ok := extractRootVariableName(rootExpr)
 			if !ok {
 				return nil, ir.Issue{
 					Kind:    ir.IssueKindUnsupportedFeature,
@@ -914,6 +923,8 @@ func newTemplate(td ir.TemplateDefinition) *ir.Template {
 						continue
 					}
 				case *exprlang.GetMemberExpr:
+				case *exprlang.LenExpr:
+				case *exprlang.IsEmptyExpr:
 				case *exprlang.UnsupportedExpr:
 					msg := "unsupported operation: " + expr.Operation
 					addInvalid(segment, msg)
@@ -3166,21 +3177,29 @@ func exploreTypesForExpressions(
 
 		// Validate condition types.
 		if cond := ap.condition; cond != nil {
-			eqExpr, ok := cond.expr.(*exprlang.EqExpr)
-			if !ok {
+			var condExploreExpr exprlang.Expr
+			switch ce := cond.expr.(type) {
+			case *exprlang.EqExpr:
+				condExploreExpr = ce.Left
+			case *exprlang.IsEmptyExpr:
+				condExploreExpr = ce.Operand
+			default:
 				ap.conditionIssue = ir.Issue{
 					Kind:    ir.IssueKindUnsupportedFeature,
 					Message: fmt.Sprintf("unsupported condition expression type: %T", cond.expr),
 				}
 				ap.condition = nil
-			} else if _, err := exploreExpressionTypes(
-				eqExpr.Left, cond.rootVariable.Type, tc, "",
-			); err != nil {
-				ap.conditionIssue = ir.Issue{
-					Kind:    ir.IssueKindConditionExpressionUnresolvable,
-					Message: fmt.Sprintf("condition type exploration failed: %v", err),
+			}
+			if condExploreExpr != nil {
+				if _, err := exploreExpressionTypes(
+					condExploreExpr, cond.rootVariable.Type, tc, "",
+				); err != nil {
+					ap.conditionIssue = ir.Issue{
+						Kind:    ir.IssueKindConditionExpressionUnresolvable,
+						Message: fmt.Sprintf("condition type exploration failed: %v", err),
+					}
+					ap.condition = nil
 				}
-				ap.condition = nil
 			}
 		}
 	}
@@ -3370,6 +3389,12 @@ func exploreExpressionTypes(
 		}
 
 		return curType, nil
+	case *exprlang.LenExpr:
+		return exploreLenExprTypes(e.Operand, currentType, tc, exprPath)
+
+	case *exprlang.IsEmptyExpr:
+		return exploreLenExprTypes(e.Operand, currentType, tc, exprPath)
+
 	case *exprlang.EqExpr:
 		// Resolve the left and right expressions.
 		_, err := exploreExpressionTypes(e.Left, currentType, tc, exprPath)
@@ -3387,6 +3412,81 @@ func exploreExpressionTypes(
 	default:
 		// Unknown expression type - nothing to explore.
 		return currentType, nil
+	}
+}
+
+// exploreLenExprTypes explores types for a len/isEmpty operand, resolving
+// through pointers and validating the collection type has a length field.
+func exploreLenExprTypes(
+	operand exprlang.Expr,
+	currentType ir.Type,
+	tc *typeCatalog,
+	exprPath string,
+) (ir.Type, error) {
+	// Explore the operand to resolve its type.
+	resolvedType, err := exploreExpressionTypes(operand, currentType, tc, exprPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Look up the canonical type from the catalog (may have been promoted
+	// from StructureType to GoStringHeaderType etc. by completeGoTypes).
+	resolvedType = tc.typesByID[resolvedType.GetID()]
+
+	// If result is a pointer, dereference to get the collection type.
+	if ptrType, ok := resolvedType.(*ir.PointerType); ok {
+		pointee := ptrType.Pointee
+		pointee = tc.typesByID[pointee.GetID()]
+		if ppt, ok := pointee.(*pointeePlaceholderType); ok {
+			newT, err := tc.addType(ppt.offset)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve pointee for len: %w", err)
+			}
+			resolvedType = newT
+		} else {
+			resolvedType = pointee
+		}
+	}
+
+	// Get the struct and field for the length.
+	structType, fieldName, err := lenFieldInfo(resolvedType)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := field(tc, structType, fieldName)
+	if err != nil {
+		return nil, fmt.Errorf("len field lookup failed: %w", err)
+	}
+	return f.Type, nil
+}
+
+// lenFieldInfo maps a collection type to the struct and field name containing
+// its length.
+func lenFieldInfo(typ ir.Type) (*ir.StructureType, string, error) {
+	switch t := typ.(type) {
+	case *ir.GoStringHeaderType:
+		return t.StructureType, "len", nil
+	case *ir.GoSliceHeaderType:
+		return t.StructureType, "len", nil
+	case *ir.GoHMapHeaderType:
+		return t.StructureType, "count", nil
+	case *ir.GoSwissMapHeaderType:
+		return t.StructureType, "used", nil
+	default:
+		var kindString string
+		if kind, ok := typ.GetGoKind(); ok {
+			kindString = kind.String()
+		} else {
+			// It's not clear how one could get here, but just in case
+			// we'll state the name of internal ir type. It might help
+			// debug the situation.
+			kindString = reflect.TypeOf(typ).Name()
+		}
+		return nil, "", fmt.Errorf(
+			"len/isEmpty not supported on type %q (%s)",
+			typ.GetName(), kindString,
+		)
 	}
 }
 
@@ -3572,11 +3672,79 @@ func resolveExpression(
 			Operations: operations,
 		}, nil
 
+	case *exprlang.LenExpr:
+		return resolveLenExpression(e.Operand, rootVar, tc)
+
+	case *exprlang.IsEmptyExpr:
+		return resolveLenExpression(e.Operand, rootVar, tc)
+
 	default:
 		return ir.Expression{}, fmt.Errorf(
 			"unsupported expression type: %T", expr,
 		)
 	}
+}
+
+// resolveLenExpression resolves a len/isEmpty operand to an IR expression
+// that reads the length field from the collection header.
+func resolveLenExpression(
+	operand exprlang.Expr,
+	rootVar *ir.Variable,
+	tc *typeCatalog,
+) (ir.Expression, error) {
+	// Resolve the operand expression.
+	baseExpr, err := resolveExpression(operand, rootVar, tc)
+	if err != nil {
+		return ir.Expression{}, fmt.Errorf("failed to resolve len operand: %w", err)
+	}
+
+	currentType := tc.typesByID[baseExpr.Type.GetID()]
+	operations := baseExpr.Operations
+
+	// If the resolved type is a pointer to a collection, dereference it.
+	if _, ok := currentType.(*ir.PointerType); ok {
+		pointee, err := resolvePointeeType[ir.Type](tc, currentType)
+		if err != nil {
+			return ir.Expression{}, fmt.Errorf("failed to resolve pointee for len: %w", err)
+		}
+
+		pointeeSize := pointee.GetByteSize()
+		operations = append(operations, &ir.DereferenceOp{
+			Bias:     0,
+			ByteSize: pointeeSize,
+		})
+		currentType = tc.typesByID[pointee.GetID()]
+	}
+
+	// Look up the length field info.
+	structType, fieldName, err := lenFieldInfo(currentType)
+	if err != nil {
+		return ir.Expression{}, err
+	}
+
+	f, err := field(tc, structType, fieldName)
+	if err != nil {
+		return ir.Expression{}, fmt.Errorf("len field %q not found: %w", fieldName, err)
+	}
+
+	// Adjust the operations to read just the length field.
+	// This follows the same pattern as GetMemberExpr field access.
+	if len(operations) >= 1 {
+		lastOp := operations[len(operations)-1]
+		switch op := lastOp.(type) {
+		case *ir.LocationOp:
+			op.Offset += f.Offset
+			op.ByteSize = f.Type.GetByteSize()
+		case *ir.DereferenceOp:
+			op.Bias += f.Offset
+			op.ByteSize = f.Type.GetByteSize()
+		}
+	}
+
+	return ir.Expression{
+		Type:       f.Type,
+		Operations: operations,
+	}, nil
 }
 
 // coerceLiteral encodes a literal value into bytes matching the target type's
@@ -3775,6 +3943,11 @@ func resolveCondition(
 	rootVar *ir.Variable,
 	tc *typeCatalog,
 ) (*ir.Expression, error) {
+	// Handle isEmpty as a standalone condition: semantically len(x) == 0.
+	if ie, ok := condExpr.(*exprlang.IsEmptyExpr); ok {
+		return resolveIsEmptyCondition(ie, rootVar, tc)
+	}
+
 	eqExpr, ok := condExpr.(*exprlang.EqExpr)
 	if !ok {
 		return nil, fmt.Errorf("unsupported condition expression type: %T", condExpr)
@@ -3866,6 +4039,45 @@ func resolveCondition(
 
 	return &ir.Expression{
 		Type:       lhsType,
+		Operations: ops,
+	}, nil
+}
+
+// resolveIsEmptyCondition resolves an isEmpty condition: semantically len(x) == 0.
+func resolveIsEmptyCondition(
+	ie *exprlang.IsEmptyExpr,
+	rootVar *ir.Variable,
+	tc *typeCatalog,
+) (*ir.Expression, error) {
+	// Resolve the operand to get the length value.
+	lenExpr, err := resolveLenExpression(ie.Operand, rootVar, tc)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve isEmpty operand: %w", err)
+	}
+
+	baseType, ok := lenExpr.Type.(*ir.BaseType)
+	if !ok {
+		return nil, fmt.Errorf("isEmpty: resolved len type is %T, expected BaseType", lenExpr.Type)
+	}
+
+	byteSize := baseType.GetByteSize()
+	ops := lenExpr.Operations
+
+	// Push offset for the length value.
+	ops = append(ops, &ir.ExprPushOffsetOp{ByteSize: uint32(byteSize)})
+
+	// Load literal zero of the same size.
+	litData := make([]byte, byteSize)
+	ops = append(ops, &ir.ExprLoadLiteralOp{Data: litData})
+
+	// Compare: len == 0.
+	ops = append(ops, &ir.ExprCmpEqBaseOp{ByteSize: uint8(byteSize)})
+
+	// Check the result.
+	ops = append(ops, &ir.ConditionCheckOp{})
+
+	return &ir.Expression{
+		Type:       lenExpr.Type,
 		Operations: ops,
 	}, nil
 }

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0xd04a4f"
               Frameless: false
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1361 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0xd0aba0", Frameless: true}]
           Condition:
-            Type: 11 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -12084,11 +12084,11 @@ Types:
     - __kind: EventRootType
       ID: 1168
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12098,7 +12098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12108,7 +12108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12118,7 +12118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
@@ -12128,7 +12128,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
@@ -12942,11 +12942,11 @@ Types:
     - __kind: EventRootType
       ID: 1309
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -12956,7 +12956,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12966,7 +12966,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -12976,7 +12976,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12986,7 +12986,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -12996,7 +12996,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13006,7 +13006,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13016,7 +13016,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13026,7 +13026,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13036,7 +13036,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13046,7 +13046,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13056,7 +13056,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13066,7 +13066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13076,7 +13076,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13086,7 +13086,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13096,7 +13096,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13106,7 +13106,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13116,7 +13116,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13716,11 +13716,11 @@ Types:
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13730,7 +13730,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13740,7 +13740,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13750,7 +13750,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13760,7 +13760,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13770,7 +13770,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13780,7 +13780,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13790,7 +13790,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13800,7 +13800,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13810,7 +13810,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13820,7 +13820,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13830,7 +13830,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13840,7 +13840,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13850,7 +13850,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13860,7 +13860,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13870,7 +13870,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13880,7 +13880,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -13890,7 +13890,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14198,11 +14198,11 @@ Types:
     - __kind: EventRootType
       ID: 1264
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -14212,7 +14212,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14222,7 +14222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14232,7 +14232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -14242,7 +14242,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14252,7 +14252,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14342,11 +14342,11 @@ Types:
     - __kind: EventRootType
       ID: 1231
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14356,7 +14356,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14366,7 +14366,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14376,7 +14376,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14386,7 +14386,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -14396,7 +14396,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -14406,7 +14406,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 15 BaseType uint
@@ -14416,7 +14416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 15 BaseType uint
@@ -14426,7 +14426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14436,7 +14436,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14707,11 +14707,11 @@ Types:
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 14 BaseType int8
@@ -14721,7 +14721,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 14 BaseType int8
@@ -14731,7 +14731,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14741,7 +14741,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14751,7 +14751,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 15 BaseType uint
@@ -14761,7 +14761,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 15 BaseType uint
@@ -15077,11 +15077,11 @@ Types:
     - __kind: EventRootType
       ID: 1290
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15091,7 +15091,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15101,7 +15101,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15111,7 +15111,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15121,7 +15121,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15131,7 +15131,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15141,7 +15141,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15151,7 +15151,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15161,7 +15161,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 11 GoStringHeaderType string
@@ -15473,11 +15473,11 @@ Types:
     - __kind: EventRootType
       ID: 1276
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15487,7 +15487,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15497,7 +15497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15507,7 +15507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15517,7 +15517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15527,7 +15527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15537,7 +15537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15547,7 +15547,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15557,7 +15557,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15567,7 +15567,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15577,7 +15577,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15587,7 +15587,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15597,7 +15597,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15607,7 +15607,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15617,7 +15617,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15627,7 +15627,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15637,7 +15637,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15671,11 +15671,11 @@ Types:
     - __kind: EventRootType
       ID: 1294
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15685,7 +15685,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15695,7 +15695,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15705,7 +15705,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15715,7 +15715,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 11 GoStringHeaderType string
@@ -15778,11 +15778,11 @@ Types:
     - __kind: EventRootType
       ID: 1274
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 14 BaseType int8
@@ -15792,7 +15792,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 97 BaseType int16
@@ -15802,7 +15802,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 12 BaseType int32
@@ -15812,7 +15812,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 13 BaseType int64
@@ -15822,7 +15822,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -15832,7 +15832,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType uint16
@@ -15842,7 +15842,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -15852,7 +15852,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 10 BaseType uint64
@@ -16903,11 +16903,11 @@ Types:
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16917,7 +16917,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16927,7 +16927,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16937,7 +16937,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16947,7 +16947,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16957,7 +16957,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16969,11 +16969,11 @@ Types:
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -16983,7 +16983,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -16993,7 +16993,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17003,7 +17003,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17013,7 +17013,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17023,7 +17023,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17190,11 +17190,11 @@ Types:
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17204,7 +17204,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17214,7 +17214,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17224,7 +17224,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17234,7 +17234,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17244,7 +17244,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -12389,11 +12389,11 @@ Types:
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12403,7 +12403,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12413,7 +12413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12423,7 +12423,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
@@ -12433,7 +12433,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
@@ -13247,11 +13247,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13261,7 +13261,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13271,7 +13271,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13281,7 +13281,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13291,7 +13291,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13301,7 +13301,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13311,7 +13311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13321,7 +13321,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13331,7 +13331,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13341,7 +13341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13351,7 +13351,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13361,7 +13361,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13371,7 +13371,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13381,7 +13381,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13391,7 +13391,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13401,7 +13401,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13411,7 +13411,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13421,7 +13421,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14021,11 +14021,11 @@ Types:
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14035,7 +14035,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14045,7 +14045,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14055,7 +14055,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14065,7 +14065,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14075,7 +14075,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14085,7 +14085,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14095,7 +14095,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14105,7 +14105,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14115,7 +14115,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14125,7 +14125,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14135,7 +14135,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14145,7 +14145,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14155,7 +14155,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14165,7 +14165,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14175,7 +14175,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14185,7 +14185,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14195,7 +14195,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14503,11 +14503,11 @@ Types:
     - __kind: EventRootType
       ID: 1439
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14517,7 +14517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14527,7 +14527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14537,7 +14537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14547,7 +14547,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14557,7 +14557,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14647,11 +14647,11 @@ Types:
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14661,7 +14661,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14671,7 +14671,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14681,7 +14681,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14691,7 +14691,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 10 BaseType int32
@@ -14701,7 +14701,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14711,7 +14711,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 16 BaseType uint
@@ -14721,7 +14721,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 16 BaseType uint
@@ -14731,7 +14731,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14741,7 +14741,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15012,11 +15012,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 15 BaseType int8
@@ -15026,7 +15026,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 15 BaseType int8
@@ -15036,7 +15036,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15046,7 +15046,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15056,7 +15056,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 16 BaseType uint
@@ -15066,7 +15066,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 16 BaseType uint
@@ -15382,11 +15382,11 @@ Types:
     - __kind: EventRootType
       ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15396,7 +15396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15406,7 +15406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15416,7 +15416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15426,7 +15426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15436,7 +15436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15446,7 +15446,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15456,7 +15456,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15466,7 +15466,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15778,11 +15778,11 @@ Types:
     - __kind: EventRootType
       ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15792,7 +15792,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15802,7 +15802,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15812,7 +15812,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15822,7 +15822,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15832,7 +15832,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15842,7 +15842,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15852,7 +15852,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15862,7 +15862,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15872,7 +15872,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15882,7 +15882,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15892,7 +15892,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15902,7 +15902,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15912,7 +15912,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15922,7 +15922,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15932,7 +15932,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15942,7 +15942,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -15976,11 +15976,11 @@ Types:
     - __kind: EventRootType
       ID: 1469
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15990,7 +15990,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16000,7 +16000,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16010,7 +16010,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16020,7 +16020,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16083,11 +16083,11 @@ Types:
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 15 BaseType int8
@@ -16097,7 +16097,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 102 BaseType int16
@@ -16107,7 +16107,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 10 BaseType int32
@@ -16117,7 +16117,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 12 BaseType int64
@@ -16127,7 +16127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16137,7 +16137,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16147,7 +16147,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16157,7 +16157,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17208,11 +17208,11 @@ Types:
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17222,7 +17222,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17232,7 +17232,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17242,7 +17242,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17252,7 +17252,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17262,7 +17262,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17274,11 +17274,11 @@ Types:
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17288,7 +17288,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17298,7 +17298,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17308,7 +17308,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17318,7 +17318,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17328,7 +17328,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17495,11 +17495,11 @@ Types:
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17509,7 +17509,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17519,7 +17519,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17529,7 +17529,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17539,7 +17539,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17549,7 +17549,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0xcd5d6f"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1536 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0xcdbfe0", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -12446,11 +12446,11 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12460,7 +12460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12470,7 +12470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12480,7 +12480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 13 GoInterfaceType error
@@ -12490,7 +12490,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
@@ -13304,11 +13304,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13318,7 +13318,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13328,7 +13328,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13338,7 +13338,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13348,7 +13348,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13358,7 +13358,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13368,7 +13368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13378,7 +13378,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13388,7 +13388,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13398,7 +13398,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13408,7 +13408,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13418,7 +13418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13428,7 +13428,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13438,7 +13438,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13448,7 +13448,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13458,7 +13458,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13468,7 +13468,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13478,7 +13478,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14078,11 +14078,11 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14092,7 +14092,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14102,7 +14102,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14112,7 +14112,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14122,7 +14122,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14132,7 +14132,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14142,7 +14142,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14152,7 +14152,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14162,7 +14162,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14172,7 +14172,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14182,7 +14182,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14192,7 +14192,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14202,7 +14202,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14212,7 +14212,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14222,7 +14222,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14232,7 +14232,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14242,7 +14242,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14252,7 +14252,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14560,11 +14560,11 @@ Types:
     - __kind: EventRootType
       ID: 1458
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14574,7 +14574,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14584,7 +14584,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14594,7 +14594,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14604,7 +14604,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14614,7 +14614,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14704,11 +14704,11 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14718,7 +14718,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14728,7 +14728,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14738,7 +14738,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14748,7 +14748,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 10 BaseType int32
@@ -14758,7 +14758,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14768,7 +14768,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 17 BaseType uint
@@ -14778,7 +14778,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 17 BaseType uint
@@ -14788,7 +14788,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14798,7 +14798,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15069,11 +15069,11 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 16 BaseType int8
@@ -15083,7 +15083,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 16 BaseType int8
@@ -15093,7 +15093,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15103,7 +15103,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15113,7 +15113,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 17 BaseType uint
@@ -15123,7 +15123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 17 BaseType uint
@@ -15439,11 +15439,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15453,7 +15453,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15463,7 +15463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15473,7 +15473,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15483,7 +15483,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15493,7 +15493,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15503,7 +15503,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15513,7 +15513,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15523,7 +15523,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15835,11 +15835,11 @@ Types:
     - __kind: EventRootType
       ID: 1470
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15849,7 +15849,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15859,7 +15859,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15869,7 +15869,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15879,7 +15879,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15889,7 +15889,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15899,7 +15899,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15909,7 +15909,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15919,7 +15919,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15929,7 +15929,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15939,7 +15939,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15949,7 +15949,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15959,7 +15959,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15969,7 +15969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15979,7 +15979,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15989,7 +15989,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -15999,7 +15999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -16033,11 +16033,11 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16047,7 +16047,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -16057,7 +16057,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16067,7 +16067,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 15 BaseType float64
@@ -16077,7 +16077,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16140,11 +16140,11 @@ Types:
     - __kind: EventRootType
       ID: 1468
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 16 BaseType int8
@@ -16154,7 +16154,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 104 BaseType int16
@@ -16164,7 +16164,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 10 BaseType int32
@@ -16174,7 +16174,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 12 BaseType int64
@@ -16184,7 +16184,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16194,7 +16194,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16204,7 +16204,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16214,7 +16214,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17265,11 +17265,11 @@ Types:
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17279,7 +17279,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17289,7 +17289,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17299,7 +17299,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17309,7 +17309,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17319,7 +17319,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17331,11 +17331,11 @@ Types:
     - __kind: EventRootType
       ID: 1543
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17345,7 +17345,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17355,7 +17355,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17365,7 +17365,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17375,7 +17375,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17385,7 +17385,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17552,11 +17552,11 @@ Types:
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17566,7 +17566,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17576,7 +17576,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17586,7 +17586,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17596,7 +17596,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17606,7 +17606,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0xcda64f"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1555 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0xce0800", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -12430,11 +12430,11 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12444,7 +12444,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12454,7 +12454,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12464,7 +12464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 15 GoInterfaceType error
@@ -12474,7 +12474,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
@@ -13308,11 +13308,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13322,7 +13322,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13332,7 +13332,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13342,7 +13342,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13352,7 +13352,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13362,7 +13362,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13372,7 +13372,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13382,7 +13382,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13392,7 +13392,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13402,7 +13402,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13412,7 +13412,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13422,7 +13422,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13432,7 +13432,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13442,7 +13442,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13452,7 +13452,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13462,7 +13462,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13472,7 +13472,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13482,7 +13482,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14082,11 +14082,11 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14096,7 +14096,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14106,7 +14106,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14116,7 +14116,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14126,7 +14126,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14136,7 +14136,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14146,7 +14146,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14156,7 +14156,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14166,7 +14166,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14176,7 +14176,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14186,7 +14186,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14196,7 +14196,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14206,7 +14206,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14216,7 +14216,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14226,7 +14226,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14236,7 +14236,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14246,7 +14246,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14256,7 +14256,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14564,11 +14564,11 @@ Types:
     - __kind: EventRootType
       ID: 1458
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14578,7 +14578,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14588,7 +14588,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14598,7 +14598,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14608,7 +14608,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14618,7 +14618,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14708,11 +14708,11 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14722,7 +14722,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14732,7 +14732,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14742,7 +14742,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14752,7 +14752,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 10 BaseType int32
@@ -14762,7 +14762,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14772,7 +14772,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 14 BaseType uint
@@ -14782,7 +14782,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 14 BaseType uint
@@ -14792,7 +14792,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14802,7 +14802,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15073,11 +15073,11 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 20 BaseType int8
@@ -15087,7 +15087,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 20 BaseType int8
@@ -15097,7 +15097,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15107,7 +15107,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15117,7 +15117,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 14 BaseType uint
@@ -15127,7 +15127,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 14 BaseType uint
@@ -15443,11 +15443,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15457,7 +15457,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15467,7 +15467,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15477,7 +15477,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15487,7 +15487,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15497,7 +15497,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15507,7 +15507,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15517,7 +15517,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15527,7 +15527,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15839,11 +15839,11 @@ Types:
     - __kind: EventRootType
       ID: 1470
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15853,7 +15853,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15863,7 +15863,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15873,7 +15873,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15883,7 +15883,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15893,7 +15893,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15903,7 +15903,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15913,7 +15913,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15923,7 +15923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15933,7 +15933,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15943,7 +15943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15953,7 +15953,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15963,7 +15963,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15973,7 +15973,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15983,7 +15983,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -15993,7 +15993,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -16003,7 +16003,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -16037,11 +16037,11 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16051,7 +16051,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -16061,7 +16061,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16071,7 +16071,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 13 BaseType float64
@@ -16081,7 +16081,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16144,11 +16144,11 @@ Types:
     - __kind: EventRootType
       ID: 1468
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 20 BaseType int8
@@ -16158,7 +16158,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 109 BaseType int16
@@ -16168,7 +16168,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 10 BaseType int32
@@ -16178,7 +16178,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 12 BaseType int64
@@ -16188,7 +16188,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16198,7 +16198,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16208,7 +16208,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16218,7 +16218,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17260,11 +17260,11 @@ Types:
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17274,7 +17274,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17284,7 +17284,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17294,7 +17294,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17304,7 +17304,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17314,7 +17314,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17326,11 +17326,11 @@ Types:
     - __kind: EventRootType
       ID: 1541
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17340,7 +17340,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17350,7 +17350,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17360,7 +17360,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17370,7 +17370,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17380,7 +17380,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17541,11 +17541,11 @@ Types:
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17555,7 +17555,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17565,7 +17565,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17575,7 +17575,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17585,7 +17585,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17595,7 +17595,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -382,7 +382,7 @@ Probes:
             - PC: "0xce69cf"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -492,7 +492,7 @@ Probes:
           Type: 1550 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0xcecb20", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0x88da3c"
               Frameless: false
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1361 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0x892e40", Frameless: true}]
           Condition:
-            Type: 11 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -12322,11 +12322,11 @@ Types:
     - __kind: EventRootType
       ID: 1168
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12336,7 +12336,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12346,7 +12346,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12356,7 +12356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 18 GoInterfaceType error
@@ -12366,7 +12366,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
@@ -13180,11 +13180,11 @@ Types:
     - __kind: EventRootType
       ID: 1309
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13194,7 +13194,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13204,7 +13204,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13214,7 +13214,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13224,7 +13224,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13234,7 +13234,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13244,7 +13244,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13254,7 +13254,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13264,7 +13264,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13274,7 +13274,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13284,7 +13284,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13294,7 +13294,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13304,7 +13304,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13314,7 +13314,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13324,7 +13324,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13334,7 +13334,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13344,7 +13344,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13354,7 +13354,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13954,11 +13954,11 @@ Types:
     - __kind: EventRootType
       ID: 1311
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13968,7 +13968,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13978,7 +13978,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -13988,7 +13988,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13998,7 +13998,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14008,7 +14008,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14018,7 +14018,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14028,7 +14028,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14038,7 +14038,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14048,7 +14048,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14058,7 +14058,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14068,7 +14068,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14078,7 +14078,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14088,7 +14088,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14098,7 +14098,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 9 BaseType int
@@ -14108,7 +14108,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14118,7 +14118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14128,7 +14128,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14436,11 +14436,11 @@ Types:
     - __kind: EventRootType
       ID: 1264
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -14450,7 +14450,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14460,7 +14460,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14470,7 +14470,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -14480,7 +14480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14490,7 +14490,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14580,11 +14580,11 @@ Types:
     - __kind: EventRootType
       ID: 1231
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14594,7 +14594,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14604,7 +14604,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14614,7 +14614,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14624,7 +14624,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 13 BaseType int32
@@ -14634,7 +14634,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 13 BaseType int32
@@ -14644,7 +14644,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 12 BaseType uint
@@ -14654,7 +14654,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 12 BaseType uint
@@ -14664,7 +14664,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14674,7 +14674,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -14945,11 +14945,11 @@ Types:
     - __kind: EventRootType
       ID: 1328
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 15 BaseType int8
@@ -14959,7 +14959,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 15 BaseType int8
@@ -14969,7 +14969,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14979,7 +14979,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14989,7 +14989,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 12 BaseType uint
@@ -14999,7 +14999,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 12 BaseType uint
@@ -15315,11 +15315,11 @@ Types:
     - __kind: EventRootType
       ID: 1290
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15329,7 +15329,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15339,7 +15339,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15349,7 +15349,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15359,7 +15359,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15369,7 +15369,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15379,7 +15379,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15389,7 +15389,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15399,7 +15399,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 11 GoStringHeaderType string
@@ -15711,11 +15711,11 @@ Types:
     - __kind: EventRootType
       ID: 1276
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15725,7 +15725,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15735,7 +15735,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15745,7 +15745,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15755,7 +15755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15765,7 +15765,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15775,7 +15775,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15785,7 +15785,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15795,7 +15795,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15805,7 +15805,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15815,7 +15815,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15825,7 +15825,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15835,7 +15835,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15845,7 +15845,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15855,7 +15855,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15865,7 +15865,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15875,7 +15875,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15909,11 +15909,11 @@ Types:
     - __kind: EventRootType
       ID: 1294
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15923,7 +15923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15933,7 +15933,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -15943,7 +15943,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 17 BaseType float64
@@ -15953,7 +15953,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 11 GoStringHeaderType string
@@ -16016,11 +16016,11 @@ Types:
     - __kind: EventRootType
       ID: 1274
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 15 BaseType int8
@@ -16030,7 +16030,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 89 BaseType int16
@@ -16040,7 +16040,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 13 BaseType int32
@@ -16050,7 +16050,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 14 BaseType int64
@@ -16060,7 +16060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16070,7 +16070,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType uint16
@@ -16080,7 +16080,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16090,7 +16090,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 10 BaseType uint64
@@ -17141,11 +17141,11 @@ Types:
     - __kind: EventRootType
       ID: 1333
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17155,7 +17155,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17165,7 +17165,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17175,7 +17175,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17185,7 +17185,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17195,7 +17195,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17207,11 +17207,11 @@ Types:
     - __kind: EventRootType
       ID: 1349
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17221,7 +17221,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17231,7 +17231,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17241,7 +17241,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17251,7 +17251,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17261,7 +17261,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17428,11 +17428,11 @@ Types:
     - __kind: EventRootType
       ID: 1337
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17442,7 +17442,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17452,7 +17452,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17462,7 +17462,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17472,7 +17472,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17482,7 +17482,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -12627,11 +12627,11 @@ Types:
     - __kind: EventRootType
       ID: 1343
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12641,7 +12641,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12651,7 +12651,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12661,7 +12661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
@@ -12671,7 +12671,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 14 GoInterfaceType error
@@ -13485,11 +13485,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13499,7 +13499,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13509,7 +13509,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13519,7 +13519,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13529,7 +13529,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13539,7 +13539,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13549,7 +13549,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13559,7 +13559,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13569,7 +13569,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13579,7 +13579,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13589,7 +13589,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13599,7 +13599,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13609,7 +13609,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13619,7 +13619,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13629,7 +13629,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13639,7 +13639,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13649,7 +13649,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13659,7 +13659,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14259,11 +14259,11 @@ Types:
     - __kind: EventRootType
       ID: 1486
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14273,7 +14273,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14283,7 +14283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14293,7 +14293,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14303,7 +14303,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14313,7 +14313,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14323,7 +14323,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14333,7 +14333,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14343,7 +14343,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14353,7 +14353,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14363,7 +14363,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14373,7 +14373,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14383,7 +14383,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14393,7 +14393,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14403,7 +14403,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14413,7 +14413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14423,7 +14423,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14433,7 +14433,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14741,11 +14741,11 @@ Types:
     - __kind: EventRootType
       ID: 1439
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14755,7 +14755,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14765,7 +14765,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14775,7 +14775,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14785,7 +14785,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14795,7 +14795,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14885,11 +14885,11 @@ Types:
     - __kind: EventRootType
       ID: 1406
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14899,7 +14899,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14909,7 +14909,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -14919,7 +14919,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -14929,7 +14929,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -14939,7 +14939,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -14949,7 +14949,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -14959,7 +14959,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -14969,7 +14969,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14979,7 +14979,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15250,11 +15250,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 16 BaseType int8
@@ -15264,7 +15264,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 16 BaseType int8
@@ -15274,7 +15274,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15284,7 +15284,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15294,7 +15294,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -15304,7 +15304,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -15620,11 +15620,11 @@ Types:
     - __kind: EventRootType
       ID: 1465
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15634,7 +15634,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15644,7 +15644,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15654,7 +15654,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15664,7 +15664,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15674,7 +15674,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15684,7 +15684,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15694,7 +15694,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15704,7 +15704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16016,11 +16016,11 @@ Types:
     - __kind: EventRootType
       ID: 1451
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16030,7 +16030,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16040,7 +16040,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16050,7 +16050,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16060,7 +16060,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16070,7 +16070,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16080,7 +16080,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16090,7 +16090,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16100,7 +16100,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16110,7 +16110,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16120,7 +16120,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16130,7 +16130,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16140,7 +16140,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16150,7 +16150,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16160,7 +16160,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16170,7 +16170,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16180,7 +16180,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16214,11 +16214,11 @@ Types:
     - __kind: EventRootType
       ID: 1469
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16228,7 +16228,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16238,7 +16238,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16248,7 +16248,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 18 BaseType float64
@@ -16258,7 +16258,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16321,11 +16321,11 @@ Types:
     - __kind: EventRootType
       ID: 1449
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 16 BaseType int8
@@ -16335,7 +16335,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 94 BaseType int16
@@ -16345,7 +16345,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 12 BaseType int32
@@ -16355,7 +16355,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 13 BaseType int64
@@ -16365,7 +16365,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16375,7 +16375,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16385,7 +16385,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16395,7 +16395,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17446,11 +17446,11 @@ Types:
     - __kind: EventRootType
       ID: 1508
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17460,7 +17460,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17470,7 +17470,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17480,7 +17480,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17490,7 +17490,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17500,7 +17500,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17512,11 +17512,11 @@ Types:
     - __kind: EventRootType
       ID: 1524
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17526,7 +17526,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17536,7 +17536,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17546,7 +17546,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17556,7 +17556,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17566,7 +17566,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17733,11 +17733,11 @@ Types:
     - __kind: EventRootType
       ID: 1512
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17747,7 +17747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17757,7 +17757,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17767,7 +17767,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17777,7 +17777,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17787,7 +17787,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0x84b13c"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1536 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0x850430", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -12720,11 +12720,11 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 58
-      PresenceBitsetSize: 1
+      ByteSize: 59
+      PresenceBitsetSize: 2
       Expressions:
         - Name: shouldErr
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 4 BaseType bool
@@ -12734,7 +12734,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12744,7 +12744,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12754,7 +12754,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 18
+          Offset: 19
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12764,7 +12764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 14 GoInterfaceType error
@@ -12774,7 +12774,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 42
+          Offset: 43
           Kind: template_segment
           Expression:
             Type: 14 GoInterfaceType error
@@ -13588,11 +13588,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13602,7 +13602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13612,7 +13612,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13622,7 +13622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13632,7 +13632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13642,7 +13642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13652,7 +13652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13662,7 +13662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13672,7 +13672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13682,7 +13682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13692,7 +13692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13702,7 +13702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13712,7 +13712,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13722,7 +13722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13732,7 +13732,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13742,7 +13742,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13752,7 +13752,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13762,7 +13762,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14362,11 +14362,11 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14376,7 +14376,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14386,7 +14386,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14396,7 +14396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14406,7 +14406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14416,7 +14416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14426,7 +14426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14436,7 +14436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14446,7 +14446,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14456,7 +14456,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14466,7 +14466,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14476,7 +14476,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14486,7 +14486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14496,7 +14496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14506,7 +14506,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14516,7 +14516,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14526,7 +14526,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14536,7 +14536,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14844,11 +14844,11 @@ Types:
     - __kind: EventRootType
       ID: 1458
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14858,7 +14858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14868,7 +14868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14878,7 +14878,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14888,7 +14888,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14898,7 +14898,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14988,11 +14988,11 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -15002,7 +15002,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -15012,7 +15012,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -15022,7 +15022,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -15032,7 +15032,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -15042,7 +15042,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -15052,7 +15052,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -15062,7 +15062,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -15072,7 +15072,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15082,7 +15082,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15353,11 +15353,11 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 17 BaseType int8
@@ -15367,7 +15367,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 17 BaseType int8
@@ -15377,7 +15377,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15387,7 +15387,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15397,7 +15397,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 10 BaseType uint
@@ -15407,7 +15407,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -15723,11 +15723,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15737,7 +15737,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15747,7 +15747,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15757,7 +15757,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15767,7 +15767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15777,7 +15777,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15787,7 +15787,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15797,7 +15797,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15807,7 +15807,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16119,11 +16119,11 @@ Types:
     - __kind: EventRootType
       ID: 1470
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16133,7 +16133,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16143,7 +16143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16153,7 +16153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16163,7 +16163,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16173,7 +16173,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16183,7 +16183,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16193,7 +16193,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16203,7 +16203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16213,7 +16213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16223,7 +16223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16233,7 +16233,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16243,7 +16243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16253,7 +16253,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16263,7 +16263,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16273,7 +16273,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16283,7 +16283,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16317,11 +16317,11 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16331,7 +16331,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16341,7 +16341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16351,7 +16351,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 16 BaseType float64
@@ -16361,7 +16361,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16424,11 +16424,11 @@ Types:
     - __kind: EventRootType
       ID: 1468
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 17 BaseType int8
@@ -16438,7 +16438,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 96 BaseType int16
@@ -16448,7 +16448,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 12 BaseType int32
@@ -16458,7 +16458,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 13 BaseType int64
@@ -16468,7 +16468,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16478,7 +16478,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16488,7 +16488,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16498,7 +16498,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17549,11 +17549,11 @@ Types:
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17563,7 +17563,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17573,7 +17573,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17583,7 +17583,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17593,7 +17593,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17603,7 +17603,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17615,11 +17615,11 @@ Types:
     - __kind: EventRootType
       ID: 1543
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17629,7 +17629,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17639,7 +17639,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17649,7 +17649,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17659,7 +17659,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17669,7 +17669,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17836,11 +17836,11 @@ Types:
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17850,7 +17850,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17860,7 +17860,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17870,7 +17870,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17880,7 +17880,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17890,7 +17890,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -390,7 +390,7 @@ Probes:
             - PC: "0x80791c"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -500,7 +500,7 @@ Probes:
           Type: 1555 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0x80c810", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -12690,11 +12690,11 @@ Types:
     - __kind: EventRootType
       ID: 1362
       Name: Probe[main.testErrorAtLine]Line
-      ByteSize: 57
-      PresenceBitsetSize: 1
+      ByteSize: 58
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12704,7 +12704,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12714,7 +12714,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12724,7 +12724,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: err
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 15 GoInterfaceType error
@@ -12734,7 +12734,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: err
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
@@ -13568,11 +13568,11 @@ Types:
     - __kind: EventRootType
       ID: 1503
       Name: Probe[main.testManyArgsArrayReturn]
-      ByteSize: 147
-      PresenceBitsetSize: 3
+      ByteSize: 149
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13582,7 +13582,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13592,7 +13592,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13602,7 +13602,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13612,7 +13612,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13622,7 +13622,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13632,7 +13632,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13642,7 +13642,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13652,7 +13652,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13662,7 +13662,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13672,7 +13672,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13682,7 +13682,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13692,7 +13692,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13702,7 +13702,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13712,7 +13712,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13722,7 +13722,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13732,7 +13732,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -13742,7 +13742,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 139
+          Offset: 141
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14342,11 +14342,11 @@ Types:
     - __kind: EventRootType
       ID: 1505
       Name: Probe[main.testMixedArgsStackReturn]
-      ByteSize: 163
-      PresenceBitsetSize: 3
+      ByteSize: 165
+      PresenceBitsetSize: 5
       Expressions:
         - Name: a
-          Offset: 3
+          Offset: 5
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14356,7 +14356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 11
+          Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14366,7 +14366,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 19
+          Offset: 21
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14376,7 +14376,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: b
-          Offset: 27
+          Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14386,7 +14386,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 35
+          Offset: 37
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14396,7 +14396,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: c
-          Offset: 43
+          Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14406,7 +14406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 51
+          Offset: 53
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14416,7 +14416,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 59
+          Offset: 61
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14426,7 +14426,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 67
+          Offset: 69
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14436,7 +14436,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 75
+          Offset: 77
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14446,7 +14446,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 83
+          Offset: 85
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14456,7 +14456,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: f
-          Offset: 91
+          Offset: 93
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14466,7 +14466,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 99
+          Offset: 101
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14476,7 +14476,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: g
-          Offset: 107
+          Offset: 109
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14486,7 +14486,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 115
+          Offset: 117
           Kind: argument
           Expression:
             Type: 7 BaseType int
@@ -14496,7 +14496,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: h
-          Offset: 123
+          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14506,7 +14506,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 131
+          Offset: 133
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14516,7 +14516,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: s
-          Offset: 147
+          Offset: 149
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -14824,11 +14824,11 @@ Types:
     - __kind: EventRootType
       ID: 1458
       Name: Probe[main.testMultipleNamedReturn]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: result
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14838,7 +14838,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 9
+          Offset: 10
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14848,7 +14848,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14858,7 +14858,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -14868,7 +14868,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 33
+          Offset: 34
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14878,7 +14878,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 41
+          Offset: 42
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14968,11 +14968,11 @@ Types:
     - __kind: EventRootType
       ID: 1425
       Name: Probe[main.testMultipleSimpleParams]
-      ByteSize: 62
-      PresenceBitsetSize: 2
+      ByteSize: 63
+      PresenceBitsetSize: 3
       Expressions:
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: argument
           Expression:
             Type: 4 BaseType bool
@@ -14982,7 +14982,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 3
+          Offset: 4
           Kind: template_segment
           Expression:
             Type: 4 BaseType bool
@@ -14992,7 +14992,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 4
+          Offset: 5
           Kind: argument
           Expression:
             Type: 3 BaseType uint8
@@ -15002,7 +15002,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: b
-          Offset: 5
+          Offset: 6
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -15012,7 +15012,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: c
-          Offset: 6
+          Offset: 7
           Kind: argument
           Expression:
             Type: 12 BaseType int32
@@ -15022,7 +15022,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: c
-          Offset: 10
+          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -15032,7 +15032,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 14
+          Offset: 15
           Kind: argument
           Expression:
             Type: 11 BaseType uint
@@ -15042,7 +15042,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: d
-          Offset: 22
+          Offset: 23
           Kind: template_segment
           Expression:
             Type: 11 BaseType uint
@@ -15052,7 +15052,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 30
+          Offset: 31
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15062,7 +15062,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: e
-          Offset: 46
+          Offset: 47
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -15333,11 +15333,11 @@ Types:
     - __kind: EventRootType
       ID: 1522
       Name: Probe[main.testNilSliceWithOtherParams]
-      ByteSize: 67
-      PresenceBitsetSize: 1
+      ByteSize: 68
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 19 BaseType int8
@@ -15347,7 +15347,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: a
-          Offset: 2
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 19 BaseType int8
@@ -15357,7 +15357,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 3
+          Offset: 4
           Kind: argument
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15367,7 +15367,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: s
-          Offset: 27
+          Offset: 28
           Kind: template_segment
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15377,7 +15377,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 51
+          Offset: 52
           Kind: argument
           Expression:
             Type: 11 BaseType uint
@@ -15387,7 +15387,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 59
+          Offset: 60
           Kind: template_segment
           Expression:
             Type: 11 BaseType uint
@@ -15703,11 +15703,11 @@ Types:
     - __kind: EventRootType
       ID: 1484
       Name: Probe[main.testReturnsBacktrackInt]Return
-      ByteSize: 82
-      PresenceBitsetSize: 2
+      ByteSize: 83
+      PresenceBitsetSize: 3
       Expressions:
         - Name: ~r0
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15717,7 +15717,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 10
+          Offset: 11
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15727,7 +15727,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 18
+          Offset: 19
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15737,7 +15737,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 26
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15747,7 +15747,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 34
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15757,7 +15757,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 42
+          Offset: 43
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15767,7 +15767,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 50
+          Offset: 51
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15777,7 +15777,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 58
+          Offset: 59
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -15787,7 +15787,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 66
+          Offset: 67
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16099,11 +16099,11 @@ Types:
     - __kind: EventRootType
       ID: 1470
       Name: Probe[main.testReturnsManyFloats]Return
-      ByteSize: 139
-      PresenceBitsetSize: 3
+      ByteSize: 141
+      PresenceBitsetSize: 5
       Expressions:
         - Name: ~r0
-          Offset: 3
+          Offset: 5
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16113,7 +16113,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 11
+          Offset: 13
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16123,7 +16123,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 19
+          Offset: 21
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16133,7 +16133,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 27
+          Offset: 29
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16143,7 +16143,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 35
+          Offset: 37
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16153,7 +16153,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r5
-          Offset: 43
+          Offset: 45
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16163,7 +16163,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r6
-          Offset: 51
+          Offset: 53
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16173,7 +16173,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r7
-          Offset: 59
+          Offset: 61
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16183,7 +16183,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r8
-          Offset: 67
+          Offset: 69
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16193,7 +16193,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r9
-          Offset: 75
+          Offset: 77
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16203,7 +16203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r10
-          Offset: 83
+          Offset: 85
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16213,7 +16213,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r11
-          Offset: 91
+          Offset: 93
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16223,7 +16223,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r12
-          Offset: 99
+          Offset: 101
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16233,7 +16233,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r13
-          Offset: 107
+          Offset: 109
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16243,7 +16243,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r14
-          Offset: 115
+          Offset: 117
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16253,7 +16253,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: onlyOnAmd64_16
-          Offset: 123
+          Offset: 125
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16263,7 +16263,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: bothArmAndAmd64
-          Offset: 131
+          Offset: 133
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16297,11 +16297,11 @@ Types:
     - __kind: EventRootType
       ID: 1488
       Name: Probe[main.testReturnsMixed]Return
-      ByteSize: 49
-      PresenceBitsetSize: 1
+      ByteSize: 50
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16311,7 +16311,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r1
-          Offset: 9
+          Offset: 10
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16321,7 +16321,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r2
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -16331,7 +16331,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r3
-          Offset: 25
+          Offset: 26
           Kind: local
           Expression:
             Type: 14 BaseType float64
@@ -16341,7 +16341,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 33
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 GoStringHeaderType string
@@ -16404,11 +16404,11 @@ Types:
     - __kind: EventRootType
       ID: 1468
       Name: Probe[main.testReturnsPrimitives]Return
-      ByteSize: 31
-      PresenceBitsetSize: 1
+      ByteSize: 32
+      PresenceBitsetSize: 2
       Expressions:
         - Name: ~r0
-          Offset: 1
+          Offset: 2
           Kind: local
           Expression:
             Type: 19 BaseType int8
@@ -16418,7 +16418,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r1
-          Offset: 2
+          Offset: 3
           Kind: local
           Expression:
             Type: 102 BaseType int16
@@ -16428,7 +16428,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r2
-          Offset: 4
+          Offset: 5
           Kind: local
           Expression:
             Type: 12 BaseType int32
@@ -16438,7 +16438,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r3
-          Offset: 8
+          Offset: 9
           Kind: local
           Expression:
             Type: 13 BaseType int64
@@ -16448,7 +16448,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: ~r4
-          Offset: 16
+          Offset: 17
           Kind: local
           Expression:
             Type: 3 BaseType uint8
@@ -16458,7 +16458,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r5
-          Offset: 17
+          Offset: 18
           Kind: local
           Expression:
             Type: 6 BaseType uint16
@@ -16468,7 +16468,7 @@ Types:
                   Offset: 0
                   ByteSize: 2
         - Name: ~r6
-          Offset: 19
+          Offset: 20
           Kind: local
           Expression:
             Type: 2 BaseType uint32
@@ -16478,7 +16478,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: ~r7
-          Offset: 23
+          Offset: 24
           Kind: local
           Expression:
             Type: 8 BaseType uint64
@@ -17520,11 +17520,11 @@ Types:
     - __kind: EventRootType
       ID: 1527
       Name: Probe[main.testSubslices]
-      ByteSize: 145
-      PresenceBitsetSize: 1
+      ByteSize: 146
+      PresenceBitsetSize: 2
       Expressions:
         - Name: as
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17534,7 +17534,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: as
-          Offset: 25
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17544,7 +17544,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 49
+          Offset: 50
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17554,7 +17554,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 73
+          Offset: 74
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17564,7 +17564,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 97
+          Offset: 98
           Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17574,7 +17574,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 121
+          Offset: 122
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17586,11 +17586,11 @@ Types:
     - __kind: EventRootType
       ID: 1541
       Name: Probe[main.testSubstrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: a
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17600,7 +17600,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: a
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17610,7 +17610,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17620,7 +17620,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17630,7 +17630,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17640,7 +17640,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17801,11 +17801,11 @@ Types:
     - __kind: EventRootType
       ID: 1531
       Name: Probe[main.testThreeStrings]
-      ByteSize: 97
-      PresenceBitsetSize: 1
+      ByteSize: 98
+      PresenceBitsetSize: 2
       Expressions:
         - Name: x
-          Offset: 1
+          Offset: 2
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17815,7 +17815,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: x
-          Offset: 17
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17825,7 +17825,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 33
+          Offset: 34
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17835,7 +17835,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 49
+          Offset: 50
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17845,7 +17845,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 65
+          Offset: 66
           Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17855,7 +17855,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 81
+          Offset: 82
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -382,7 +382,7 @@ Probes:
             - PC: "0x80406c"
               Frameless: false
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 160, index: 0, name: x}
@@ -492,7 +492,7 @@ Probes:
           Type: 1550 EventRootType Probe[main.testTenStrings]
           InjectionPoints: [{PC: "0x808f20", Frameless: true}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 157, index: 0, name: x}

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.PointerChainArg]
+          Type: 333 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 334 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 184 EventRootType Probe[main.bigMapArg]
+          Type: 187 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a71d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 185 EventRootType Probe[main.bigMapArg]Return
+          Type: 188 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a725e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 228 EventRootType Probe[main.condBool]
+          Type: 231 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 229 EventRootType Probe[main.condBool]Return
+          Type: 232 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 230 EventRootType Probe[main.condBool]
+          Type: 233 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 231 EventRootType Probe[main.condBool]Return
+          Type: 234 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 232 EventRootType Probe[main.condBool]
+          Type: 235 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 233 EventRootType Probe[main.condBool]Return
+          Type: 236 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 224 EventRootType Probe[main.condFloat32]
+          Type: 227 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0x4a78ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 225 EventRootType Probe[main.condFloat32]Return
+          Type: 228 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0x4a7965", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 226 EventRootType Probe[main.condFloat64]
+          Type: 229 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0x4a79ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 227 EventRootType Probe[main.condFloat64]Return
+          Type: 230 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0x4a7a26", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.condInt16]
+          Type: 195 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a73aa", Frameless: false}]
           Condition:
             Type: 96 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 193 EventRootType Probe[main.condInt16]Return
+          Type: 196 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4a741a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.condInt16]
+          Type: 197 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a73aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.condInt16]Return
+          Type: 198 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4a741a", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.condInt32]
+          Type: 199 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 197 EventRootType Probe[main.condInt32]Return
+          Type: 200 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.condInt32]
+          Type: 201 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 199 EventRootType Probe[main.condInt32]Return
+          Type: 202 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 200 EventRootType Probe[main.condInt32]
+          Type: 203 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 201 EventRootType Probe[main.condInt32]Return
+          Type: 204 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 202 EventRootType Probe[main.condInt64]
+          Type: 205 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a752a", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 203 EventRootType Probe[main.condInt64]Return
+          Type: 206 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4a759a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.condInt64]
+          Type: 207 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a752a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.condInt64]Return
+          Type: 208 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4a759a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 188 EventRootType Probe[main.condInt8]
+          Type: 191 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a72ea", Frameless: false}]
           Condition:
             Type: 14 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 189 EventRootType Probe[main.condInt8]Return
+          Type: 192 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4a735a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 190 EventRootType Probe[main.condInt8]
+          Type: 193 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a72ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 191 EventRootType Probe[main.condInt8]Return
+          Type: 194 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4a735a", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 272 EventRootType Probe[main.condLine]Line
+          Type: 275 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 273 EventRootType Probe[main.condLine]Line
+          Type: 276 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condNilPtrStruct]
+          Type: 263 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 264 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condNilPtrStruct]
+          Type: 265 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 266 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condOnly]
+          Type: 271 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condOnly]Return
+          Type: 272 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condOnly]
+          Type: 273 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condOnly]Return
+          Type: 274 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 254 EventRootType Probe[main.condPtrStructArg]
+          Type: 257 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 255 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 258 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 256 EventRootType Probe[main.condPtrStructArg]
+          Type: 259 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 257 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 260 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condPtrStructArg]
+          Type: 261 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condReturnAndLocal]
+          Type: 267 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 268 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condReturnAndLocal]
+          Type: 269 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 270 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 234 EventRootType Probe[main.condString]
+          Type: 237 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 235 EventRootType Probe[main.condString]Return
+          Type: 238 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 236 EventRootType Probe[main.condString]
+          Type: 239 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 237 EventRootType Probe[main.condString]Return
+          Type: 240 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 238 EventRootType Probe[main.condString]
+          Type: 241 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 239 EventRootType Probe[main.condString]Return
+          Type: 242 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 240 EventRootType Probe[main.condString]
+          Type: 243 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 241 EventRootType Probe[main.condString]Return
+          Type: 244 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 242 EventRootType Probe[main.condStructArg]
+          Type: 245 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 243 EventRootType Probe[main.condStructArg]Return
+          Type: 246 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 244 EventRootType Probe[main.condStructArg]
+          Type: 247 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 245 EventRootType Probe[main.condStructArg]Return
+          Type: 248 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 246 EventRootType Probe[main.condStructArg]
+          Type: 249 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 17 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 247 EventRootType Probe[main.condStructArg]Return
+          Type: 250 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 248 EventRootType Probe[main.condStructArg]
+          Type: 251 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 249 EventRootType Probe[main.condStructArg]Return
+          Type: 252 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 250 EventRootType Probe[main.condStructArg]
+          Type: 253 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 251 EventRootType Probe[main.condStructArg]Return
+          Type: 254 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 252 EventRootType Probe[main.condStructArg]
+          Type: 255 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 253 EventRootType Probe[main.condStructArg]Return
+          Type: 256 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 212 EventRootType Probe[main.condUint16]
+          Type: 215 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a76aa", Frameless: false}]
           Condition:
             Type: 7 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 213 EventRootType Probe[main.condUint16]Return
+          Type: 216 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4a771a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 214 EventRootType Probe[main.condUint16]
+          Type: 217 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a76aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 215 EventRootType Probe[main.condUint16]Return
+          Type: 218 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4a771a", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 216 EventRootType Probe[main.condUint32]
+          Type: 219 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a776a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 217 EventRootType Probe[main.condUint32]Return
+          Type: 220 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4a77da", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 218 EventRootType Probe[main.condUint32]
+          Type: 221 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a776a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 219 EventRootType Probe[main.condUint32]Return
+          Type: 222 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4a77da", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 220 EventRootType Probe[main.condUint64]
+          Type: 223 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a782a", Frameless: false}]
           Condition:
             Type: 11 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 221 EventRootType Probe[main.condUint64]Return
+          Type: 224 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4a789a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 222 EventRootType Probe[main.condUint64]
+          Type: 225 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a782a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 223 EventRootType Probe[main.condUint64]Return
+          Type: 226 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4a789a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.condUint8]
+          Type: 209 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 207 EventRootType Probe[main.condUint8]Return
+          Type: 210 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.condUint8]
+          Type: 211 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 209 EventRootType Probe[main.condUint8]Return
+          Type: 212 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 210 EventRootType Probe[main.condUint8]
+          Type: 213 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 211 EventRootType Probe[main.condUint8]Return
+          Type: 214 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.inlined]
+          Type: 331 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5eee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 277 EventRootType Probe[main.inlined]Return
+          Type: 332 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a70ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 165 EventRootType Probe[main.intArg]
+          Type: 168 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a6d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 166 EventRootType Probe[main.intArg]Return
+          Type: 169 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a6dca", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 175 EventRootType Probe[main.intArrayArg]
+          Type: 178 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a6f0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 176 EventRootType Probe[main.intArrayArg]Return
+          Type: 179 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a6f56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 181 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 184 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a7080", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 173 EventRootType Probe[main.intSliceArg]
+          Type: 176 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a6e8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 174 EventRootType Probe[main.intSliceArg]Return
+          Type: 177 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a6ecf", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 327 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 328 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 291 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 292 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 293 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 294 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 295 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 296 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 297 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 298 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 315 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 316 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 317 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 318 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 287 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 288 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 277 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 278 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 279 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 280 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 281 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 282 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 283 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 284 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 285 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 286 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 167 EventRootType Probe[main.stringArg]
+          Type: 170 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 168 EventRootType Probe[main.stringArg]Return
+          Type: 171 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 169 EventRootType Probe[main.stringArg]
+          Type: 172 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 170 EventRootType Probe[main.stringArg]Return
+          Type: 173 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 182 EventRootType Probe[main.mapArg]
+          Type: 185 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a716a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 183 EventRootType Probe[main.mapArg]Return
+          Type: 186 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a719f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 186 EventRootType Probe[main.noArgs]
+          Type: 189 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a728a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 187 EventRootType Probe[main.noArgs]Return
+          Type: 190 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a72c6", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 171 EventRootType Probe[main.stringArg]
+          Type: 174 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 172 EventRootType Probe[main.stringArg]Return
+          Type: 175 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 179 EventRootType Probe[main.stringArrayArg]
+          Type: 182 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a700a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 180 EventRootType Probe[main.stringArrayArg]Return
+          Type: 183 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a7056", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 177 EventRootType Probe[main.stringSliceArg]
+          Type: 180 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a6f8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 178 EventRootType Probe[main.stringSliceArg]Return
+          Type: 181 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a6fcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 329 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8f36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 275 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 330 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a90ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2412,12 +3079,316 @@ Subprograms:
                   Op: {CfaOffset: 88}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4a8400..0x4a8545]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8400..0x4a8487
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4a8487..0x4a848c
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4a848c..0x4a8545
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8400..0x4a848f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4a848f..0x4a8494
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4a8494..0x4a8545
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0x4a8560..0x4a86bb]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 100 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4a8560..0x4a85f6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a85f6..0x4a85fb
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a85fb..0x4a85fe
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+            - Range: 0x4a85fe..0x4a86bb
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8560..0x4a8605
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4a8605..0x4a86bb
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0x4a86c0..0x4a87ea]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0x4a86c0..0x4a872c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a872c..0x4a87ea
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a86c0..0x4a8731
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a8731..0x4a8734
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4a8734..0x4a87ea
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0x4a8800..0x4a8913]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 88 PointerType *string
+          Locations:
+            - Range: 0x4a8800..0x4a886c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a886c..0x4a8913
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8800..0x4a8871
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a8871..0x4a8874
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4a8874..0x4a8913
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4a8920..0x4a8af4]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 StructureType main.lenFields
+          Locations:
+            - Range: 0x4a8920..0x4a8af4
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8920..0x4a89f2
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4a89f2..0x4a89f5
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4a89f5..0x4a8af4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4a8b00..0x4a8c8d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4a8b00..0x4a8b7d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8b7d..0x4a8c8d
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8b00..0x4a8b82
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a8b82..0x4a8b85
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4a8b85..0x4a8c8d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4a8ca0..0x4a8dca]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0x4a8ca0..0x4a8d1b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4a8d1b..0x4a8dca
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8ca0..0x4a8d20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4a8d20..0x4a8d23
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4a8d23..0x4a8dca
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0x4a8de0..0x4a8f1d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 116 StructureType main.condFields
+          Locations:
+            - Range: 0x4a8de0..0x4a8f1d
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0x4a8de0..0x4a8e76
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4a8e76..0x4a8e79
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4a8e79..0x4a8f1d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0x4a8f20..0x4a9105]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0x4a8f20..0x4a90ee
               Pieces: []
@@ -2427,10 +3398,10 @@ Subprograms:
               Pieces: []
           Role: Return
         - Name: m
-          Type: 124 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
+          Type: 127 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
           Locations: [{Range: 0x4a8f20..0x4a9105, Pieces: []}]
           Role: Local
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0x4a70a0..0x4a7102]
       InlinePCRanges:
@@ -2445,7 +3416,7 @@ Subprograms:
             - Range: 0x4a70a0..0x4a70b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2453,12 +3424,12 @@ Subprograms:
           RootRanges: [0x4a5d60..0x4a6d7f]
       Variables:
         - Name: ptr
-          Type: 129 PointerType *****int
+          Type: 132 PointerType *****int
           Locations:
             - Range: 0x4a60ff..0x4a614b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2466,45 +3437,52 @@ Subprograms:
           RootRanges: [0x4a5d60..0x4a6d7f]
       Variables:
         - Name: ptr
-          Type: 131 PointerType **int
+          Type: 134 PointerType **int
           Locations:
             - Range: 0x4a6170..0x4a61aa
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 33312
       GoKind: 22
-      Pointee: 130 PointerType ****int
+      Pointee: 133 PointerType ****int
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 33248
       GoKind: 22
-      Pointee: 164 PointerType ***int
+      Pointee: 167 PointerType ***int
     - __kind: PointerType
-      ID: 164
+      ID: 167
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 33184
       GoKind: 22
-      Pointee: 131 PointerType **int
+      Pointee: 134 PointerType **int
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 33120
       GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
-      ID: 139
+      ID: 120
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 33056
+      GoKind: 22
+      Pointee: 100 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 142
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 138 GoSliceDataType []int.array
+      Pointee: 141 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2513,20 +3491,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 140 GoSliceDataType []string.array
+      Pointee: 143 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uint8.array
+      Pointee: 137 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []uintptr.array
+      Pointee: 139 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -2535,10 +3513,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,int>'
@@ -2550,15 +3528,15 @@ Types:
       ByteSize: 8
       Pointee: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*bucket<string,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 122
+      ID: 125
       Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 95
       Name: '*error'
@@ -2581,10 +3559,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 153
+      ID: 156
       Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 157 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*hash<string,int>'
@@ -2596,15 +3574,15 @@ Types:
       ByteSize: 8
       Pointee: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*hash<string,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 93
       Name: '*int'
@@ -2627,12 +3605,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24992
       GoKind: 22
-      Pointee: 148 StructureType main.bigStruct
+      Pointee: 151 StructureType main.bigStruct
     - __kind: PointerType
       ID: 118
       Name: '*main.condFields'
@@ -2640,6 +3618,13 @@ Types:
       GoRuntimeType: 24800
       GoKind: 22
       Pointee: 116 StructureType main.condFields
+    - __kind: PointerType
+      ID: 121
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 24864
+      GoKind: 22
+      Pointee: 119 StructureType main.lenFields
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2718,10 +3703,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 135 GoStringDataType string.str
     - __kind: PointerType
       ID: 98
       Name: '*uint'
@@ -2765,7 +3750,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 278
+      ID: 333
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2774,24 +3759,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 334
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2800,14 +3785,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 131 PointerType **int
+            Type: 134 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 184
+      ID: 187
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2833,10 +3818,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 188
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2852,7 +3837,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2868,7 +3853,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2894,16 +3879,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 224
+      ID: 227
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2919,10 +3904,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2938,10 +3923,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2957,7 +3942,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -2983,13 +3968,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 193
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 195
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 196
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 198
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 199
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3005,7 +3990,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3021,7 +4006,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3047,16 +4032,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 197
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 199
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 201
+      ID: 200
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 202
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 205
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3072,7 +4057,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3098,13 +4083,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3120,7 +4105,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3146,13 +4131,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3168,7 +4153,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3194,7 +4179,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3210,7 +4195,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 262
+      ID: 265
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3236,71 +4221,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 270
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 269
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 271
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 272
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 254
+      ID: 274
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 257
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3316,7 +4301,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3332,7 +4317,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3358,16 +4343,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 257
+      ID: 260
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 259
+      ID: 262
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 264
+      ID: 267
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3383,7 +4368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3409,10 +4394,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3428,7 +4413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3444,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3452,6 +4437,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -3461,70 +4498,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 238
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 240
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 241
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 242
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 245
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3540,7 +4525,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3556,7 +4541,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3572,7 +4557,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3588,7 +4573,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3604,7 +4589,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3630,25 +4615,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3664,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3690,13 +4675,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 213
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 216
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 218
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 219
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3712,7 +4697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 218
+      ID: 221
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3738,13 +4723,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 219
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 220
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 222
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 223
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3760,7 +4745,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3786,13 +4771,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 223
+      ID: 226
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3808,7 +4793,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3824,7 +4809,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3850,16 +4835,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 331
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3871,14 +4856,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 332
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 165
+      ID: 168
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3894,10 +4879,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 166
+      ID: 169
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 175
+      ID: 178
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3913,10 +4898,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 176
+      ID: 179
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 173
+      ID: 176
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3932,10 +4917,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 174
+      ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 321
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 104 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 88 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 100 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 278
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 282
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 119 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 185
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3961,16 +5470,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 186
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 186
+      ID: 189
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 167
+      ID: 170
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3986,10 +5495,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 169
+      ID: 172
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 171
+      ID: 174
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4015,16 +5524,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 168
+      ID: 171
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 170
+      ID: 173
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 172
+      ID: 175
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 181
+      ID: 184
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4040,7 +5549,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 179
+      ID: 182
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4056,10 +5565,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 180
+      ID: 183
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 177
+      ID: 180
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4075,13 +5584,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 178
+      ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 329
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 275
+      ID: 330
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4090,10 +5599,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4106,7 +5615,7 @@ Types:
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 163
+      ID: 166
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 43200
@@ -4223,7 +5732,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 142
+      ID: 145
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 42528
@@ -4232,35 +5741,35 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 165
       Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Element: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 145
+      ID: 148
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 108 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 152
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 161
       Name: '[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
-      Element: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 100
       Name: '[]int'
@@ -4277,29 +5786,29 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 138 GoSliceDataType []int.array
+      Data: 141 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 141
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 159
+      ID: 162
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 143
+      ID: 146
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 150
+      ID: 153
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -4325,9 +5834,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 140 GoSliceDataType []string.array
+      Data: 143 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 143
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4348,9 +5857,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 134 GoSliceDataType []uint8.array
+      Data: 137 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4371,41 +5880,41 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 136 GoSliceDataType []uintptr.array
+      Data: 139 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 144
+      ID: 147
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 160
+      ID: 163
       Name: '[]val<main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 161 StructureType main.aStructNotUsedAsAnArgument
+      Element: 164 StructureType main.aStructNotUsedAsAnArgument
     - __kind: ArrayType
-      ID: 146
+      ID: 149
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 147 PointerType *main.bigStruct
+      Element: 150 PointerType *main.bigStruct
     - __kind: ArrayType
-      ID: 151
+      ID: 154
       Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      Element: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -4413,24 +5922,24 @@ Types:
       GoRuntimeType: 39584
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 159
       Name: bucket<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 159 ArrayType []key<int>
+          Type: 162 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 160 ArrayType []val<main.aStructNotUsedAsAnArgument>
+          Type: 163 ArrayType []val<main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 136
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
       KeyType: 9 BaseType int
-      ValueType: 161 StructureType main.aStructNotUsedAsAnArgument
+      ValueType: 164 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 108
       Name: bucket<string,int>
@@ -4438,13 +5947,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<int>
+          Type: 147 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 107 PointerType *bucket<string,int>
@@ -4457,56 +5966,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 146 ArrayType []val<main.bigStruct>
+          Type: 149 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 114 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 147 PointerType *main.bigStruct
+      ValueType: 150 PointerType *main.bigStruct
     - __kind: GoHMapBucketType
-      ID: 128
+      ID: 131
       Name: bucket<string,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 151 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 154 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 200
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
-      ID: 123
+      ID: 126
       Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 153 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 151 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 154 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 80
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 3 BaseType uint8
-      ValueType: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 90
       Name: complex128
@@ -4557,7 +6066,7 @@ Types:
       GoRuntimeType: 52992
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 157
       Name: hash<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4578,18 +6087,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
-      BucketsType: 162 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
+      BucketType: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 165 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 106
       Name: hash<string,int>
@@ -4623,7 +6132,7 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,int>
-      BucketsType: 145 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 148 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 113
       Name: hash<string,main.bigStruct>
@@ -4657,9 +6166,9 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 115 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 149 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 152 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 126
+      ID: 129
       Name: hash<string,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4680,20 +6189,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 158 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketType: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 161 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
-      ID: 121
+      ID: 124
       Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4714,18 +6223,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 157 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketType: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 160 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -4856,14 +6365,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 65120
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 113280
@@ -4892,7 +6401,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 163 ArrayType [128]uint8
+          Type: 166 ArrayType [128]uint8
     - __kind: StructureType
       ID: 116
       Name: main.condFields
@@ -4939,13 +6448,38 @@ Types:
         - Name: arr
           Offset: 72
           Type: 117 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 119
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 107904
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 10 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 100 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 104 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 88 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 120 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 117 ArrayType [3]int16
     - __kind: GoMapType
-      ID: 152
+      ID: 155
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56256
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 157 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
@@ -4961,19 +6495,19 @@ Types:
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 124
+      ID: 127
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56448
       GoKind: 21
-      HeaderType: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
-      ID: 119
+      ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56544
       GoKind: 21
-      HeaderType: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5703,13 +7237,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 136 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 135 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 132
+      ID: 135
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -5755,7 +7289,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39648
       GoKind: 26
-MaxTypeID: 279
+MaxTypeID: 334
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -5986,6 +7520,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.PointerChainArg]
+          Type: 349 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 350 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.inlined]
+          Type: 347 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5eee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.inlined]Return
+          Type: 348 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a70ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenErrInt]
+          Type: 337 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenErrInt]Return
+          Type: 338 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenErrStruct]
+          Type: 341 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenErrStruct]Return
+          Type: 342 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenErrInt]
+          Type: 339 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenErrInt]Return
+          Type: 340 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenErrStruct]
+          Type: 343 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenErrStruct]Return
+          Type: 344 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 297 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 298 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.lenMap]
+          Type: 303 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.lenMap]Return
+          Type: 304 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.lenMap]
+          Type: 305 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.lenMap]Return
+          Type: 306 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.lenPtrString]
+          Type: 307 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.lenPtrString]Return
+          Type: 308 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.lenPtrString]
+          Type: 309 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 298 EventRootType Probe[main.lenPtrString]Return
+          Type: 310 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenPtrStructFields]
+          Type: 329 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 330 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenPtrStructFields]
+          Type: 331 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 332 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenPtrStructFields]
+          Type: 333 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 334 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenPtrStructFields]
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 287 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 288 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 291 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 292 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.lenSlice]
+          Type: 293 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.lenSlice]Return
+          Type: 294 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.lenSlice]
+          Type: 295 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.lenSlice]Return
+          Type: 296 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenStructFields]
+          Type: 311 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenStructFields]Return
+          Type: 312 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenStructFields]
+          Type: 313 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenStructFields]Return
+          Type: 314 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenStructFields]
+          Type: 315 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenStructFields]Return
+          Type: 316 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenStructFields]
+          Type: 317 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenStructFields]Return
+          Type: 318 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenStructFields]
+          Type: 319 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenStructFields]Return
+          Type: 320 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenStructFields]
+          Type: 321 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenStructFields]Return
+          Type: 322 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenStructFields]
+          Type: 327 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 345 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8f36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a90ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3750,7 +4055,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3776,7 +4081,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4844,7 +5149,7 @@ Types:
       ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4860,7 +5165,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 168
@@ -4920,7 +5225,7 @@ Types:
       ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 337
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4946,16 +5251,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 322
+      ID: 338
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 340
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -4981,19 +5286,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 326
+      ID: 342
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 344
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 297
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 299
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5019,13 +5391,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 298
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 300
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 295
+      ID: 302
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 307
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5044,7 +5425,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 309
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5070,13 +5451,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 308
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 310
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 329
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5102,10 +5483,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 331
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 333
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5124,7 +5524,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 335
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5143,19 +5543,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 330
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 332
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 334
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 320
+      ID: 336
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 287
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 293
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5171,7 +5619,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 295
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5201,6 +5649,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 290
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 296
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 277
@@ -5308,7 +5765,7 @@ Types:
       ID: 286
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 311
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5334,10 +5791,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 301
+      ID: 313
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 315
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5356,7 +5829,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5375,7 +5848,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5391,7 +5864,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5407,7 +5880,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 323
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5423,25 +5896,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.lenStructFields]Return
+      ID: 325
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.lenStructFields]Return
+      ID: 327
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 312
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 328
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 185
@@ -5587,10 +6098,10 @@ Types:
       ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 345
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7289,7 +7800,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39648
       GoKind: 26
-MaxTypeID: 334
+MaxTypeID: 350
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.PointerChainArg]
+          Type: 365 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a6126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 366 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a6170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 195 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a73aa", Frameless: false}]
           Condition:
-            Type: 96 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 199 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 201 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 205 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a752a", Frameless: false}]
           Condition:
-            Type: 13 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 191 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a72ea", Frameless: false}]
           Condition:
-            Type: 14 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 275 EventRootType Probe[main.condLine]Line
+          Type: 279 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 276 EventRootType Probe[main.condLine]Line
+          Type: 280 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condNilPtrStruct]
+          Type: 267 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 268 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condNilPtrStruct]
+          Type: 269 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 270 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condOnly]
+          Type: 275 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condOnly]Return
+          Type: 276 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condOnly]
+          Type: 277 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condOnly]Return
+          Type: 278 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condPtrStructArg]
+          Type: 261 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condPtrStructArg]
+          Type: 263 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 264 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condPtrStructArg]
+          Type: 265 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 266 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condReturnAndLocal]
+          Type: 271 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 272 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condReturnAndLocal]
+          Type: 273 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 274 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 237 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 239 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 241 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 242 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 243 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 244 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condString]
+          Type: 245 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condString]Return
+          Type: 246 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condString]
+          Type: 247 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condString]Return
+          Type: 248 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condStructArg]
+          Type: 249 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condStructArg]Return
+          Type: 250 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condStructArg]
+          Type: 251 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condStructArg]Return
+          Type: 252 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condStructArg]
+          Type: 253 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
-            Type: 17 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condStructArg]Return
+          Type: 254 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condStructArg]
+          Type: 255 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condStructArg]Return
+          Type: 256 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condStructArg]
+          Type: 257 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condStructArg]Return
+          Type: 258 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condStructArg]
+          Type: 259 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condStructArg]Return
+          Type: 260 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 215 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a76aa", Frameless: false}]
           Condition:
-            Type: 7 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 219 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a776a", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 223 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a782a", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 209 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 211 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.inlined]
+          Type: 363 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a5eee"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 348 EventRootType Probe[main.inlined]Return
+          Type: 364 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a70ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenErrInt]
+          Type: 353 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenErrInt]Return
+          Type: 354 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenErrStruct]
+          Type: 357 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenErrStruct]Return
+          Type: 358 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenErrInt]
+          Type: 355 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4a8cb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenErrInt]Return
+          Type: 356 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4a8d9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenErrStruct]
+          Type: 359 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4a8df3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenErrStruct]Return
+          Type: 360 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4a8ef6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.lenMap]
+          Type: 311 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 298 EventRootType Probe[main.lenMap]Return
+          Type: 312 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenMap]
+          Type: 315 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenMap]Return
+          Type: 316 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenMap]
+          Type: 317 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenMap]Return
+          Type: 318 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenMap]
+          Type: 319 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenMap]Return
+          Type: 320 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenMap]
+          Type: 321 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4a86ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenMap]Return
+          Type: 322 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4a87bc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenPtrString]
+          Type: 323 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenPtrString]Return
+          Type: 324 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenPtrString]
+          Type: 325 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4a880e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenPtrString]Return
+          Type: 326 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4a88e5", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenPtrStructFields]
+          Type: 345 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenPtrStructFields]
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 348 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenPtrStructFields]
+          Type: 349 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 350 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4a8b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4a8c5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.lenSlice]
+          Type: 299 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 288 EventRootType Probe[main.lenSlice]Return
+          Type: 300 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.lenSlice]
+          Type: 303 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.lenSlice]Return
+          Type: 304 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.lenSlice]
+          Type: 305 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 292 EventRootType Probe[main.lenSlice]Return
+          Type: 306 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.lenSlice]
+          Type: 307 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.lenSlice]Return
+          Type: 308 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.lenSlice]
+          Type: 309 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4a8573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.lenSlice]Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4a8676", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 281 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 282 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 283 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 284 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 285 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 286 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.lenString]
+          Type: 287 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.lenString]Return
+          Type: 288 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.lenString]
+          Type: 291 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.lenString]Return
+          Type: 292 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.lenString]
+          Type: 293 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.lenString]Return
+          Type: 294 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.lenString]
+          Type: 295 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.lenString]Return
+          Type: 296 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.lenString]
+          Type: 297 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4a8413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 286 EventRootType Probe[main.lenString]Return
+          Type: 298 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4a8505", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenStructFields]
+          Type: 327 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenStructFields]
+          Type: 329 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenStructFields]Return
+          Type: 330 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenStructFields]
+          Type: 331 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenStructFields]Return
+          Type: 332 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenStructFields]
+          Type: 333 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenStructFields]Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenStructFields]
+          Type: 335 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenStructFields]Return
+          Type: 336 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenStructFields]
+          Type: 337 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          Type: 338 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenStructFields]
+          Type: 339 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          Type: 340 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenStructFields]
+          Type: 341 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          Type: 342 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenStructFields]
+          Type: 343 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4a8933", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          Type: 344 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4a8ac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 361 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4a8f36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4a90ee", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4055,7 +4267,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4081,7 +4293,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4442,7 +4654,7 @@ Types:
       ID: 194
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 275
+      ID: 279
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4458,7 +4670,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 276
+      ID: 280
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4484,7 +4696,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 267
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4500,7 +4712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 269
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4526,13 +4738,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 268
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 266
+      ID: 270
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 275
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4558,7 +4770,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 277
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4584,45 +4796,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 276
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 278
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 261
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 265
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4648,16 +4860,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 260
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 262
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 264
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 271
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4673,7 +4885,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 273
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4699,10 +4911,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 272
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 270
+      ID: 274
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4752,6 +4964,48 @@ Types:
     - __kind: EventRootType
       ID: 241
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4776,7 +5030,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 247
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4814,7 +5068,13 @@ Types:
       ID: 244
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 246
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 249
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4822,38 +5082,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 247
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 249
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -4896,6 +5124,38 @@ Types:
     - __kind: EventRootType
       ID: 255
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4920,12 +5180,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 248
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 250
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4936,6 +5190,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 256
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 260
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 215
@@ -5149,7 +5409,7 @@ Types:
       ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5165,7 +5425,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 168
@@ -5225,7 +5485,7 @@ Types:
       ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5251,16 +5511,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5286,16 +5546,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 311
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5311,7 +5571,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 313
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 315
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5330,7 +5615,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 317
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5346,7 +5631,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 319
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5365,7 +5650,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 321
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5391,22 +5676,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 312
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 300
+      ID: 314
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 302
+      ID: 316
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 318
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 306
+      ID: 320
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 307
+      ID: 322
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 323
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5425,7 +5713,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 325
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5451,13 +5739,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 308
+      ID: 324
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 310
+      ID: 326
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 345
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5483,7 +5771,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5505,7 +5793,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5524,7 +5812,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,19 +5831,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 287
+      ID: 299
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5571,7 +5859,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 301
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5587,7 +5897,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 305
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5603,7 +5913,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 307
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5619,7 +5929,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 309
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5645,22 +5955,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 300
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 290
+      ID: 302
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 304
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 306
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 308
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 277
+      ID: 310
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5676,7 +6055,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 289
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5692,7 +6093,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 293
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5708,7 +6109,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 295
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5724,7 +6125,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 297
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5750,12 +6151,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 282
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5765,7 +6160,25 @@ Types:
       ID: 286
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 288
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 327
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5791,7 +6204,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 329
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5810,7 +6223,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 331
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5829,7 +6242,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 333
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5848,7 +6261,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 335
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5864,7 +6277,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 337
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5880,7 +6293,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5896,7 +6309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5912,7 +6325,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5927,32 +6340,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 328
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 344
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 185
@@ -6098,10 +6511,10 @@ Types:
       ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7800,7 +8213,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39648
       GoKind: 26
-MaxTypeID: 350
+MaxTypeID: 366
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -7878,7 +8291,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -7908,7 +8321,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -7923,7 +8336,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -7938,7 +8351,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 184 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a6bf3", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a71d3", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 185 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0x4a6c7e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a725e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 228 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a748a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 229 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a74fa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 230 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a748a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 231 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a74fa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 232 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a748a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7a6a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 233 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a74fa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7ada", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 224 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0x4a730e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a78ee", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 225 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0x4a7385", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7965", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 226 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0x4a73ce", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a79ae", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 227 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0x4a7446", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7a26", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4a6dca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a73aa", Frameless: false}]
           Condition:
             Type: 96 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 193 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4a6e3a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a741a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4a6dca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a73aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4a6e3a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a741a", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a6e8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 197 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a6efa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a6e8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 199 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a6efa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 200 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a6e8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a746a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 201 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a6efa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a74da", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 202 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4a6f4a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a752a", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 203 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4a6fba", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a759a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4a6f4a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a752a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4a6fba", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a759a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 188 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4a6d0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a72ea", Frameless: false}]
           Condition:
             Type: 14 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 189 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4a6d7a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a735a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 190 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4a6d0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a72ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 191 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4a6d7a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a735a", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 272 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4a7ae7", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 273 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4a7ae7", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a80c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 260 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4a78ae", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 261 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4a792e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 262 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4a78ae", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7e8e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 263 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4a792e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 268 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4a7a0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 269 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4a7a7a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 270 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4a7a0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7fea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 271 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4a7a7a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a805a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 254 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a774e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 255 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a7865", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 256 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a774e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 257 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a7865", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 258 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a774e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7d2e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 259 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a7865", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 264 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4a796a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 265 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4a79d5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 266 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4a796a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7f4a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 267 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4a79d5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 234 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a754a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 235 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a75bf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 236 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a754a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 237 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a75bf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 238 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a754a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 239 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a75bf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 240 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a754a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b2a", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 241 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a75bf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 242 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 243 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 244 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 245 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 246 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 17 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 247 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 248 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 249 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 250 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 251 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 252 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a760e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7bee", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 253 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a7716", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7cf6", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 212 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4a70ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a76aa", Frameless: false}]
           Condition:
             Type: 7 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 213 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4a713a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a771a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 214 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4a70ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a76aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 215 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4a713a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a771a", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 216 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4a718a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a776a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 217 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4a71fa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a77da", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 218 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4a718a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a776a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 219 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4a71fa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a77da", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 220 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4a724a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a782a", Frameless: false}]
           Condition:
             Type: 11 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 221 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4a72ba", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a789a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 222 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4a724a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a782a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 223 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4a72ba", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a789a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a700a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 207 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a707a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a700a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 209 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a707a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 210 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a700a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a75ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 211 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a707a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a765a", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0x4a5eee"
               Frameless: false
-            - PC: "0x4a6aca"
+            - PC: "0x4a70aa"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 277 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0x4a6b0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a70ea", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 165 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a67aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6d8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 166 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0x4a67ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6dca", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 175 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a692a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6f0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 176 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0x4a6976", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6f56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 181 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a6aa0", Frameless: true}]
+          InjectionPoints: [{PC: "0x4a7080", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 173 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a68aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 174 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0x4a68ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6ecf", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 167 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a682a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 168 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a686f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 169 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a682a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 170 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a686f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 182 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a6b8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a716a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 183 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0x4a6bbf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a719f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 186 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4a6caa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a728a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 187 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0x4a6ce6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a72c6", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 171 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a682a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 172 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a686f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 179 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a6a2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a700a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 180 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0x4a6a76", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a7056", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 177 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a69aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6f8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 178 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a69ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a6fcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 274 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4a7e16", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8f36", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 275 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0x4a7fce", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a90ee", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a67a0..0x4a6802]
+      OutOfLinePCRanges: [0x4a6d80..0x4a6de2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a67a0..0x4a67b9
+            - Range: 0x4a6d80..0x4a6d99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a6820..0x4a6891]
+      OutOfLinePCRanges: [0x4a6e00..0x4a6e71]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6820..0x4a683e
+            - Range: 0x4a6e00..0x4a6e1e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a68a0..0x4a691a]
+      OutOfLinePCRanges: [0x4a6e80..0x4a6efa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a68a0..0x4a68be
+            - Range: 0x4a6e80..0x4a6e9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a6920..0x4a6987]
+      OutOfLinePCRanges: [0x4a6f00..0x4a6f67]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 ArrayType [3]int
           Locations:
-            - Range: 0x4a6920..0x4a6987
+            - Range: 0x4a6f00..0x4a6f67
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a69a0..0x4a6a1a]
+      OutOfLinePCRanges: [0x4a6f80..0x4a6ffa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a69a0..0x4a69be
+            - Range: 0x4a6f80..0x4a6f9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a6a20..0x4a6a87]
+      OutOfLinePCRanges: [0x4a7000..0x4a7067]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0x4a6a20..0x4a6a87
+            - Range: 0x4a7000..0x4a7067
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a6aa0..0x4a6aa1]
+      OutOfLinePCRanges: [0x4a7080..0x4a7081]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0x4a6aa0..0x4a6aa1
+            - Range: 0x4a7080..0x4a7081
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a6b80..0x4a6bd6]
+      OutOfLinePCRanges: [0x4a7160..0x4a71b6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4a6b80..0x4a6bad
+            - Range: 0x4a7160..0x4a718d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a6be0..0x4a6c9b]
+      OutOfLinePCRanges: [0x4a71c0..0x4a727b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a6be0..0x4a6c13
+            - Range: 0x4a71c0..0x4a71f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a6c13..0x4a6c9b
+            - Range: 0x4a71f3..0x4a727b
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4a6ca0..0x4a6cf3]
+      OutOfLinePCRanges: [0x4a7280..0x4a72d3]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4a6d00..0x4a6da8]
+      OutOfLinePCRanges: [0x4a72e0..0x4a7388]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int8
           Locations:
-            - Range: 0x4a6d00..0x4a6d41
+            - Range: 0x4a72e0..0x4a7321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6d00..0x4a6d44
+            - Range: 0x4a72e0..0x4a7324
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a6d44..0x4a6d49
+            - Range: 0x4a7324..0x4a7329
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4a6dc0..0x4a6e69]
+      OutOfLinePCRanges: [0x4a73a0..0x4a7449]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0x4a6dc0..0x4a6de9
+            - Range: 0x4a73a0..0x4a73c9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6dc0..0x4a6de9
+            - Range: 0x4a73a0..0x4a73c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a6de9..0x4a6e69
+            - Range: 0x4a73c9..0x4a7449
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4a6e80..0x4a6f27]
+      OutOfLinePCRanges: [0x4a7460..0x4a7507]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0x4a6e80..0x4a6ea9
+            - Range: 0x4a7460..0x4a7489
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6e80..0x4a6ea9
+            - Range: 0x4a7460..0x4a7489
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a6ea9..0x4a6f27
+            - Range: 0x4a7489..0x4a7507
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4a6f40..0x4a6fe9]
+      OutOfLinePCRanges: [0x4a7520..0x4a75c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0x4a6f40..0x4a6f69
+            - Range: 0x4a7520..0x4a7549
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a6f40..0x4a6f69
+            - Range: 0x4a7520..0x4a7549
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a6f69..0x4a6fe9
+            - Range: 0x4a7549..0x4a75c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4a7000..0x4a70a8]
+      OutOfLinePCRanges: [0x4a75e0..0x4a7688]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4a7000..0x4a7041
+            - Range: 0x4a75e0..0x4a7621
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7000..0x4a7044
+            - Range: 0x4a75e0..0x4a7624
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a7044..0x4a7049
+            - Range: 0x4a7624..0x4a7629
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4a70c0..0x4a7169]
+      OutOfLinePCRanges: [0x4a76a0..0x4a7749]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0x4a70c0..0x4a70e9
+            - Range: 0x4a76a0..0x4a76c9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a70c0..0x4a70e9
+            - Range: 0x4a76a0..0x4a76c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a70e9..0x4a7169
+            - Range: 0x4a76c9..0x4a7749
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4a7180..0x4a7227]
+      OutOfLinePCRanges: [0x4a7760..0x4a7807]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4a7180..0x4a71a9
+            - Range: 0x4a7760..0x4a7789
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7180..0x4a71a9
+            - Range: 0x4a7760..0x4a7789
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a71a9..0x4a7227
+            - Range: 0x4a7789..0x4a7807
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4a7240..0x4a72e9]
+      OutOfLinePCRanges: [0x4a7820..0x4a78c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0x4a7240..0x4a7269
+            - Range: 0x4a7820..0x4a7849
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7240..0x4a7269
+            - Range: 0x4a7820..0x4a7849
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a7269..0x4a72e9
+            - Range: 0x4a7849..0x4a78c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4a7300..0x4a73ba]
+      OutOfLinePCRanges: [0x4a78e0..0x4a799a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0x4a7300..0x4a7333
+            - Range: 0x4a78e0..0x4a7913
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7300..0x4a732e
+            - Range: 0x4a78e0..0x4a790e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a732e..0x4a7333
+            - Range: 0x4a790e..0x4a7913
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a7333..0x4a73ba
+            - Range: 0x4a7913..0x4a799a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4a73c0..0x4a747a]
+      OutOfLinePCRanges: [0x4a79a0..0x4a7a5a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0x4a73c0..0x4a73f5
+            - Range: 0x4a79a0..0x4a79d5
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a73c0..0x4a73f0
+            - Range: 0x4a79a0..0x4a79d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a73f0..0x4a73f5
+            - Range: 0x4a79d0..0x4a79d5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a73f5..0x4a747a
+            - Range: 0x4a79d5..0x4a7a5a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4a7480..0x4a7528]
+      OutOfLinePCRanges: [0x4a7a60..0x4a7b08]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4a7480..0x4a74c1
+            - Range: 0x4a7a60..0x4a7aa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7480..0x4a74c4
+            - Range: 0x4a7a60..0x4a7aa4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a74c4..0x4a74c9
+            - Range: 0x4a7aa4..0x4a7aa9
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4a7540..0x4a75f7]
+      OutOfLinePCRanges: [0x4a7b20..0x4a7bd7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7540..0x4a756e
+            - Range: 0x4a7b20..0x4a7b4e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7540..0x4a756e
+            - Range: 0x4a7b20..0x4a7b4e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4a756e..0x4a75f7
+            - Range: 0x4a7b4e..0x4a7bd7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4a7600..0x4a773a]
+      OutOfLinePCRanges: [0x4a7be0..0x4a7d1a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0x4a7600..0x4a773a
+            - Range: 0x4a7be0..0x4a7d1a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7600..0x4a7647
+            - Range: 0x4a7be0..0x4a7c27
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a7647..0x4a764c
+            - Range: 0x4a7c27..0x4a7c2c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4a764c..0x4a773a
+            - Range: 0x4a7c2c..0x4a7d1a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4a7740..0x4a7893]
+      OutOfLinePCRanges: [0x4a7d20..0x4a7e73]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0x4a7740..0x4a7798
+            - Range: 0x4a7d20..0x4a7d78
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a7798..0x4a7893
+            - Range: 0x4a7d78..0x4a7e73
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7740..0x4a779d
+            - Range: 0x4a7d20..0x4a7d7d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a779d..0x4a7893
+            - Range: 0x4a7d7d..0x4a7e73
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4a78a0..0x4a795c]
+      OutOfLinePCRanges: [0x4a7e80..0x4a7f3c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0x4a78a0..0x4a78f5
+            - Range: 0x4a7e80..0x4a7ed5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a78a0..0x4a78f8
+            - Range: 0x4a7e80..0x4a7ed8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a78f8..0x4a78fd
+            - Range: 0x4a7ed8..0x4a7edd
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4a7960..0x4a79f9]
+      OutOfLinePCRanges: [0x4a7f40..0x4a7fd9]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7960..0x4a7971
+            - Range: 0x4a7f40..0x4a7f51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7960..0x4a799f
+            - Range: 0x4a7f40..0x4a7f7f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7960..0x4a79d5
+            - Range: 0x4a7f40..0x4a7fb5
               Pieces: []
-            - Range: 0x4a79d5..0x4a79d6
+            - Range: 0x4a7fb5..0x4a7fb6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a79d6..0x4a79f9
+            - Range: 0x4a7fb6..0x4a7fd9
               Pieces: []
           Role: Return
         - Name: sum
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7971..0x4a799f
+            - Range: 0x4a7f51..0x4a7f7f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a799f..0x4a79f9
+            - Range: 0x4a7f7f..0x4a7fd9
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4a7a00..0x4a7aa9]
+      OutOfLinePCRanges: [0x4a7fe0..0x4a8089]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7a00..0x4a7a29
+            - Range: 0x4a7fe0..0x4a8009
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7a00..0x4a7a29
+            - Range: 0x4a7fe0..0x4a8009
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a7a29..0x4a7aa9
+            - Range: 0x4a8009..0x4a8089
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2291,27 +2291,27 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4a7ac0..0x4a7ba5]
+      OutOfLinePCRanges: [0x4a80a0..0x4a8185]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 9 BaseType int
           Locations:
-            - Range: 0x4a7ac0..0x4a7afc
+            - Range: 0x4a80a0..0x4a80dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a7afc..0x4a7ba5
+            - Range: 0x4a80dc..0x4a8185
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7ac0..0x4a7b05
+            - Range: 0x4a80a0..0x4a80e5
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a7b05..0x4a7ba5
+            - Range: 0x4a80e5..0x4a8185
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2320,13 +2320,13 @@ Subprograms:
           Role: Parameter
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4a7bc0..0x4a7c85]
+      OutOfLinePCRanges: [0x4a81a0..0x4a8265]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a7bc0..0x4a7bee
+            - Range: 0x4a81a0..0x4a81ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2338,13 +2338,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7bc0..0x4a7bee
+            - Range: 0x4a81a0..0x4a81ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4a7bee..0x4a7c85
+            - Range: 0x4a81ce..0x4a8265
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2353,25 +2353,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4a7ca0..0x4a7d3a]
+      OutOfLinePCRanges: [0x4a8280..0x4a831a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0x4a7ca0..0x4a7cd3
+            - Range: 0x4a8280..0x4a82b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7ca0..0x4a7cd6
+            - Range: 0x4a8280..0x4a82b6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a7cd6..0x4a7cdb
+            - Range: 0x4a82b6..0x4a82bb
               Pieces:
                 - Size: 8
                   Op: null
@@ -2380,31 +2380,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4a7d40..0x4a7dfa]
+      OutOfLinePCRanges: [0x4a8320..0x4a83da]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0x4a7d40..0x4a7dfa
+            - Range: 0x4a8320..0x4a83da
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0x4a7d40..0x4a7d75
+            - Range: 0x4a8320..0x4a8355
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a7d75..0x4a7d7a
+            - Range: 0x4a8355..0x4a835a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4a7d7a..0x4a7dfa
+            - Range: 0x4a835a..0x4a83da
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2413,36 +2413,36 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4a7e00..0x4a7fe5]
+      OutOfLinePCRanges: [0x4a8f20..0x4a9105]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4a7e00..0x4a7fce
+            - Range: 0x4a8f20..0x4a90ee
               Pieces: []
-            - Range: 0x4a7fce..0x4a7fcf
+            - Range: 0x4a90ee..0x4a90ef
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a7fcf..0x4a7fe5
+            - Range: 0x4a90ef..0x4a9105
               Pieces: []
           Role: Return
         - Name: m
           Type: 124 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0x4a7e00..0x4a7fe5, Pieces: []}]
+          Locations: [{Range: 0x4a8f20..0x4a9105, Pieces: []}]
           Role: Local
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a6ac0..0x4a6b22]
+      OutOfLinePCRanges: [0x4a70a0..0x4a7102]
       InlinePCRanges:
         - Ranges: [0x4a5eee..0x4a5f3f]
-          RootRanges: [0x4a5d60..0x4a6798]
+          RootRanges: [0x4a5d60..0x4a6d7f]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
             - Range: 0x4a5eee..0x4a5f3f
               Pieces: []
-            - Range: 0x4a6ac0..0x4a6ad9
+            - Range: 0x4a70a0..0x4a70b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
@@ -2450,7 +2450,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6126..0x4a6165]
-          RootRanges: [0x4a5d60..0x4a6798]
+          RootRanges: [0x4a5d60..0x4a6d7f]
       Variables:
         - Name: ptr
           Type: 129 PointerType *****int
@@ -2463,7 +2463,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a6170..0x4a61aa]
-          RootRanges: [0x4a5d60..0x4a6798]
+          RootRanges: [0x4a5d60..0x4a6d7f]
       Variables:
         - Name: ptr
           Type: 131 PointerType **int
@@ -2476,28 +2476,28 @@ Types:
       ID: 129
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 33152
+      GoRuntimeType: 33312
       GoKind: 22
       Pointee: 130 PointerType ****int
     - __kind: PointerType
       ID: 130
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 33088
+      GoRuntimeType: 33248
       GoKind: 22
       Pointee: 164 PointerType ***int
     - __kind: PointerType
       ID: 164
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 33024
+      GoRuntimeType: 33184
       GoKind: 22
       Pointee: 131 PointerType **int
     - __kind: PointerType
       ID: 131
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32960
+      GoRuntimeType: 33120
       GoKind: 22
       Pointee: 93 PointerType *int
     - __kind: PointerType
@@ -2509,7 +2509,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 36672
+      GoRuntimeType: 36832
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2531,7 +2531,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 27584
+      GoRuntimeType: 27680
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -2563,21 +2563,21 @@ Types:
       ID: 95
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 26496
+      GoRuntimeType: 26592
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 97
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 27456
+      GoRuntimeType: 27552
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 91
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 27520
+      GoRuntimeType: 27616
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -2609,112 +2609,112 @@ Types:
       ID: 93
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 27136
+      GoRuntimeType: 27232
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26880
+      GoRuntimeType: 26976
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 92
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 27008
+      GoRuntimeType: 27104
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 147
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24896
+      GoRuntimeType: 24992
       GoKind: 22
       Pointee: 148 StructureType main.bigStruct
     - __kind: PointerType
       ID: 118
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 24768
+      GoRuntimeType: 24800
       GoKind: 22
       Pointee: 116 StructureType main.condFields
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27776
+      GoRuntimeType: 27872
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 71712
+      GoRuntimeType: 71872
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 28416
+      GoRuntimeType: 28512
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 28480
+      GoRuntimeType: 28576
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 54656
+      GoRuntimeType: 54816
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 62304
+      GoRuntimeType: 62464
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 109
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 30400
+      GoRuntimeType: 30496
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 29184
+      GoRuntimeType: 29280
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 114656
+      GoRuntimeType: 115072
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 88032
+      GoRuntimeType: 88192
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 26560
+      GoRuntimeType: 26656
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -2726,42 +2726,42 @@ Types:
       ID: 98
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 27200
+      GoRuntimeType: 27296
       GoKind: 22
       Pointee: 15 BaseType uint
     - __kind: PointerType
       ID: 99
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26816
+      GoRuntimeType: 26912
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26944
+      GoRuntimeType: 27040
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 94
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 27072
+      GoRuntimeType: 27168
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26688
+      GoRuntimeType: 26784
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 27264
+      GoRuntimeType: 27360
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -4100,7 +4100,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 48800
+      GoRuntimeType: 48960
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4109,7 +4109,7 @@ Types:
       ID: 163
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 43040
+      GoRuntimeType: 43200
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4118,7 +4118,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 48512
+      GoRuntimeType: 48672
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4127,7 +4127,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 48704
+      GoRuntimeType: 48864
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4136,7 +4136,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 44768
+      GoRuntimeType: 44928
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4145,7 +4145,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 50720
+      GoRuntimeType: 50880
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4154,7 +4154,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 48320
+      GoRuntimeType: 48480
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4163,7 +4163,7 @@ Types:
       ID: 101
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 42464
+      GoRuntimeType: 42912
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4172,7 +4172,7 @@ Types:
       ID: 117
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 42272
+      GoRuntimeType: 42432
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4181,7 +4181,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 48032
+      GoRuntimeType: 48192
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4190,7 +4190,7 @@ Types:
       ID: 103
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 42560
+      GoRuntimeType: 43008
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4199,7 +4199,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 49760
+      GoRuntimeType: 49920
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4208,7 +4208,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 47264
+      GoRuntimeType: 47424
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4217,7 +4217,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 48608
+      GoRuntimeType: 48768
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4226,7 +4226,7 @@ Types:
       ID: 142
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 42656
+      GoRuntimeType: 42528
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4265,7 +4265,7 @@ Types:
       ID: 100
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 34816
+      GoRuntimeType: 34976
       GoKind: 23
       RawFields:
         - Name: array
@@ -4313,7 +4313,7 @@ Types:
       ID: 102
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 35136
+      GoRuntimeType: 35296
       GoKind: 23
       RawFields:
         - Name: array
@@ -4336,7 +4336,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 34432
+      GoRuntimeType: 34592
       GoKind: 23
       RawFields:
         - Name: array
@@ -4359,7 +4359,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34944
+      GoRuntimeType: 35104
       GoKind: 23
       RawFields:
         - Name: array
@@ -4410,7 +4410,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 39424
+      GoRuntimeType: 39584
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 156
@@ -4511,19 +4511,19 @@ Types:
       ID: 90
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 39232
+      GoRuntimeType: 39392
       GoKind: 16
     - __kind: BaseType
       ID: 89
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 39168
+      GoRuntimeType: 39328
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 60640
+      GoRuntimeType: 60800
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4536,25 +4536,25 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 39296
+      GoRuntimeType: 39456
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 39360
+      GoRuntimeType: 39520
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 33472
+      GoRuntimeType: 33632
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 52832
+      GoRuntimeType: 52992
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 154
@@ -4730,37 +4730,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38976
+      GoRuntimeType: 39136
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 38592
+      GoRuntimeType: 38752
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 38720
+      GoRuntimeType: 38880
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 38848
+      GoRuntimeType: 39008
       GoKind: 6
     - __kind: BaseType
       ID: 14
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 38464
+      GoRuntimeType: 38624
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 105856
+      GoRuntimeType: 106016
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4782,7 +4782,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 69440
+      GoRuntimeType: 69600
       GoKind: 25
       RawFields:
         - Name: u
@@ -4792,7 +4792,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 91680
+      GoRuntimeType: 91840
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4808,7 +4808,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 81760
+      GoRuntimeType: 81920
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4821,7 +4821,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 81600
+      GoRuntimeType: 81760
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4834,7 +4834,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 81920
+      GoRuntimeType: 82080
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4846,27 +4846,27 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 59072
+      GoRuntimeType: 59232
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 58976
+      GoRuntimeType: 59136
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 161
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 64960
+      GoRuntimeType: 65120
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 148
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 112864
+      GoRuntimeType: 113280
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4897,7 +4897,7 @@ Types:
       ID: 116
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 119008
+      GoRuntimeType: 119424
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4943,35 +4943,35 @@ Types:
       ID: 152
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 56000
+      GoRuntimeType: 56256
       GoKind: 21
       HeaderType: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 56096
+      GoRuntimeType: 56160
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 56192
+      GoRuntimeType: 56352
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
       ID: 124
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 56288
+      GoRuntimeType: 56448
       GoKind: 21
       HeaderType: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 119
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 56384
+      GoRuntimeType: 56544
       GoKind: 21
       HeaderType: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
@@ -4993,14 +4993,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 58400
+      GoRuntimeType: 58560
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 133280
+      GoRuntimeType: 133696
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5175,7 +5175,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 67776
+      GoRuntimeType: 67936
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5185,7 +5185,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 110848
+      GoRuntimeType: 111264
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5213,7 +5213,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 79520
+      GoRuntimeType: 79680
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5226,7 +5226,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 99168
+      GoRuntimeType: 99328
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5245,13 +5245,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 51488
+      GoRuntimeType: 51648
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 79360
+      GoRuntimeType: 79520
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5264,7 +5264,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 109536
+      GoRuntimeType: 109952
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5289,13 +5289,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 51392
+      GoRuntimeType: 51552
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 136448
+      GoRuntimeType: 136864
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5515,7 +5515,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 109280
+      GoRuntimeType: 109696
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5540,7 +5540,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 88416
+      GoRuntimeType: 88576
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5556,7 +5556,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 88224
+      GoRuntimeType: 88384
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5576,20 +5576,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 51104
+      GoRuntimeType: 51264
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 67392
+      GoRuntimeType: 67552
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 79200
+      GoRuntimeType: 79360
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5602,7 +5602,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 99936
+      GoRuntimeType: 100096
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5621,13 +5621,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 51296
+      GoRuntimeType: 51456
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 54272
+      GoRuntimeType: 54432
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5636,7 +5636,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 77600
+      GoRuntimeType: 77760
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5653,7 +5653,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 39680
+      GoRuntimeType: 39840
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5663,7 +5663,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 39744
+      GoRuntimeType: 39904
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -5673,7 +5673,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 78560
+      GoRuntimeType: 78720
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5686,19 +5686,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 64608
+      GoRuntimeType: 64768
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 58304
+      GoRuntimeType: 58464
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 38400
+      GoRuntimeType: 38560
       GoKind: 24
       RawFields:
         - Name: str
@@ -5717,43 +5717,43 @@ Types:
       ID: 15
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 39040
+      GoRuntimeType: 39200
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 38656
+      GoRuntimeType: 38816
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 38784
+      GoRuntimeType: 38944
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 38912
+      GoRuntimeType: 39072
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 38528
+      GoRuntimeType: 38688
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 39104
+      GoRuntimeType: 39264
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 39488
+      GoRuntimeType: 39648
       GoKind: 26
 MaxTypeID: 279
 Issues:
@@ -5997,7 +5997,7 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x576240", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x578240", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.PointerChainArg]
+          Type: 350 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 351 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 201 EventRootType Probe[main.bigMapArg]
+          Type: 204 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4a91d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 202 EventRootType Probe[main.bigMapArg]Return
+          Type: 205 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4a925e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condBool]
+          Type: 248 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condBool]Return
+          Type: 249 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condBool]
+          Type: 250 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condBool]Return
+          Type: 251 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condBool]
+          Type: 252 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condBool]Return
+          Type: 253 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condFloat32]
+          Type: 244 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0x4a98ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condFloat32]Return
+          Type: 245 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0x4a995e", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condFloat64]
+          Type: 246 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condFloat64]Return
+          Type: 247 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0x4a9a1f", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 209 EventRootType Probe[main.condInt16]
+          Type: 212 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
           Condition:
             Type: 101 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 210 EventRootType Probe[main.condInt16]Return
+          Type: 213 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 211 EventRootType Probe[main.condInt16]
+          Type: 214 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 212 EventRootType Probe[main.condInt16]Return
+          Type: 215 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 213 EventRootType Probe[main.condInt32]
+          Type: 216 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 214 EventRootType Probe[main.condInt32]Return
+          Type: 217 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 215 EventRootType Probe[main.condInt32]
+          Type: 218 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 216 EventRootType Probe[main.condInt32]Return
+          Type: 219 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 217 EventRootType Probe[main.condInt32]
+          Type: 220 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 218 EventRootType Probe[main.condInt32]Return
+          Type: 221 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 219 EventRootType Probe[main.condInt64]
+          Type: 222 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 220 EventRootType Probe[main.condInt64]Return
+          Type: 223 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 221 EventRootType Probe[main.condInt64]
+          Type: 224 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 222 EventRootType Probe[main.condInt64]Return
+          Type: 225 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 205 EventRootType Probe[main.condInt8]
+          Type: 208 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
           Condition:
             Type: 15 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 206 EventRootType Probe[main.condInt8]Return
+          Type: 209 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 207 EventRootType Probe[main.condInt8]
+          Type: 210 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 208 EventRootType Probe[main.condInt8]Return
+          Type: 211 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 289 EventRootType Probe[main.condLine]Line
+          Type: 292 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 290 EventRootType Probe[main.condLine]Line
+          Type: 293 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condNilPtrStruct]
+          Type: 280 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 281 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condNilPtrStruct]
+          Type: 282 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condOnly]
+          Type: 288 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condOnly]Return
+          Type: 289 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condOnly]
+          Type: 290 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condOnly]Return
+          Type: 291 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condPtrStructArg]
+          Type: 274 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 275 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condPtrStructArg]
+          Type: 276 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condPtrStructArg]
+          Type: 278 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condReturnAndLocal]
+          Type: 284 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 285 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condReturnAndLocal]
+          Type: 286 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condString]
+          Type: 254 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condString]Return
+          Type: 255 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condString]
+          Type: 256 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condString]Return
+          Type: 257 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condString]
+          Type: 258 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condString]Return
+          Type: 259 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condString]
+          Type: 260 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condString]Return
+          Type: 261 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condStructArg]
+          Type: 262 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condStructArg]Return
+          Type: 263 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condStructArg]
+          Type: 264 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condStructArg]Return
+          Type: 265 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condStructArg]
+          Type: 266 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 18 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condStructArg]Return
+          Type: 267 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condStructArg]
+          Type: 268 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condStructArg]Return
+          Type: 269 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condStructArg]
+          Type: 270 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condStructArg]Return
+          Type: 271 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 229 EventRootType Probe[main.condUint16]
+          Type: 232 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 230 EventRootType Probe[main.condUint16]Return
+          Type: 233 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 231 EventRootType Probe[main.condUint16]
+          Type: 234 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 232 EventRootType Probe[main.condUint16]Return
+          Type: 235 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 233 EventRootType Probe[main.condUint32]
+          Type: 236 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 234 EventRootType Probe[main.condUint32]Return
+          Type: 237 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 235 EventRootType Probe[main.condUint32]
+          Type: 238 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 236 EventRootType Probe[main.condUint32]Return
+          Type: 239 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 237 EventRootType Probe[main.condUint64]
+          Type: 240 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 238 EventRootType Probe[main.condUint64]Return
+          Type: 241 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 239 EventRootType Probe[main.condUint64]
+          Type: 242 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 240 EventRootType Probe[main.condUint64]Return
+          Type: 243 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 223 EventRootType Probe[main.condUint8]
+          Type: 226 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 224 EventRootType Probe[main.condUint8]Return
+          Type: 227 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 225 EventRootType Probe[main.condUint8]
+          Type: 228 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 226 EventRootType Probe[main.condUint8]Return
+          Type: 229 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 227 EventRootType Probe[main.condUint8]
+          Type: 230 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 228 EventRootType Probe[main.condUint8]Return
+          Type: 231 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.inlined]
+          Type: 348 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7eee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.inlined]Return
+          Type: 349 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a90ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 182 EventRootType Probe[main.intArg]
+          Type: 185 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4a8d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 183 EventRootType Probe[main.intArg]Return
+          Type: 186 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.intArrayArg]
+          Type: 195 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4a8f0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 193 EventRootType Probe[main.intArrayArg]Return
+          Type: 196 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4a8f56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 201 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4a9080", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 190 EventRootType Probe[main.intSliceArg]
+          Type: 193 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4a8e8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 191 EventRootType Probe[main.intSliceArg]Return
+          Type: 194 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4a8ecf", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 338 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 339 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 344 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 345 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 332 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 333 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 334 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 337 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 294 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 295 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 296 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 297 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 298 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 299 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 300 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 301 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 302 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 303 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 320 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 321 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 322 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 323 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 184 EventRootType Probe[main.stringArg]
+          Type: 187 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 185 EventRootType Probe[main.stringArg]Return
+          Type: 188 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 186 EventRootType Probe[main.stringArg]
+          Type: 189 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 187 EventRootType Probe[main.stringArg]Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 199 EventRootType Probe[main.mapArg]
+          Type: 202 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4a916a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 200 EventRootType Probe[main.mapArg]Return
+          Type: 203 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4a919f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 203 EventRootType Probe[main.noArgs]
+          Type: 206 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4a928a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 204 EventRootType Probe[main.noArgs]Return
+          Type: 207 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4a92c6", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 188 EventRootType Probe[main.stringArg]
+          Type: 191 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 189 EventRootType Probe[main.stringArg]Return
+          Type: 192 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArrayArg]
+          Type: 199 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 197 EventRootType Probe[main.stringArrayArg]Return
+          Type: 200 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4a9056", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.stringSliceArg]
+          Type: 197 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4a8f8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.stringSliceArg]Return
+          Type: 198 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4a8fcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aaf36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 347 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4ab0fc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2424,12 +3091,316 @@ Subprograms:
                   Op: {CfaOffset: 88}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4aa400..0x4aa545]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa400..0x4aa487
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4aa487..0x4aa48c
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4aa48c..0x4aa545
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa400..0x4aa48f
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4aa48f..0x4aa494
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4aa494..0x4aa545
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0x4aa560..0x4aa6bb]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 105 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4aa560..0x4aa5f6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa5f6..0x4aa5fb
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa5fb..0x4aa5fe
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa5fe..0x4aa6bb
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa560..0x4aa605
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4aa605..0x4aa6bb
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0x4aa6c0..0x4aa7ea]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0x4aa6c0..0x4aa72c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aa72c..0x4aa7ea
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa6c0..0x4aa731
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa731..0x4aa734
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aa734..0x4aa7ea
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0x4aa800..0x4aa913]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 93 PointerType *string
+          Locations:
+            - Range: 0x4aa800..0x4aa86c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aa86c..0x4aa913
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa800..0x4aa871
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aa871..0x4aa874
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aa874..0x4aa913
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4aa920..0x4aaaf4]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 122 StructureType main.lenFields
+          Locations:
+            - Range: 0x4aa920..0x4aaaf4
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aa920..0x4aa9ed
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4aa9ed..0x4aa9f2
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4aa9f2..0x4aaaf4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4aab00..0x4aac8d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4aab00..0x4aab7d
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aab7d..0x4aac8d
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aab00..0x4aab82
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aab82..0x4aab85
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aab85..0x4aac8d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4aaca0..0x4aadca]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4aaca0..0x4aad1b
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4aad1b..0x4aadca
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aaca0..0x4aad20
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4aad20..0x4aad23
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4aad23..0x4aadca
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0x4aade0..0x4aaf1d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 StructureType main.condFields
+          Locations:
+            - Range: 0x4aade0..0x4aaf1d
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4aade0..0x4aae71
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4aae71..0x4aae76
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4aae76..0x4aaf1d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0x4aaf20..0x4ab10f]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0x4aaf20..0x4ab0fc
               Pieces: []
@@ -2438,7 +3409,7 @@ Subprograms:
             - Range: 0x4ab0fd..0x4ab10f
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0x4a90a0..0x4a9102]
       InlinePCRanges:
@@ -2453,7 +3424,7 @@ Subprograms:
             - Range: 0x4a90a0..0x4a90b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2461,12 +3432,12 @@ Subprograms:
           RootRanges: [0x4a7d60..0x4a8d78]
       Variables:
         - Name: ptr
-          Type: 127 PointerType *****int
+          Type: 130 PointerType *****int
           Locations:
             - Range: 0x4a80ff..0x4a814b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2474,45 +3445,45 @@ Subprograms:
           RootRanges: [0x4a7d60..0x4a8d78]
       Variables:
         - Name: ptr
-          Type: 129 PointerType **int
+          Type: 132 PointerType **int
           Locations:
             - Range: 0x4a8170..0x4a81aa
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35968
       GoKind: 22
-      Pointee: 128 PointerType ****int
+      Pointee: 131 PointerType ****int
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35904
       GoKind: 22
-      Pointee: 181 PointerType ***int
+      Pointee: 184 PointerType ***int
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35840
       GoKind: 22
-      Pointee: 129 PointerType **int
+      Pointee: 132 PointerType **int
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35776
       GoKind: 22
       Pointee: 98 PointerType *int
     - __kind: PointerType
-      ID: 167
+      ID: 170
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 171 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '**table<string,int>'
@@ -2524,15 +3495,22 @@ Types:
       ByteSize: 8
       Pointee: 118 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 137
+      ID: 123
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 35712
+      GoKind: 22
+      Pointee: 105 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 140
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []int.array
+      Pointee: 139 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2541,20 +3519,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 138 GoSliceDataType []string.array
+      Pointee: 141 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []uint8.array
+      Pointee: 135 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uintptr.array
+      Pointee: 137 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -2605,12 +3583,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 154
+      ID: 157
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27520
       GoKind: 22
-      Pointee: 155 StructureType main.bigStruct
+      Pointee: 158 StructureType main.bigStruct
     - __kind: PointerType
       ID: 121
       Name: '*main.condFields'
@@ -2619,10 +3597,17 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType main.condFields
     - __kind: PointerType
-      ID: 165
+      ID: 124
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 27392
+      GoKind: 22
+      Pointee: 122 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 168
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 169 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 110
       Name: '*map<string,int>'
@@ -2634,30 +3619,30 @@ Types:
       ByteSize: 8
       Pointee: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]int
+      Pointee: 146 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 150
+      ID: 153
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 151 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2736,30 +3721,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 130 GoStringDataType string.str
+      Pointee: 133 GoStringDataType string.str
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 171 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 174 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 113
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 140 StructureType table<string,int>
+      Pointee: 143 StructureType table<string,int>
     - __kind: PointerType
       ID: 118
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 148 StructureType table<string,main.bigStruct>
+      Pointee: 151 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 126
+      ID: 129
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 158 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 161 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 103
       Name: '*uint'
@@ -2803,7 +3788,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 295
+      ID: 350
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2812,24 +3797,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 127 PointerType *****int
+            Type: 130 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 127 PointerType *****int
+            Type: 130 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 351
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2838,14 +3823,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType **int
+            Type: 132 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2871,10 +3856,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2890,7 +3875,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2906,7 +3891,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2932,16 +3917,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 241
+      ID: 244
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2957,10 +3942,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 245
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2976,10 +3961,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2995,7 +3980,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3021,13 +4006,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 210
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 212
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 213
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 216
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3043,7 +4028,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 215
+      ID: 218
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3059,7 +4044,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 220
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3085,16 +4070,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 214
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 216
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 218
+      ID: 217
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 219
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 221
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 222
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3110,7 +4095,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3136,13 +4121,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
+      ID: 223
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3158,7 +4143,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3184,13 +4169,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3206,7 +4191,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 293
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3232,7 +4217,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3248,7 +4233,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3274,71 +4259,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 288
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 289
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 291
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 274
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3354,7 +4339,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3370,7 +4355,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3396,16 +4381,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 279
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 284
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3421,7 +4406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3447,10 +4432,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3466,7 +4451,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3482,7 +4467,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3490,6 +4475,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3499,70 +4536,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 255
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 257
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 252
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 254
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 256
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 258
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 259
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 262
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3578,7 +4563,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3594,7 +4579,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3610,7 +4595,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3626,7 +4611,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3642,7 +4627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 269
+      ID: 272
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3668,25 +4653,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 262
+      ID: 265
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 264
+      ID: 267
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 268
+      ID: 271
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3702,7 +4687,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3728,13 +4713,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 232
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 233
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 235
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 236
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3750,7 +4735,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
+      ID: 238
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3776,13 +4761,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 234
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 236
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 237
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 240
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3798,7 +4783,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 239
+      ID: 242
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3824,13 +4809,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 238
+      ID: 241
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 240
+      ID: 243
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 223
+      ID: 226
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3846,7 +4831,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3862,7 +4847,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3888,16 +4873,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
+      ID: 227
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 348
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3909,14 +4894,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 294
+      ID: 349
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 185
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3932,10 +4917,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 186
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3951,10 +4936,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3970,10 +4955,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 338
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 119 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 109 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 122 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 202
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3999,16 +5508,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 184
+      ID: 187
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4024,10 +5533,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 186
+      ID: 189
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4053,16 +5562,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 185
+      ID: 188
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4078,7 +5587,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4094,10 +5603,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4113,13 +5622,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 346
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 292
+      ID: 347
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4128,10 +5637,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4151,7 +5660,7 @@ Types:
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 48000
@@ -4277,29 +5786,29 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 181
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 171 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 149
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 113 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 159
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 118 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 172
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 126 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 129 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 105
       Name: '[]int'
@@ -4316,37 +5825,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 136 GoSliceDataType []int.array
+      Data: 139 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 182
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 150
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 143 StructureType noalg.map.group[string]int
+      Element: 146 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 151 StructureType noalg.map.group[string]main.bigStruct
+      Element: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 173
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -4367,9 +5876,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 138 GoSliceDataType []string.array
+      Data: 141 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 141
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4390,9 +5899,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 132 GoSliceDataType []uint8.array
+      Data: 135 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 135
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4413,9 +5922,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 134 GoSliceDataType []uintptr.array
+      Data: 137 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4476,61 +5985,61 @@ Types:
       GoRuntimeType: 58336
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 175
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 176 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 179 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 182 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 144
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]int
+          Type: 145 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]int
-      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 146 StructureType noalg.map.group[string]int
+      GroupSliceType: 150 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 149
+      ID: 152
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 150 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 153 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 151 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 157 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 154 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 160 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 159
+      ID: 162
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 160 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 163 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 173 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4661,14 +6170,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 177
+      ID: 180
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 71424
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 155
+      ID: 158
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 123296
@@ -4697,7 +6206,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 180 ArrayType [128]uint8
+          Type: 183 ArrayType [128]uint8
     - __kind: StructureType
       ID: 119
       Name: main.condFields
@@ -4744,8 +6253,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 120 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 122
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 117664
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 105 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 109 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 93 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 123 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 120 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 169
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4758,7 +6292,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 170 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4774,8 +6308,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 178 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 181 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 111
       Name: map<string,int>
@@ -4806,8 +6340,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 146 GoSliceDataType []*table<string,int>.array
-      GroupType: 143 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 149 GoSliceDataType []*table<string,int>.array
+      GroupType: 146 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 116
       Name: map<string,main.bigStruct>
@@ -4838,10 +6372,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 156 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 151 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 159 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 127
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4854,7 +6388,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 128 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4870,15 +6404,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 172 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 69408
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 169 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
@@ -4894,50 +6428,50 @@ Types:
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 122
+      ID: 125
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 69792
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 175
+      ID: 178
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 47904
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 179 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 152
+      ID: 155
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 48096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 153 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 156 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 144
+      ID: 147
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47520
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem int }
+      Element: 148 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 162
+      ID: 165
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 48288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 163 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 166 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 174
+      ID: 177
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 77440
@@ -4948,9 +6482,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 178 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 143
+      ID: 146
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77184
@@ -4961,9 +6495,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 147 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 151
+      ID: 154
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77696
@@ -4974,9 +6508,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 152 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 78208
@@ -4987,9 +6521,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 162 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 165 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 176
+      ID: 179
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 77312
@@ -5000,9 +6534,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 177 StructureType main.aStructNotUsedAsAnArgument
+          Type: 180 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77568
@@ -5013,9 +6547,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 154 PointerType *main.bigStruct
+          Type: 157 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 77056
@@ -5028,7 +6562,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 78080
@@ -5039,7 +6573,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 164 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 167 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5803,18 +7337,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 131 PointerType *string.str
+          Type: 134 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 130 GoStringDataType string.str
+      Data: 133 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 130
+      ID: 133
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 171
+      ID: 174
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5836,9 +7370,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 175 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -5860,9 +7394,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,int>
+          Type: 144 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -5884,9 +7418,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 149 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 152 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5908,7 +7442,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 159 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 162 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 16
       Name: uint
@@ -5951,7 +7485,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43680
       GoKind: 26
-MaxTypeID: 296
+MaxTypeID: 351
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6182,6 +7716,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.PointerChainArg]
+          Type: 366 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 367 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.inlined]
+          Type: 364 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7eee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.inlined]Return
+          Type: 365 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a90ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenErrInt]
+          Type: 354 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenErrInt]Return
+          Type: 355 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenErrStruct]
+          Type: 358 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenErrStruct]Return
+          Type: 359 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenErrInt]
+          Type: 356 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenErrInt]Return
+          Type: 357 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenErrStruct]
+          Type: 360 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenErrStruct]Return
+          Type: 361 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenMap]
+          Type: 320 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenMap]Return
+          Type: 321 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenMap]
+          Type: 322 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenMap]Return
+          Type: 323 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenPtrString]
+          Type: 324 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenPtrString]Return
+          Type: 325 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenPtrString]
+          Type: 326 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenPtrString]Return
+          Type: 327 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenPtrStructFields]
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenPtrStructFields]
+          Type: 348 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 349 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenPtrStructFields]
+          Type: 350 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 353 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenSlice]
+          Type: 310 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenSlice]Return
+          Type: 311 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenSlice]
+          Type: 312 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenSlice]Return
+          Type: 313 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenStructFields]
+          Type: 328 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenStructFields]Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenStructFields]
+          Type: 330 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenStructFields]Return
+          Type: 331 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenStructFields]
+          Type: 332 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenStructFields]Return
+          Type: 333 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenStructFields]
+          Type: 334 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenStructFields]Return
+          Type: 335 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenStructFields]
+          Type: 336 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenStructFields]Return
+          Type: 337 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenStructFields]
+          Type: 338 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aaf36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 363 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4ab0fc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3788,7 +4093,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3814,7 +4119,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4882,7 +5187,7 @@ Types:
       ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,7 +5203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 185
@@ -4958,7 +5263,7 @@ Types:
       ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4984,16 +5289,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5019,19 +5324,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 308
+      ID: 314
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 316
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 322
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5057,13 +5429,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 309
+      ID: 315
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 317
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 312
+      ID: 319
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 324
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5082,7 +5463,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5108,13 +5489,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 325
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 315
+      ID: 327
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5140,10 +5521,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5162,7 +5562,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5181,19 +5581,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 304
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5209,7 +5657,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 312
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5239,6 +5687,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 307
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 313
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 294
@@ -5346,7 +5803,7 @@ Types:
       ID: 303
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 328
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5372,10 +5829,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 332
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5394,7 +5867,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 334
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5413,7 +5886,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 336
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5429,7 +5902,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 338
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5445,7 +5918,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 340
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5461,25 +5934,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.lenStructFields]Return
+      ID: 342
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 325
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.lenStructFields]Return
+      ID: 344
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 345
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 202
@@ -5625,10 +6136,10 @@ Types:
       ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7485,7 +7996,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43680
       GoKind: 26
-MaxTypeID: 351
+MaxTypeID: 367
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 366 EventRootType Probe[main.PointerChainArg]
+          Type: 382 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4a8126", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 367 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 383 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4a8170", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 212 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
           Condition:
-            Type: 101 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 216 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 218 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 222 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
           Condition:
-            Type: 12 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 208 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
           Condition:
-            Type: 15 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 292 EventRootType Probe[main.condLine]Line
+          Type: 296 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 293 EventRootType Probe[main.condLine]Line
+          Type: 297 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condNilPtrStruct]
+          Type: 284 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condNilPtrStruct]
+          Type: 286 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 287 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condOnly]
+          Type: 292 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condOnly]Return
+          Type: 293 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condOnly]
+          Type: 294 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condOnly]Return
+          Type: 295 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condPtrStructArg]
+          Type: 278 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condPtrStructArg]
+          Type: 280 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 281 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condPtrStructArg]
+          Type: 282 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 283 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condReturnAndLocal]
+          Type: 288 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condReturnAndLocal]
+          Type: 290 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 291 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 254 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 256 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 258 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 259 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 260 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 261 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condString]
+          Type: 262 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condString]Return
+          Type: 263 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condString]
+          Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condString]Return
+          Type: 265 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condStructArg]
+          Type: 266 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condStructArg]Return
+          Type: 267 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condStructArg]
+          Type: 268 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condStructArg]Return
+          Type: 269 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condStructArg]
+          Type: 270 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
-            Type: 18 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condStructArg]Return
+          Type: 271 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condStructArg]
+          Type: 274 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condStructArg]Return
+          Type: 275 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 232 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 236 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 240 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 226 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 228 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 364 EventRootType Probe[main.inlined]
+          Type: 380 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4a7eee"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 365 EventRootType Probe[main.inlined]Return
+          Type: 381 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4a90ea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenErrInt]
+          Type: 370 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenErrInt]Return
+          Type: 371 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.lenErrStruct]
+          Type: 374 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.lenErrStruct]Return
+          Type: 375 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.lenErrInt]
+          Type: 372 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4aacb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.lenErrInt]Return
+          Type: 373 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4aad9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.lenErrStruct]
+          Type: 376 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4aadf3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 361 EventRootType Probe[main.lenErrStruct]Return
+          Type: 377 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4aaef6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenMap]
+          Type: 328 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenMap]Return
+          Type: 329 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenMap]
+          Type: 332 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenMap]Return
+          Type: 333 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenMap]
+          Type: 334 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenMap]Return
+          Type: 335 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenMap]
+          Type: 336 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenMap]Return
+          Type: 337 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenMap]
+          Type: 338 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4aa6ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenMap]Return
+          Type: 339 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4aa7bc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenPtrString]
+          Type: 340 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          Type: 341 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenPtrString]
+          Type: 342 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4aa80e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenPtrString]Return
+          Type: 343 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4aa8e5", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          Type: 362 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenPtrStructFields]
+          Type: 364 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 365 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenPtrStructFields]
+          Type: 366 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 367 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenPtrStructFields]
+          Type: 368 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4aab13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 369 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4aac5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenSlice]
+          Type: 316 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenSlice]Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenSlice]
+          Type: 320 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenSlice]Return
+          Type: 321 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenSlice]
+          Type: 322 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenSlice]Return
+          Type: 323 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenSlice]
+          Type: 324 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenSlice]Return
+          Type: 325 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenSlice]
+          Type: 326 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4aa573", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenSlice]Return
+          Type: 327 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4aa676", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 298 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 299 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 300 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 301 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 302 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 303 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 294 EventRootType Probe[main.lenString]
+          Type: 304 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 295 EventRootType Probe[main.lenString]Return
+          Type: 305 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.lenString]
+          Type: 308 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.lenString]Return
+          Type: 309 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.lenString]
+          Type: 310 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 299 EventRootType Probe[main.lenString]Return
+          Type: 311 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.lenString]
+          Type: 312 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 301 EventRootType Probe[main.lenString]Return
+          Type: 313 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 302 EventRootType Probe[main.lenString]
+          Type: 314 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4aa413", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 303 EventRootType Probe[main.lenString]Return
+          Type: 315 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4aa505", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenStructFields]
+          Type: 346 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          Type: 347 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenStructFields]
+          Type: 348 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          Type: 349 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenStructFields]
+          Type: 350 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          Type: 351 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenStructFields]
+          Type: 352 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          Type: 353 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenStructFields]
+          Type: 356 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          Type: 357 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenStructFields]
+          Type: 358 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          Type: 359 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenStructFields]
+          Type: 360 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4aa933", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenStructFields]Return
+          Type: 361 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4aaac8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 378 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4aaf36", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 363 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 379 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4ab0fc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4093,7 +4305,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4119,7 +4331,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4480,7 +4692,7 @@ Types:
       ID: 211
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4496,7 +4708,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4522,7 +4734,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 284
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4538,7 +4750,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 286
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4564,13 +4776,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 285
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 283
+      ID: 287
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 288
+      ID: 292
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4596,7 +4808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4622,45 +4834,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 293
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 278
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 282
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4686,16 +4898,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 277
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 279
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 281
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 288
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4711,7 +4923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 290
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4737,10 +4949,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 289
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 287
+      ID: 291
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4790,6 +5002,48 @@ Types:
     - __kind: EventRootType
       ID: 258
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4814,7 +5068,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 264
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4852,7 +5106,13 @@ Types:
       ID: 261
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 262
+      ID: 263
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 266
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4860,38 +5120,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -4934,6 +5162,38 @@ Types:
     - __kind: EventRootType
       ID: 272
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4958,12 +5218,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 265
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 267
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4974,6 +5228,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 273
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 232
@@ -5187,7 +5447,7 @@ Types:
       ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5203,7 +5463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 185
@@ -5263,7 +5523,7 @@ Types:
       ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5289,16 +5549,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5324,16 +5584,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 328
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5349,7 +5609,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 330
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5368,7 +5653,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 334
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5384,7 +5669,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 336
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5403,7 +5688,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 338
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5429,22 +5714,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 329
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 331
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 333
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 335
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 323
+      ID: 337
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 339
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 340
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5463,7 +5751,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 342
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5489,13 +5777,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5521,7 +5809,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,7 +5831,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5562,7 +5850,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5581,19 +5869,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 316
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5609,7 +5897,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 306
+      ID: 318
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5625,7 +5935,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 322
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5641,7 +5951,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 324
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5657,7 +5967,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 326
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5683,22 +5993,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 323
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 325
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 327
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5714,7 +6093,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 306
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5730,7 +6131,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 310
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5746,7 +6147,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 312
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5762,7 +6163,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 314
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5788,12 +6189,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 299
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5803,7 +6198,25 @@ Types:
       ID: 303
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 305
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 344
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5829,7 +6242,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5848,7 +6261,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5867,7 +6280,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5886,7 +6299,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5902,7 +6315,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5918,7 +6331,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5934,7 +6347,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5950,7 +6363,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5965,32 +6378,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 331
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 339
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 345
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 357
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 361
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 202
@@ -6136,10 +6549,10 @@ Types:
       ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7996,7 +8409,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43680
       GoKind: 26
-MaxTypeID: 367
+MaxTypeID: 383
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8074,7 +8487,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8104,7 +8517,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8119,7 +8532,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8134,7 +8547,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 201 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4a8bd3", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a91d3", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 202 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0x4a8c5e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a925e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 245 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 246 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 247 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 248 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 249 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9a6a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 250 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9ada", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 241 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a98ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 242 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0x4a935e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a995e", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 243 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a99aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 244 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0x4a941f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9a1f", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 209 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4a8daa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
           Condition:
             Type: 101 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 210 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4a8e1a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 211 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4a8daa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a93aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 212 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4a8e1a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a941a", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 213 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a8e6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 214 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a8eda", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 215 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a8e6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 216 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a8eda", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 217 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4a8e6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a946a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 218 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4a8eda", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a94da", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 219 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4a8f2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 220 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4a8f9a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 221 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4a8f2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 222 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4a8f9a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a959a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 205 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4a8cea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
           Condition:
             Type: 15 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 206 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4a8d5a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 207 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4a8cea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a92ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 208 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4a8d5a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a935a", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 289 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4a9ac7", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 290 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4a9ac7", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aa0c1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 277 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4a988e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 278 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4a990e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 279 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4a988e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9e8e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 280 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4a990e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9f0e", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 285 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4a99ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 286 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4a9a5a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 287 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4a99ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9fea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 288 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4a9a5a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aa05a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 271 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a972e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 272 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a9845", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 273 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a972e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 274 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a9845", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 275 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4a972e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9d2e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 276 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4a9845", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9e45", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 281 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4a994a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 282 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4a99b5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 283 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4a994a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9f4a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 284 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4a99b5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9fb5", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 251 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 252 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a959f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 253 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 254 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a959f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 255 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 256 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a959f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 257 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4a952a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b2a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 258 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4a959f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9b9f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 259 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 260 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 261 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 262 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 263 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 18 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 264 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 265 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 266 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 267 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 268 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 269 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4a95ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9bee", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 270 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4a96ef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9cef", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 229 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4a90aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 230 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4a911a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 231 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4a90aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a96aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 232 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4a911a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a971a", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 233 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4a916a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 234 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4a91da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 235 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4a916a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a976a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 236 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4a91da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a97da", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 237 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4a922a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 238 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4a929a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 239 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4a922a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a982a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 240 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4a929a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a989a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 223 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a8fea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 224 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a905a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 225 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a8fea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 226 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a905a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 227 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4a8fea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a95ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 228 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4a905a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a965a", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0x4a7eee"
               Frameless: false
-            - PC: "0x4a8aaa"
+            - PC: "0x4a90aa"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 294 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0x4a8aea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a90ea", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 182 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4a878a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8d8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 183 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0x4a87ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8dca", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4a890a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8f0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 193 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0x4a8956", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8f56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4a8a80", Frameless: true}]
+          InjectionPoints: [{PC: "0x4a9080", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 190 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4a888a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 191 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0x4a88cf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8ecf", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 184 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a880a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 185 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a884f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 186 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a880a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 187 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a884f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 199 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4a8b6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a916a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 200 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0x4a8b9f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a919f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 203 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4a8c8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a928a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 204 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0x4a8cc6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a92c6", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 188 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4a880a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 189 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4a884f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8e4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4a8a0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a900a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 197 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0x4a8a56", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a9056", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4a898a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8f8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4a89cf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4a8fcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 291 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4a9df6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aaf36", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 292 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0x4a9fbc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4ab0fc", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4a8780..0x4a87e2]
+      OutOfLinePCRanges: [0x4a8d80..0x4a8de2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a8780..0x4a8799
+            - Range: 0x4a8d80..0x4a8d99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4a8800..0x4a8871]
+      OutOfLinePCRanges: [0x4a8e00..0x4a8e71]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8800..0x4a881e
+            - Range: 0x4a8e00..0x4a8e1e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4a8880..0x4a88fa]
+      OutOfLinePCRanges: [0x4a8e80..0x4a8efa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a8880..0x4a889e
+            - Range: 0x4a8e80..0x4a8e9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4a8900..0x4a8967]
+      OutOfLinePCRanges: [0x4a8f00..0x4a8f67]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0x4a8900..0x4a8967
+            - Range: 0x4a8f00..0x4a8f67
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4a8980..0x4a89fa]
+      OutOfLinePCRanges: [0x4a8f80..0x4a8ffa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4a8980..0x4a899e
+            - Range: 0x4a8f80..0x4a8f9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4a8a00..0x4a8a67]
+      OutOfLinePCRanges: [0x4a9000..0x4a9067]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0x4a8a00..0x4a8a67
+            - Range: 0x4a9000..0x4a9067
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4a8a80..0x4a8a81]
+      OutOfLinePCRanges: [0x4a9080..0x4a9081]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0x4a8a80..0x4a8a81
+            - Range: 0x4a9080..0x4a9081
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4a8b60..0x4a8bb6]
+      OutOfLinePCRanges: [0x4a9160..0x4a91b6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4a8b60..0x4a8b8d
+            - Range: 0x4a9160..0x4a918d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4a8bc0..0x4a8c7b]
+      OutOfLinePCRanges: [0x4a91c0..0x4a927b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4a8bc0..0x4a8bf3
+            - Range: 0x4a91c0..0x4a91f3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a8bf3..0x4a8c7b
+            - Range: 0x4a91f3..0x4a927b
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4a8c80..0x4a8cd3]
+      OutOfLinePCRanges: [0x4a9280..0x4a92d3]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4a8ce0..0x4a8d88]
+      OutOfLinePCRanges: [0x4a92e0..0x4a9388]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0x4a8ce0..0x4a8d21
+            - Range: 0x4a92e0..0x4a9321
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8ce0..0x4a8d24
+            - Range: 0x4a92e0..0x4a9324
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a8d24..0x4a8d29
+            - Range: 0x4a9324..0x4a9329
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4a8da0..0x4a8e49]
+      OutOfLinePCRanges: [0x4a93a0..0x4a9449]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 101 BaseType int16
           Locations:
-            - Range: 0x4a8da0..0x4a8dc9
+            - Range: 0x4a93a0..0x4a93c9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8da0..0x4a8dc9
+            - Range: 0x4a93a0..0x4a93c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a8dc9..0x4a8e49
+            - Range: 0x4a93c9..0x4a9449
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4a8e60..0x4a8f07]
+      OutOfLinePCRanges: [0x4a9460..0x4a9507]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4a8e60..0x4a8e89
+            - Range: 0x4a9460..0x4a9489
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8e60..0x4a8e89
+            - Range: 0x4a9460..0x4a9489
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a8e89..0x4a8f07
+            - Range: 0x4a9489..0x4a9507
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4a8f20..0x4a8fc9]
+      OutOfLinePCRanges: [0x4a9520..0x4a95c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4a8f20..0x4a8f49
+            - Range: 0x4a9520..0x4a9549
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8f20..0x4a8f49
+            - Range: 0x4a9520..0x4a9549
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a8f49..0x4a8fc9
+            - Range: 0x4a9549..0x4a95c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4a8fe0..0x4a9088]
+      OutOfLinePCRanges: [0x4a95e0..0x4a9688]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4a8fe0..0x4a9021
+            - Range: 0x4a95e0..0x4a9621
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a8fe0..0x4a9024
+            - Range: 0x4a95e0..0x4a9624
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9024..0x4a9029
+            - Range: 0x4a9624..0x4a9629
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4a90a0..0x4a9149]
+      OutOfLinePCRanges: [0x4a96a0..0x4a9749]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4a90a0..0x4a90c9
+            - Range: 0x4a96a0..0x4a96c9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a90a0..0x4a90c9
+            - Range: 0x4a96a0..0x4a96c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a90c9..0x4a9149
+            - Range: 0x4a96c9..0x4a9749
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4a9160..0x4a9207]
+      OutOfLinePCRanges: [0x4a9760..0x4a9807]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4a9160..0x4a9189
+            - Range: 0x4a9760..0x4a9789
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9160..0x4a9189
+            - Range: 0x4a9760..0x4a9789
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9189..0x4a9207
+            - Range: 0x4a9789..0x4a9807
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4a9220..0x4a92c9]
+      OutOfLinePCRanges: [0x4a9820..0x4a98c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4a9220..0x4a9249
+            - Range: 0x4a9820..0x4a9849
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9220..0x4a9249
+            - Range: 0x4a9820..0x4a9849
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9249..0x4a92c9
+            - Range: 0x4a9849..0x4a98c9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4a92e0..0x4a938e]
+      OutOfLinePCRanges: [0x4a98e0..0x4a998e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x4a92e0..0x4a930d
+            - Range: 0x4a98e0..0x4a990d
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a92e0..0x4a9308
+            - Range: 0x4a98e0..0x4a9908
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a9308..0x4a930d
+            - Range: 0x4a9908..0x4a990d
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a930d..0x4a938e
+            - Range: 0x4a990d..0x4a998e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4a93a0..0x4a944f]
+      OutOfLinePCRanges: [0x4a99a0..0x4a9a4f]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0x4a93a0..0x4a93ce
+            - Range: 0x4a99a0..0x4a99ce
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a93a0..0x4a93c9
+            - Range: 0x4a99a0..0x4a99c9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a93c9..0x4a93ce
+            - Range: 0x4a99c9..0x4a99ce
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a93ce..0x4a944f
+            - Range: 0x4a99ce..0x4a9a4f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4a9460..0x4a9508]
+      OutOfLinePCRanges: [0x4a9a60..0x4a9b08]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4a9460..0x4a94a1
+            - Range: 0x4a9a60..0x4a9aa1
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9460..0x4a94a4
+            - Range: 0x4a9a60..0x4a9aa4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a94a4..0x4a94a9
+            - Range: 0x4a9aa4..0x4a9aa9
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4a9520..0x4a95d7]
+      OutOfLinePCRanges: [0x4a9b20..0x4a9bd7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9520..0x4a954e
+            - Range: 0x4a9b20..0x4a9b4e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9520..0x4a954e
+            - Range: 0x4a9b20..0x4a9b4e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4a954e..0x4a95d7
+            - Range: 0x4a9b4e..0x4a9bd7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4a95e0..0x4a9714]
+      OutOfLinePCRanges: [0x4a9be0..0x4a9d14]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0x4a95e0..0x4a9714
+            - Range: 0x4a9be0..0x4a9d14
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a95e0..0x4a9625
+            - Range: 0x4a9be0..0x4a9c25
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a9625..0x4a962a
+            - Range: 0x4a9c25..0x4a9c2a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4a962a..0x4a9714
+            - Range: 0x4a9c2a..0x4a9d14
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4a9720..0x4a9873]
+      OutOfLinePCRanges: [0x4a9d20..0x4a9e73]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0x4a9720..0x4a9776
+            - Range: 0x4a9d20..0x4a9d76
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9776..0x4a9873
+            - Range: 0x4a9d76..0x4a9e73
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9720..0x4a977b
+            - Range: 0x4a9d20..0x4a9d7b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a977b..0x4a9873
+            - Range: 0x4a9d7b..0x4a9e73
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4a9880..0x4a993c]
+      OutOfLinePCRanges: [0x4a9e80..0x4a9f3c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0x4a9880..0x4a98d5
+            - Range: 0x4a9e80..0x4a9ed5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9880..0x4a98d8
+            - Range: 0x4a9e80..0x4a9ed8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a98d8..0x4a98dd
+            - Range: 0x4a9ed8..0x4a9edd
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4a9940..0x4a99d9]
+      OutOfLinePCRanges: [0x4a9f40..0x4a9fd9]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9940..0x4a9951
+            - Range: 0x4a9f40..0x4a9f51
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9940..0x4a997f
+            - Range: 0x4a9f40..0x4a9f7f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9940..0x4a99b5
+            - Range: 0x4a9f40..0x4a9fb5
               Pieces: []
-            - Range: 0x4a99b5..0x4a99b6
+            - Range: 0x4a9fb5..0x4a9fb6
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a99b6..0x4a99d9
+            - Range: 0x4a9fb6..0x4a9fd9
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9951..0x4a997f
+            - Range: 0x4a9f51..0x4a9f7f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a997f..0x4a99d9
+            - Range: 0x4a9f7f..0x4a9fd9
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4a99e0..0x4a9a89]
+      OutOfLinePCRanges: [0x4a9fe0..0x4aa089]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a99e0..0x4a9a09
+            - Range: 0x4a9fe0..0x4aa009
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a99e0..0x4a9a09
+            - Range: 0x4a9fe0..0x4aa009
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9a09..0x4a9a89
+            - Range: 0x4aa009..0x4aa089
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2291,33 +2291,33 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4a9aa0..0x4a9b85]
+      OutOfLinePCRanges: [0x4aa0a0..0x4aa185]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9aa0..0x4a9adc
+            - Range: 0x4aa0a0..0x4aa0dc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9adc..0x4a9b85
+            - Range: 0x4aa0dc..0x4aa185
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9aa0..0x4a9ac4
+            - Range: 0x4aa0a0..0x4aa0c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9ac4..0x4a9ae5
+            - Range: 0x4aa0c4..0x4aa0e5
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4a9ae5..0x4a9b85
+            - Range: 0x4aa0e5..0x4aa185
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2327,18 +2327,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4a9ac7..0x4a9ae5
+            - Range: 0x4aa0c7..0x4aa0e5
               Pieces: [{Size: 8, Op: {RegNo: 2, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4a9ba0..0x4a9c65]
+      OutOfLinePCRanges: [0x4aa1a0..0x4aa265]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4a9ba0..0x4a9bce
+            - Range: 0x4aa1a0..0x4aa1ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2350,13 +2350,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9ba0..0x4a9bce
+            - Range: 0x4aa1a0..0x4aa1ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4a9bce..0x4a9c65
+            - Range: 0x4aa1ce..0x4aa265
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2365,25 +2365,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4a9c80..0x4a9d1a]
+      OutOfLinePCRanges: [0x4aa280..0x4aa31a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0x4a9c80..0x4a9cb3
+            - Range: 0x4aa280..0x4aa2b3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9c80..0x4a9cb6
+            - Range: 0x4aa280..0x4aa2b6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4a9cb6..0x4a9cbb
+            - Range: 0x4aa2b6..0x4aa2bb
               Pieces:
                 - Size: 8
                   Op: null
@@ -2392,31 +2392,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4a9d20..0x4a9dda]
+      OutOfLinePCRanges: [0x4aa320..0x4aa3da]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0x4a9d20..0x4a9dda
+            - Range: 0x4aa320..0x4aa3da
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4a9d20..0x4a9d55
+            - Range: 0x4aa320..0x4aa355
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4a9d55..0x4a9d5a
+            - Range: 0x4aa355..0x4aa35a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4a9d5a..0x4a9dda
+            - Range: 0x4aa35a..0x4aa3da
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2425,32 +2425,32 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4a9de0..0x4a9fcf]
+      OutOfLinePCRanges: [0x4aaf20..0x4ab10f]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4a9de0..0x4a9fbc
+            - Range: 0x4aaf20..0x4ab0fc
               Pieces: []
-            - Range: 0x4a9fbc..0x4a9fbd
+            - Range: 0x4ab0fc..0x4ab0fd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4a9fbd..0x4a9fcf
+            - Range: 0x4ab0fd..0x4ab10f
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0x4a8aa0..0x4a8b02]
+      OutOfLinePCRanges: [0x4a90a0..0x4a9102]
       InlinePCRanges:
         - Ranges: [0x4a7eee..0x4a7f3f]
-          RootRanges: [0x4a7d60..0x4a8778]
+          RootRanges: [0x4a7d60..0x4a8d78]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4a7eee..0x4a7f3f
               Pieces: []
-            - Range: 0x4a8aa0..0x4a8ab9
+            - Range: 0x4a90a0..0x4a90b9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
@@ -2458,7 +2458,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8126..0x4a8165]
-          RootRanges: [0x4a7d60..0x4a8778]
+          RootRanges: [0x4a7d60..0x4a8d78]
       Variables:
         - Name: ptr
           Type: 127 PointerType *****int
@@ -2471,7 +2471,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4a8170..0x4a81aa]
-          RootRanges: [0x4a7d60..0x4a8778]
+          RootRanges: [0x4a7d60..0x4a8d78]
       Variables:
         - Name: ptr
           Type: 129 PointerType **int
@@ -2484,28 +2484,28 @@ Types:
       ID: 127
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35712
+      GoRuntimeType: 35968
       GoKind: 22
       Pointee: 128 PointerType ****int
     - __kind: PointerType
       ID: 128
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35648
+      GoRuntimeType: 35904
       GoKind: 22
       Pointee: 181 PointerType ***int
     - __kind: PointerType
       ID: 181
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35584
+      GoRuntimeType: 35840
       GoKind: 22
       Pointee: 129 PointerType **int
     - __kind: PointerType
       ID: 129
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35520
+      GoRuntimeType: 35776
       GoKind: 22
       Pointee: 98 PointerType *int
     - __kind: PointerType
@@ -2537,7 +2537,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 40192
+      GoRuntimeType: 40384
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2559,63 +2559,63 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30144
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 100
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28928
+      GoRuntimeType: 29056
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29888
+      GoRuntimeType: 30016
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 96
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29952
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 98
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29568
+      GoRuntimeType: 29696
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29312
+      GoRuntimeType: 29440
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 97
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29440
+      GoRuntimeType: 29568
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 154
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27392
+      GoRuntimeType: 27520
       GoKind: 22
       Pointee: 155 StructureType main.bigStruct
     - __kind: PointerType
       ID: 121
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 27264
+      GoRuntimeType: 27328
       GoKind: 22
       Pointee: 119 StructureType main.condFields
     - __kind: PointerType
@@ -2662,77 +2662,77 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30208
+      GoRuntimeType: 30336
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 82208
+      GoRuntimeType: 82400
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30848
+      GoRuntimeType: 30976
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30912
+      GoRuntimeType: 31040
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 60064
+      GoRuntimeType: 60256
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 66784
+      GoRuntimeType: 66976
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31616
+      GoRuntimeType: 31744
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 94176
+      GoRuntimeType: 94368
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 125216
+      GoRuntimeType: 125664
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 99360
+      GoRuntimeType: 99552
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28992
+      GoRuntimeType: 29120
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2764,42 +2764,42 @@ Types:
       ID: 103
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29632
+      GoRuntimeType: 29760
       GoKind: 22
       Pointee: 16 BaseType uint
     - __kind: PointerType
       ID: 104
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29248
+      GoRuntimeType: 29376
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29376
+      GoRuntimeType: 29504
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 99
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29504
+      GoRuntimeType: 29632
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29120
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29696
+      GoRuntimeType: 29824
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3208,7 +3208,7 @@ Types:
     - __kind: EventRootType
       ID: 290
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3231,16 +3231,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 277
       Name: Probe[main.condNilPtrStruct]
@@ -4147,7 +4137,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 53856
+      GoRuntimeType: 54048
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -4155,7 +4145,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 53760
+      GoRuntimeType: 53952
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4164,7 +4154,7 @@ Types:
       ID: 180
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47808
+      GoRuntimeType: 48000
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4173,7 +4163,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 53376
+      GoRuntimeType: 53568
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4182,7 +4172,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 53472
+      GoRuntimeType: 53664
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4191,7 +4181,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 53664
+      GoRuntimeType: 53856
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4200,7 +4190,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 49536
+      GoRuntimeType: 49728
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4209,7 +4199,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 55872
+      GoRuntimeType: 56064
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4218,7 +4208,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 53184
+      GoRuntimeType: 53376
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4227,7 +4217,7 @@ Types:
       ID: 106
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47424
+      GoRuntimeType: 47712
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4236,7 +4226,7 @@ Types:
       ID: 120
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 47232
+      GoRuntimeType: 47424
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4245,7 +4235,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 52896
+      GoRuntimeType: 53088
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4254,7 +4244,7 @@ Types:
       ID: 108
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47520
+      GoRuntimeType: 47808
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4263,7 +4253,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54912
+      GoRuntimeType: 55104
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4272,7 +4262,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 52128
+      GoRuntimeType: 52320
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4281,7 +4271,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 53568
+      GoRuntimeType: 53760
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4314,7 +4304,7 @@ Types:
       ID: 105
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38400
+      GoRuntimeType: 38592
       GoKind: 23
       RawFields:
         - Name: array
@@ -4365,7 +4355,7 @@ Types:
       ID: 107
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 38656
+      GoRuntimeType: 38848
       GoKind: 23
       RawFields:
         - Name: array
@@ -4388,7 +4378,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 38016
+      GoRuntimeType: 38208
       GoKind: 23
       RawFields:
         - Name: array
@@ -4411,7 +4401,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38528
+      GoRuntimeType: 38720
       GoKind: 23
       RawFields:
         - Name: array
@@ -4434,25 +4424,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43424
+      GoRuntimeType: 43616
       GoKind: 1
     - __kind: BaseType
       ID: 95
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43232
+      GoRuntimeType: 43424
       GoKind: 16
     - __kind: BaseType
       ID: 94
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43168
+      GoRuntimeType: 43360
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 64992
+      GoRuntimeType: 65184
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4465,25 +4455,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43296
+      GoRuntimeType: 43488
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43360
+      GoRuntimeType: 43552
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36160
+      GoRuntimeType: 36352
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 58144
+      GoRuntimeType: 58336
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 172
@@ -4545,37 +4535,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 42976
+      GoRuntimeType: 43168
       GoKind: 2
     - __kind: BaseType
       ID: 101
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 42592
+      GoRuntimeType: 42784
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 42720
+      GoRuntimeType: 42912
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 42848
+      GoRuntimeType: 43040
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42464
+      GoRuntimeType: 42656
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 115136
+      GoRuntimeType: 115328
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4597,7 +4587,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 75584
+      GoRuntimeType: 75776
       GoKind: 25
       RawFields:
         - Name: u
@@ -4607,7 +4597,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 102432
+      GoRuntimeType: 102624
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4623,7 +4613,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 92736
+      GoRuntimeType: 92928
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4636,7 +4626,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 92576
+      GoRuntimeType: 92768
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4649,7 +4639,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 92896
+      GoRuntimeType: 93088
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4661,27 +4651,27 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 63424
+      GoRuntimeType: 63616
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 63328
+      GoRuntimeType: 63520
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 177
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71232
+      GoRuntimeType: 71424
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 155
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 122848
+      GoRuntimeType: 123296
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4712,7 +4702,7 @@ Types:
       ID: 119
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 129920
+      GoRuntimeType: 130368
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4886,35 +4876,35 @@ Types:
       ID: 164
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 69088
+      GoRuntimeType: 69408
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 69216
+      GoRuntimeType: 69280
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 69344
+      GoRuntimeType: 69536
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 69600
+      GoRuntimeType: 69792
       GoKind: 21
       HeaderType: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 175
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 47616
+      GoRuntimeType: 47904
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4923,7 +4913,7 @@ Types:
       ID: 152
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47904
+      GoRuntimeType: 48096
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4932,7 +4922,7 @@ Types:
       ID: 144
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47712
+      GoRuntimeType: 47520
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4941,7 +4931,7 @@ Types:
       ID: 162
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 48096
+      GoRuntimeType: 48288
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4950,7 +4940,7 @@ Types:
       ID: 174
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 76992
+      GoRuntimeType: 77440
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4963,7 +4953,7 @@ Types:
       ID: 143
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77248
+      GoRuntimeType: 77184
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4976,7 +4966,7 @@ Types:
       ID: 151
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77504
+      GoRuntimeType: 77696
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4989,7 +4979,7 @@ Types:
       ID: 161
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 78016
+      GoRuntimeType: 78208
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5002,7 +4992,7 @@ Types:
       ID: 176
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 76864
+      GoRuntimeType: 77312
       GoKind: 25
       RawFields:
         - Name: key
@@ -5015,7 +5005,7 @@ Types:
       ID: 153
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77376
+      GoRuntimeType: 77568
       GoKind: 25
       RawFields:
         - Name: key
@@ -5028,7 +5018,7 @@ Types:
       ID: 145
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 77120
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: key
@@ -5041,7 +5031,7 @@ Types:
       ID: 163
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 77888
+      GoRuntimeType: 78080
       GoKind: 25
       RawFields:
         - Name: key
@@ -5069,14 +5059,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 62560
+      GoRuntimeType: 62752
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 145120
+      GoRuntimeType: 145568
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5257,7 +5247,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 74048
+      GoRuntimeType: 74240
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5267,7 +5257,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 120832
+      GoRuntimeType: 121280
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5295,7 +5285,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 90176
+      GoRuntimeType: 90368
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5308,7 +5298,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 107616
+      GoRuntimeType: 107808
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5327,13 +5317,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 56704
+      GoRuntimeType: 56896
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 90016
+      GoRuntimeType: 90208
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5346,7 +5336,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 119008
+      GoRuntimeType: 119456
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5371,13 +5361,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 56608
+      GoRuntimeType: 56800
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 150176
+      GoRuntimeType: 150624
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5600,7 +5590,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 121120
+      GoRuntimeType: 121568
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5628,7 +5618,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 113792
+      GoRuntimeType: 113984
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5650,7 +5640,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 113568
+      GoRuntimeType: 113760
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5672,7 +5662,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 73792
+      GoRuntimeType: 73984
       GoKind: 25
       RawFields:
         - Name: next
@@ -5682,20 +5672,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 56320
+      GoRuntimeType: 56512
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 73664
+      GoRuntimeType: 73856
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 89856
+      GoRuntimeType: 90048
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5708,7 +5698,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 108384
+      GoRuntimeType: 108576
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5727,13 +5717,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 56512
+      GoRuntimeType: 56704
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 59680
+      GoRuntimeType: 59872
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5742,7 +5732,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 88256
+      GoRuntimeType: 88448
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5763,7 +5753,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 43680
+      GoRuntimeType: 43872
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5773,7 +5763,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 43744
+      GoRuntimeType: 43936
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -5783,7 +5773,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 89216
+      GoRuntimeType: 89408
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5796,19 +5786,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 76608
+      GoRuntimeType: 76800
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 62464
+      GoRuntimeType: 62656
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42400
+      GoRuntimeType: 42592
       GoKind: 24
       RawFields:
         - Name: str
@@ -5923,43 +5913,43 @@ Types:
       ID: 16
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43040
+      GoRuntimeType: 43232
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42656
+      GoRuntimeType: 42848
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 42784
+      GoRuntimeType: 42976
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 42912
+      GoRuntimeType: 43104
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42528
+      GoRuntimeType: 42720
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43104
+      GoRuntimeType: 43296
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43488
+      GoRuntimeType: 43680
       GoKind: 26
 MaxTypeID: 296
 Issues:
@@ -6203,7 +6193,7 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x582340", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x584340", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 355 EventRootType Probe[main.PointerChainArg]
+          Type: 371 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae726", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 372 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae770", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 353 EventRootType Probe[main.inlined]
+          Type: 369 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae4ee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 354 EventRootType Probe[main.inlined]Return
+          Type: 370 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4af6ca", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenErrInt]
+          Type: 359 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenErrInt]Return
+          Type: 360 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.lenErrStruct]
+          Type: 363 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 348 EventRootType Probe[main.lenErrStruct]Return
+          Type: 364 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.lenErrInt]
+          Type: 361 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 346 EventRootType Probe[main.lenErrInt]Return
+          Type: 362 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.lenErrStruct]
+          Type: 365 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 350 EventRootType Probe[main.lenErrStruct]Return
+          Type: 366 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenMap]
+          Type: 325 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenMap]Return
+          Type: 326 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenMap]
+          Type: 327 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenMap]Return
+          Type: 328 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenPtrString]
+          Type: 329 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenPtrString]Return
+          Type: 330 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenPtrString]
+          Type: 331 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenPtrString]Return
+          Type: 332 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenPtrStructFields]
+          Type: 353 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 354 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenPtrStructFields]
+          Type: 355 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 356 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenPtrStructFields]
+          Type: 357 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 358 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenSlice]
+          Type: 315 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenSlice]Return
+          Type: 316 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenSlice]
+          Type: 317 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenSlice]Return
+          Type: 318 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenStructFields]
+          Type: 333 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenStructFields]
+          Type: 335 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          Type: 336 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenStructFields]
+          Type: 337 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          Type: 338 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenStructFields]
+          Type: 339 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          Type: 340 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenStructFields]
+          Type: 341 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenStructFields]Return
+          Type: 342 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenStructFields]
+          Type: 343 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenStructFields]Return
+          Type: 344 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 345 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 346 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 347 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 348 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenStructFields]
+          Type: 349 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          Type: 350 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 367 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4b1476", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 352 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 368 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4b1644", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3800,7 +4105,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3826,7 +4131,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4894,7 +5199,7 @@ Types:
       ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4910,7 +5215,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 190
@@ -4970,7 +5275,7 @@ Types:
       ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4996,16 +5301,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5031,19 +5336,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 319
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 321
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5069,13 +5441,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 314
+      ID: 320
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 322
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 324
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 329
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5094,7 +5475,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 331
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5120,13 +5501,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 320
+      ID: 332
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5152,10 +5533,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5174,7 +5574,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5193,19 +5593,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 309
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5221,7 +5669,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 317
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5251,6 +5699,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 312
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 318
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 299
@@ -5358,7 +5815,7 @@ Types:
       ID: 308
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 333
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5384,10 +5841,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 337
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5406,7 +5879,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 339
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5425,7 +5898,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 341
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5441,7 +5914,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 343
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5457,7 +5930,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 345
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5473,25 +5946,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.lenStructFields]Return
+      ID: 347
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 330
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.lenStructFields]Return
+      ID: 349
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 350
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 207
@@ -5637,10 +6148,10 @@ Types:
       ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7532,7 +8043,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45056
       GoKind: 26
-MaxTypeID: 356
+MaxTypeID: 372
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.PointerChainArg]
+          Type: 355 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae726", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 356 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae770", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.bigMapArg]
+          Type: 209 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4af7b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 207 EventRootType Probe[main.bigMapArg]Return
+          Type: 210 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4af83e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 250 EventRootType Probe[main.condBool]
+          Type: 253 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 251 EventRootType Probe[main.condBool]Return
+          Type: 254 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 252 EventRootType Probe[main.condBool]
+          Type: 255 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 253 EventRootType Probe[main.condBool]Return
+          Type: 256 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 254 EventRootType Probe[main.condBool]
+          Type: 257 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 255 EventRootType Probe[main.condBool]Return
+          Type: 258 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 246 EventRootType Probe[main.condFloat32]
+          Type: 249 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0x4afeca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 247 EventRootType Probe[main.condFloat32]Return
+          Type: 250 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0x4aff3e", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 248 EventRootType Probe[main.condFloat64]
+          Type: 251 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0x4aff8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 249 EventRootType Probe[main.condFloat64]Return
+          Type: 252 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0x4affff", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 214 EventRootType Probe[main.condInt16]
+          Type: 217 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4af98a", Frameless: false}]
           Condition:
             Type: 103 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 215 EventRootType Probe[main.condInt16]Return
+          Type: 218 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4af9fa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 216 EventRootType Probe[main.condInt16]
+          Type: 219 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4af98a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 217 EventRootType Probe[main.condInt16]Return
+          Type: 220 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4af9fa", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 218 EventRootType Probe[main.condInt32]
+          Type: 221 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 219 EventRootType Probe[main.condInt32]Return
+          Type: 222 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 220 EventRootType Probe[main.condInt32]
+          Type: 223 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 221 EventRootType Probe[main.condInt32]Return
+          Type: 224 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 222 EventRootType Probe[main.condInt32]
+          Type: 225 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 223 EventRootType Probe[main.condInt32]Return
+          Type: 226 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 224 EventRootType Probe[main.condInt64]
+          Type: 227 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4afb0a", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 225 EventRootType Probe[main.condInt64]Return
+          Type: 228 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4afb7a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 226 EventRootType Probe[main.condInt64]
+          Type: 229 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4afb0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 227 EventRootType Probe[main.condInt64]Return
+          Type: 230 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4afb7a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 210 EventRootType Probe[main.condInt8]
+          Type: 213 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4af8ca", Frameless: false}]
           Condition:
             Type: 16 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 211 EventRootType Probe[main.condInt8]Return
+          Type: 214 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4af93a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 212 EventRootType Probe[main.condInt8]
+          Type: 215 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4af8ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 213 EventRootType Probe[main.condInt8]Return
+          Type: 216 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4af93a", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 294 EventRootType Probe[main.condLine]Line
+          Type: 297 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 295 EventRootType Probe[main.condLine]Line
+          Type: 298 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condNilPtrStruct]
+          Type: 285 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 286 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condNilPtrStruct]
+          Type: 287 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condOnly]
+          Type: 293 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condOnly]Return
+          Type: 294 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 292 EventRootType Probe[main.condOnly]
+          Type: 295 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 293 EventRootType Probe[main.condOnly]Return
+          Type: 296 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condPtrStructArg]
+          Type: 279 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 280 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condPtrStructArg]
+          Type: 281 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condPtrStructArg]
+          Type: 283 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condReturnAndLocal]
+          Type: 289 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 290 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condReturnAndLocal]
+          Type: 291 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 256 EventRootType Probe[main.condString]
+          Type: 259 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 257 EventRootType Probe[main.condString]Return
+          Type: 260 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condString]
+          Type: 261 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condString]Return
+          Type: 262 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condString]
+          Type: 263 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condString]Return
+          Type: 264 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condString]
+          Type: 265 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condString]Return
+          Type: 266 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condStructArg]
+          Type: 267 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condStructArg]Return
+          Type: 268 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condStructArg]
+          Type: 269 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condStructArg]Return
+          Type: 270 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condStructArg]
+          Type: 271 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 15 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condStructArg]Return
+          Type: 272 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condStructArg]
+          Type: 273 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condStructArg]Return
+          Type: 274 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 275 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 276 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condStructArg]
+          Type: 277 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condStructArg]Return
+          Type: 278 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 234 EventRootType Probe[main.condUint16]
+          Type: 237 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4afc8a", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 235 EventRootType Probe[main.condUint16]Return
+          Type: 238 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4afcfa", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 236 EventRootType Probe[main.condUint16]
+          Type: 239 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4afc8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 237 EventRootType Probe[main.condUint16]Return
+          Type: 240 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4afcfa", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 238 EventRootType Probe[main.condUint32]
+          Type: 241 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4afd4a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 239 EventRootType Probe[main.condUint32]Return
+          Type: 242 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4afdba", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 240 EventRootType Probe[main.condUint32]
+          Type: 243 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4afd4a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 241 EventRootType Probe[main.condUint32]Return
+          Type: 244 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4afdba", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 242 EventRootType Probe[main.condUint64]
+          Type: 245 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4afe0a", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 243 EventRootType Probe[main.condUint64]Return
+          Type: 246 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4afe7a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 244 EventRootType Probe[main.condUint64]
+          Type: 247 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4afe0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 245 EventRootType Probe[main.condUint64]Return
+          Type: 248 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4afe7a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 228 EventRootType Probe[main.condUint8]
+          Type: 231 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 229 EventRootType Probe[main.condUint8]Return
+          Type: 232 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 230 EventRootType Probe[main.condUint8]
+          Type: 233 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 231 EventRootType Probe[main.condUint8]Return
+          Type: 234 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 232 EventRootType Probe[main.condUint8]
+          Type: 235 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 233 EventRootType Probe[main.condUint8]Return
+          Type: 236 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.inlined]
+          Type: 353 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae4ee"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 299 EventRootType Probe[main.inlined]Return
+          Type: 354 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4af6ca", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 187 EventRootType Probe[main.intArg]
+          Type: 190 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4af36a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 188 EventRootType Probe[main.intArg]Return
+          Type: 191 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4af3aa", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 197 EventRootType Probe[main.intArrayArg]
+          Type: 200 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4af4ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 198 EventRootType Probe[main.intArrayArg]Return
+          Type: 201 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4af536", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 203 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 206 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4af660", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 195 EventRootType Probe[main.intSliceArg]
+          Type: 198 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4af46a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 196 EventRootType Probe[main.intSliceArg]Return
+          Type: 199 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4af4af", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 343 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 344 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 347 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 348 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 345 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 346 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 349 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 350 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 315 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 316 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 317 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 318 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 337 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 338 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 339 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 340 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 341 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 342 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 327 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 329 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 330 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 331 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 332 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 333 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 189 EventRootType Probe[main.stringArg]
+          Type: 192 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 190 EventRootType Probe[main.stringArg]Return
+          Type: 193 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 191 EventRootType Probe[main.stringArg]
+          Type: 194 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 192 EventRootType Probe[main.stringArg]Return
+          Type: 195 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.mapArg]
+          Type: 207 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4af74a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.mapArg]Return
+          Type: 208 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4af77f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.noArgs]
+          Type: 211 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4af86a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 209 EventRootType Probe[main.noArgs]Return
+          Type: 212 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4af8a6", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 193 EventRootType Probe[main.stringArg]
+          Type: 196 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 194 EventRootType Probe[main.stringArg]Return
+          Type: 197 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 201 EventRootType Probe[main.stringArrayArg]
+          Type: 204 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4af5ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 202 EventRootType Probe[main.stringArrayArg]Return
+          Type: 205 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4af636", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 199 EventRootType Probe[main.stringSliceArg]
+          Type: 202 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4af56a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 200 EventRootType Probe[main.stringSliceArg]Return
+          Type: 203 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4af5af", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 351 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4b1476", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 352 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4b1644", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2418,12 +3085,316 @@ Subprograms:
                   Op: {CfaOffset: 88}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4b09c0..0x4b0af7]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b09c0..0x4b0a3b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b0a3b..0x4b0a40
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4b0a40..0x4b0af7
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b09c0..0x4b0a43
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4b0a43..0x4b0a48
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4b0a48..0x4b0af7
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0x4b0b00..0x4b0c4c]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 107 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4b0b00..0x4b0b8a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b0b8a..0x4b0b8f
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b0b8f..0x4b0b92
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b0b92..0x4b0c4c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b0b00..0x4b0b97
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4b0b97..0x4b0c4c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0x4b0c60..0x4b0d7a]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0x4b0c60..0x4b0cc0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b0cc0..0x4b0d7a
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b0c60..0x4b0cc5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b0cc5..0x4b0cc8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b0cc8..0x4b0d7a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0x4b0d80..0x4b0e86]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 95 PointerType *string
+          Locations:
+            - Range: 0x4b0d80..0x4b0de0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b0de0..0x4b0e86
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b0d80..0x4b0de5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b0de5..0x4b0de8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b0de8..0x4b0e86
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4b0ea0..0x4b1074]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 StructureType main.lenFields
+          Locations:
+            - Range: 0x4b0ea0..0x4b1074
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b0ea0..0x4b0f6d
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b0f6d..0x4b0f72
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4b0f72..0x4b1074
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4b1080..0x4b11fc]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4b1080..0x4b10f1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b10f1..0x4b11fc
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b1080..0x4b10f6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b10f6..0x4b10f9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b10f9..0x4b11fc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4b1200..0x4b131a]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4b1200..0x4b126f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4b126f..0x4b131a
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b1200..0x4b1274
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4b1274..0x4b1277
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4b1277..0x4b131a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0x4b1320..0x4b145d]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 StructureType main.condFields
+          Locations:
+            - Range: 0x4b1320..0x4b145d
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4b1320..0x4b13b1
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4b13b1..0x4b13b6
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4b13b6..0x4b145d
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0x4b1460..0x4b1657]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0x4b1460..0x4b1644
               Pieces: []
@@ -2432,7 +3403,7 @@ Subprograms:
             - Range: 0x4b1645..0x4b1657
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0x4af680..0x4af6e2]
       InlinePCRanges:
@@ -2447,7 +3418,7 @@ Subprograms:
             - Range: 0x4af680..0x4af699
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2455,12 +3426,12 @@ Subprograms:
           RootRanges: [0x4ae360..0x4af35f]
       Variables:
         - Name: ptr
-          Type: 129 PointerType *****int
+          Type: 132 PointerType *****int
           Locations:
             - Range: 0x4ae6ff..0x4ae74b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2468,35 +3439,35 @@ Subprograms:
           RootRanges: [0x4ae360..0x4af35f]
       Variables:
         - Name: ptr
-          Type: 131 PointerType **int
+          Type: 134 PointerType **int
           Locations:
             - Range: 0x4ae770..0x4ae7aa
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 37024
       GoKind: 22
-      Pointee: 130 PointerType ****int
+      Pointee: 133 PointerType ****int
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36960
       GoKind: 22
-      Pointee: 186 PointerType ***int
+      Pointee: 189 PointerType ***int
     - __kind: PointerType
-      ID: 186
+      ID: 189
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36896
       GoKind: 22
-      Pointee: 131 PointerType **int
+      Pointee: 134 PointerType **int
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36832
@@ -2509,10 +3480,10 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 172
+      ID: 175
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 176 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 114
       Name: '**table<string,int>'
@@ -2524,20 +3495,27 @@ Types:
       ByteSize: 8
       Pointee: 120 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 131 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []*runtime.p.array
+      Pointee: 142 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 142
+      ID: 125
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 36768
+      GoKind: 22
+      Pointee: 107 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 145
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []int.array
+      Pointee: 144 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2546,20 +3524,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 144
+      ID: 147
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 143 GoSliceDataType []string.array
+      Pointee: 146 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uint8.array
+      Pointee: 137 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []uintptr.array
+      Pointee: 139 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -2610,12 +3588,12 @@ Types:
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
-      ID: 159
+      ID: 162
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 28384
       GoKind: 22
-      Pointee: 160 StructureType main.bigStruct
+      Pointee: 163 StructureType main.bigStruct
     - __kind: PointerType
       ID: 123
       Name: '*main.condFields'
@@ -2624,10 +3602,17 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType main.condFields
     - __kind: PointerType
-      ID: 170
+      ID: 126
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 28256
+      GoKind: 22
+      Pointee: 124 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 173
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 174 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '*map<string,int>'
@@ -2639,30 +3624,30 @@ Types:
       ByteSize: 8
       Pointee: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 148 StructureType noalg.map.group[string]int
+      Pointee: 151 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 156 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2711,7 +3696,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 69536
       GoKind: 22
-      Pointee: 138 UnresolvedPointeeType runtime.p
+      Pointee: 141 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -2748,30 +3733,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 135 GoStringDataType string.str
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 176 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 179 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 115
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 145 StructureType table<string,int>
+      Pointee: 148 StructureType table<string,int>
     - __kind: PointerType
       ID: 120
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 153 StructureType table<string,main.bigStruct>
+      Pointee: 156 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 163 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 166 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -2815,7 +3800,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 300
+      ID: 355
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2824,24 +3809,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 356
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2850,14 +3835,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 131 PointerType **int
+            Type: 134 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2883,10 +3868,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2902,7 +3887,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2918,7 +3903,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 257
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2944,16 +3929,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2969,10 +3954,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2988,10 +3973,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3007,7 +3992,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 216
+      ID: 219
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3033,13 +4018,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 217
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 218
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 220
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 221
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3055,7 +4040,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
+      ID: 223
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3071,7 +4056,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3097,16 +4082,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 219
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 221
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 223
+      ID: 222
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 224
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 226
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 227
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3122,7 +4107,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3148,13 +4133,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3170,7 +4155,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3196,13 +4181,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 213
+      ID: 216
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 297
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3218,7 +4203,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 298
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3244,7 +4229,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3260,7 +4245,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3286,71 +4271,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 285
+      ID: 288
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 290
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 293
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 294
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 296
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 279
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3366,7 +4351,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3382,7 +4367,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3408,16 +4393,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 284
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 286
+      ID: 289
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3433,7 +4418,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 288
+      ID: 291
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3459,10 +4444,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 287
+      ID: 290
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3478,7 +4463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3494,7 +4479,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3502,6 +4487,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3511,70 +4548,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 260
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 262
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 261
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 263
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 264
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 267
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3590,7 +4575,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3606,7 +4591,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 268
+      ID: 271
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3622,7 +4607,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3638,7 +4623,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3654,7 +4639,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3680,25 +4665,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 269
+      ID: 272
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 274
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3714,7 +4699,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3740,13 +4725,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 238
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 241
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3762,7 +4747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 240
+      ID: 243
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3788,13 +4773,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 241
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 242
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 245
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3810,7 +4795,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3836,13 +4821,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3858,7 +4843,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3874,7 +4859,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3900,16 +4885,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 353
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3921,14 +4906,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 354
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3944,10 +4929,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3963,10 +4948,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3982,10 +4967,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 343
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 207
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4011,16 +5520,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4036,10 +5545,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4065,16 +5574,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4090,7 +5599,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4106,10 +5615,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 202
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4125,13 +5634,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 351
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 297
+      ID: 352
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4140,10 +5649,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4156,7 +5665,7 @@ Types:
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 185
+      ID: 188
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 49440
@@ -4297,37 +5806,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []*runtime.p.array
+      Data: 142 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 142
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 186
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 176 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 154
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 115 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 164
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 120 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 177
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 128 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 131 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 107
       Name: '[]int'
@@ -4344,37 +5853,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 141 GoSliceDataType []int.array
+      Data: 144 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 144
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 187
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 155
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 148 StructureType noalg.map.group[string]int
+      Element: 151 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 165
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 156 StructureType noalg.map.group[string]main.bigStruct
+      Element: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 178
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -4395,9 +5904,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 143 GoSliceDataType []string.array
+      Data: 146 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 146
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4418,9 +5927,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 134 GoSliceDataType []uint8.array
+      Data: 137 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4441,9 +5950,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 136 GoSliceDataType []uintptr.array
+      Data: 139 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4504,61 +6013,61 @@ Types:
       GoRuntimeType: 60256
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 180
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 181 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 187 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 146
+      ID: 149
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 147 PointerType *noalg.map.group[string]int
+          Type: 150 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 148 StructureType noalg.map.group[string]int
-      GroupSliceType: 152 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 151 StructureType noalg.map.group[string]int
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 154
+      ID: 157
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 155 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 158 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 156 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 159 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 167
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 168 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 175 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4689,14 +6198,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 182
+      ID: 185
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 74016
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 160
+      ID: 163
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 128288
@@ -4725,7 +6234,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 185 ArrayType [128]uint8
+          Type: 188 ArrayType [128]uint8
     - __kind: StructureType
       ID: 121
       Name: main.condFields
@@ -4772,8 +6281,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 122 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 124
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 122432
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 107 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 111 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 95 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 125 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 122 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 174
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4786,7 +6320,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 175 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4805,8 +6339,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 186 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<string,int>
@@ -4840,8 +6374,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 151 GoSliceDataType []*table<string,int>.array
-      GroupType: 148 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,int>.array
+      GroupType: 151 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 118
       Name: map<string,main.bigStruct>
@@ -4875,10 +6409,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 156 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 129
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4891,7 +6425,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4910,15 +6444,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 174 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 177 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 169
+      ID: 172
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 72224
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 174 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
@@ -4934,50 +6468,50 @@ Types:
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 124
+      ID: 127
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 72608
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 49344
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 181 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 184 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 157
+      ID: 160
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 49536
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 158 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 161 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 149
+      ID: 152
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 48960
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 150 StructureType noalg.struct { key string; elem int }
+      Element: 153 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 170
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 49728
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 171 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 179
+      ID: 182
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 80032
@@ -4988,9 +6522,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 180 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 183 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 79776
@@ -5001,9 +6535,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 149 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 152 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 156
+      ID: 159
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 80288
@@ -5014,9 +6548,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 157 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 160 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 166
+      ID: 169
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 80800
@@ -5027,9 +6561,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 170 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 181
+      ID: 184
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 79904
@@ -5040,9 +6574,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 182 StructureType main.aStructNotUsedAsAnArgument
+          Type: 185 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 80160
@@ -5053,9 +6587,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 159 PointerType *main.bigStruct
+          Type: 162 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 79648
@@ -5068,7 +6602,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 171
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 80672
@@ -5079,7 +6613,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 169 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 172 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5725,7 +7259,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 138
+      ID: 141
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -5850,18 +7384,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 136 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 135 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 132
+      ID: 135
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 176
+      ID: 179
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5883,9 +7417,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 180 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -5907,9 +7441,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 146 GoSwissMapGroupsType groupReference<string,int>
+          Type: 149 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -5931,9 +7465,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 154 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 157 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5955,7 +7489,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 167 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 17
       Name: uint
@@ -5998,7 +7532,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45056
       GoKind: 26
-MaxTypeID: 301
+MaxTypeID: 356
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6229,6 +7763,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4af1d3", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af7b3", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 207 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0x4af25e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af83e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 250 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4afa6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 251 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4afada", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 252 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4afa6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 253 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4afada", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 254 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4afa6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b004a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 255 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4afada", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b00ba", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 246 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0x4af8ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afeca", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 247 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0x4af95e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aff3e", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 248 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0x4af9aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4aff8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 249 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0x4afa1f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4affff", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 214 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4af3aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af98a", Frameless: false}]
           Condition:
             Type: 103 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 215 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4af41a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af9fa", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 216 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4af3aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af98a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 217 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4af41a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af9fa", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 218 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4af46a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 219 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4af4da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 220 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4af46a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 221 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4af4da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 222 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4af46a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 223 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4af4da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afaba", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 224 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4af52a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afb0a", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 225 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4af59a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afb7a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 226 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4af52a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afb0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 227 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4af59a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afb7a", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 210 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4af2ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af8ca", Frameless: false}]
           Condition:
             Type: 16 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 211 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4af35a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af93a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 212 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4af2ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af8ca", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 213 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4af35a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af93a", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 294 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4b00c4", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 295 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4b00c4", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 282 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4afe8e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4aff0e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 284 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4afe8e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4aff0e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 290 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4affea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 291 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4b005a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 292 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4affea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 293 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4b005a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 276 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4afd2e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 277 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4afe45", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 278 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4afd2e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 279 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4afe45", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 280 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4afd2e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 281 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4afe45", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 286 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4aff4a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4affb5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 288 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4aff4a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4affb5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 256 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4afb2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 257 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4afb9f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 258 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4afb2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 259 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4afb9f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 260 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4afb2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 261 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4afb9f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 262 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4afb2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 263 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4afb9f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 264 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 265 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 266 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 267 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 268 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 15 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 269 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 270 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 271 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 272 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 273 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 274 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4afbee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 275 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4afcef", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 234 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4af6aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afc8a", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 235 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4af71a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afcfa", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 236 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4af6aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afc8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 237 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4af71a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afcfa", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 238 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4af76a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afd4a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 239 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4af7da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afdba", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 240 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4af76a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afd4a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 241 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4af7da", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afdba", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 242 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4af82a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afe0a", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 243 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4af89a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afe7a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 244 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4af82a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afe0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 245 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4af89a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afe7a", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 228 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4af5ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 229 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4af65a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 230 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4af5ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 231 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4af65a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 232 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4af5ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 233 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4af65a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4afc3a", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0x4ae4ee"
               Frameless: false
-            - PC: "0x4af0aa"
+            - PC: "0x4af68a"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 299 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0x4af0ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af6ca", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 187 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4aed8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af36a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 188 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0x4aedca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af3aa", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 197 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4aef0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af4ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 198 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0x4aef56", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af536", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 203 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4af080", Frameless: true}]
+          InjectionPoints: [{PC: "0x4af660", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 195 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4aee8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af46a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 196 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0x4aeecf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af4af", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 189 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4aee0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 190 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4aee4f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 191 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4aee0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 192 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4aee4f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4af16a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af74a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0x4af19f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af77f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4af28a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af86a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 209 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0x4af2c6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af8a6", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 193 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4aee0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af3ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 194 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4aee4f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af42f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 201 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4af00a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af5ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 202 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0x4af056", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af636", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 199 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4aef8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af56a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 200 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4aefcf", Frameless: false}]
+          InjectionPoints: [{PC: "0x4af5af", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 296 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4b03d6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b1476", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 297 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0x4b05a4", Frameless: false}]
+          InjectionPoints: [{PC: "0x4b1644", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4aed80..0x4aede2]
+      OutOfLinePCRanges: [0x4af360..0x4af3c2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aed80..0x4aed99
+            - Range: 0x4af360..0x4af379
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4aee00..0x4aee71]
+      OutOfLinePCRanges: [0x4af3e0..0x4af451]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4aee00..0x4aee1e
+            - Range: 0x4af3e0..0x4af3fe
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4aee80..0x4aeefa]
+      OutOfLinePCRanges: [0x4af460..0x4af4da]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4aee80..0x4aee9e
+            - Range: 0x4af460..0x4af47e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4aef00..0x4aef67]
+      OutOfLinePCRanges: [0x4af4e0..0x4af547]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]int
           Locations:
-            - Range: 0x4aef00..0x4aef67
+            - Range: 0x4af4e0..0x4af547
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4aef80..0x4aeffa]
+      OutOfLinePCRanges: [0x4af560..0x4af5da]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4aef80..0x4aef9e
+            - Range: 0x4af560..0x4af57e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4af000..0x4af067]
+      OutOfLinePCRanges: [0x4af5e0..0x4af647]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0x4af000..0x4af067
+            - Range: 0x4af5e0..0x4af647
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4af080..0x4af081]
+      OutOfLinePCRanges: [0x4af660..0x4af661]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0x4af080..0x4af081
+            - Range: 0x4af660..0x4af661
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4af160..0x4af1b6]
+      OutOfLinePCRanges: [0x4af740..0x4af796]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4af160..0x4af18d
+            - Range: 0x4af740..0x4af76d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4af1c0..0x4af27b]
+      OutOfLinePCRanges: [0x4af7a0..0x4af85b]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4af1c0..0x4af1f3
+            - Range: 0x4af7a0..0x4af7d3
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4af1f3..0x4af27b
+            - Range: 0x4af7d3..0x4af85b
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4af280..0x4af2d3]
+      OutOfLinePCRanges: [0x4af860..0x4af8b3]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4af2e0..0x4af388]
+      OutOfLinePCRanges: [0x4af8c0..0x4af968]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0x4af2e0..0x4af321
+            - Range: 0x4af8c0..0x4af901
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af2e0..0x4af324
+            - Range: 0x4af8c0..0x4af904
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af324..0x4af329
+            - Range: 0x4af904..0x4af909
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4af3a0..0x4af449]
+      OutOfLinePCRanges: [0x4af980..0x4afa29]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 103 BaseType int16
           Locations:
-            - Range: 0x4af3a0..0x4af3c9
+            - Range: 0x4af980..0x4af9a9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af3a0..0x4af3c9
+            - Range: 0x4af980..0x4af9a9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af3c9..0x4af449
+            - Range: 0x4af9a9..0x4afa29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4af460..0x4af507]
+      OutOfLinePCRanges: [0x4afa40..0x4afae7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4af460..0x4af489
+            - Range: 0x4afa40..0x4afa69
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af460..0x4af489
+            - Range: 0x4afa40..0x4afa69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af489..0x4af507
+            - Range: 0x4afa69..0x4afae7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4af520..0x4af5c9]
+      OutOfLinePCRanges: [0x4afb00..0x4afba9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4af520..0x4af549
+            - Range: 0x4afb00..0x4afb29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af520..0x4af549
+            - Range: 0x4afb00..0x4afb29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af549..0x4af5c9
+            - Range: 0x4afb29..0x4afba9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4af5e0..0x4af688]
+      OutOfLinePCRanges: [0x4afbc0..0x4afc68]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4af5e0..0x4af621
+            - Range: 0x4afbc0..0x4afc01
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af5e0..0x4af624
+            - Range: 0x4afbc0..0x4afc04
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af624..0x4af629
+            - Range: 0x4afc04..0x4afc09
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4af6a0..0x4af749]
+      OutOfLinePCRanges: [0x4afc80..0x4afd29]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4af6a0..0x4af6c9
+            - Range: 0x4afc80..0x4afca9
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af6a0..0x4af6c9
+            - Range: 0x4afc80..0x4afca9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af6c9..0x4af749
+            - Range: 0x4afca9..0x4afd29
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4af760..0x4af807]
+      OutOfLinePCRanges: [0x4afd40..0x4afde7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4af760..0x4af789
+            - Range: 0x4afd40..0x4afd69
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af760..0x4af789
+            - Range: 0x4afd40..0x4afd69
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af789..0x4af807
+            - Range: 0x4afd69..0x4afde7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4af820..0x4af8c9]
+      OutOfLinePCRanges: [0x4afe00..0x4afea9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4af820..0x4af849
+            - Range: 0x4afe00..0x4afe29
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af820..0x4af849
+            - Range: 0x4afe00..0x4afe29
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4af849..0x4af8c9
+            - Range: 0x4afe29..0x4afea9
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4af8e0..0x4af98e]
+      OutOfLinePCRanges: [0x4afec0..0x4aff6e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0x4af8e0..0x4af90d
+            - Range: 0x4afec0..0x4afeed
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af8e0..0x4af908
+            - Range: 0x4afec0..0x4afee8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4af908..0x4af90d
+            - Range: 0x4afee8..0x4afeed
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4af90d..0x4af98e
+            - Range: 0x4afeed..0x4aff6e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4af9a0..0x4afa4f]
+      OutOfLinePCRanges: [0x4aff80..0x4b002f]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType float64
           Locations:
-            - Range: 0x4af9a0..0x4af9ce
+            - Range: 0x4aff80..0x4affae
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4af9a0..0x4af9c9
+            - Range: 0x4aff80..0x4affa9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4af9c9..0x4af9ce
+            - Range: 0x4affa9..0x4affae
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4af9ce..0x4afa4f
+            - Range: 0x4affae..0x4b002f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4afa60..0x4afb08]
+      OutOfLinePCRanges: [0x4b0040..0x4b00e8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4afa60..0x4afaa1
+            - Range: 0x4b0040..0x4b0081
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afa60..0x4afaa4
+            - Range: 0x4b0040..0x4b0084
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4afaa4..0x4afaa9
+            - Range: 0x4b0084..0x4b0089
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4afb20..0x4afbd7]
+      OutOfLinePCRanges: [0x4b0100..0x4b01b7]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afb20..0x4afb4e
+            - Range: 0x4b0100..0x4b012e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afb20..0x4afb4e
+            - Range: 0x4b0100..0x4b012e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4afb4e..0x4afbd7
+            - Range: 0x4b012e..0x4b01b7
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4afbe0..0x4afd14]
+      OutOfLinePCRanges: [0x4b01c0..0x4b02f4]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0x4afbe0..0x4afd14
+            - Range: 0x4b01c0..0x4b02f4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afbe0..0x4afc25
+            - Range: 0x4b01c0..0x4b0205
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4afc25..0x4afc2a
+            - Range: 0x4b0205..0x4b020a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4afc2a..0x4afd14
+            - Range: 0x4b020a..0x4b02f4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4afd20..0x4afe73]
+      OutOfLinePCRanges: [0x4b0300..0x4b0453]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0x4afd20..0x4afd76
+            - Range: 0x4b0300..0x4b0356
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4afd76..0x4afe73
+            - Range: 0x4b0356..0x4b0453
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afd20..0x4afd7b
+            - Range: 0x4b0300..0x4b035b
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4afd7b..0x4afe73
+            - Range: 0x4b035b..0x4b0453
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4afe80..0x4aff3c]
+      OutOfLinePCRanges: [0x4b0460..0x4b051c]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0x4afe80..0x4afed5
+            - Range: 0x4b0460..0x4b04b5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4afe80..0x4afed8
+            - Range: 0x4b0460..0x4b04b8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4afed8..0x4afedd
+            - Range: 0x4b04b8..0x4b04bd
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4aff40..0x4affd9]
+      OutOfLinePCRanges: [0x4b0520..0x4b05b9]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aff40..0x4aff51
+            - Range: 0x4b0520..0x4b0531
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aff40..0x4aff7f
+            - Range: 0x4b0520..0x4b055f
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aff40..0x4affb5
+            - Range: 0x4b0520..0x4b0595
               Pieces: []
-            - Range: 0x4affb5..0x4affb6
+            - Range: 0x4b0595..0x4b0596
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4affb6..0x4affd9
+            - Range: 0x4b0596..0x4b05b9
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4aff51..0x4aff7f
+            - Range: 0x4b0531..0x4b055f
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4aff7f..0x4affd9
+            - Range: 0x4b055f..0x4b05b9
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4affe0..0x4b0089]
+      OutOfLinePCRanges: [0x4b05c0..0x4b0669]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4affe0..0x4b0009
+            - Range: 0x4b05c0..0x4b05e9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4affe0..0x4b0009
+            - Range: 0x4b05c0..0x4b05e9
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b0009..0x4b0089
+            - Range: 0x4b05e9..0x4b0669
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2291,27 +2291,27 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4b00a0..0x4b0179]
+      OutOfLinePCRanges: [0x4b0680..0x4b0759]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b00a0..0x4b00c4
+            - Range: 0x4b0680..0x4b06a4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b00c4..0x4b0179
+            - Range: 0x4b06a4..0x4b0759
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b00a0..0x4b00db
+            - Range: 0x4b0680..0x4b06bb
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b00db..0x4b0179
+            - Range: 0x4b06bb..0x4b0759
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2321,18 +2321,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4b00c4..0x4b00db
+            - Range: 0x4b06a4..0x4b06bb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4b0180..0x4b0245]
+      OutOfLinePCRanges: [0x4b0760..0x4b0825]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4b0180..0x4b01ae
+            - Range: 0x4b0760..0x4b078e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2344,13 +2344,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b0180..0x4b01ae
+            - Range: 0x4b0760..0x4b078e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4b01ae..0x4b0245
+            - Range: 0x4b078e..0x4b0825
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2359,25 +2359,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4b0260..0x4b02fa]
+      OutOfLinePCRanges: [0x4b0840..0x4b08da]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0x4b0260..0x4b0293
+            - Range: 0x4b0840..0x4b0873
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b0260..0x4b0296
+            - Range: 0x4b0840..0x4b0876
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4b0296..0x4b029b
+            - Range: 0x4b0876..0x4b087b
               Pieces:
                 - Size: 8
                   Op: null
@@ -2386,31 +2386,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4b0300..0x4b03ba]
+      OutOfLinePCRanges: [0x4b08e0..0x4b099a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0x4b0300..0x4b03ba
+            - Range: 0x4b08e0..0x4b099a
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4b0300..0x4b0335
+            - Range: 0x4b08e0..0x4b0915
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4b0335..0x4b033a
+            - Range: 0x4b0915..0x4b091a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4b033a..0x4b03ba
+            - Range: 0x4b091a..0x4b099a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2419,32 +2419,32 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4b03c0..0x4b05b7]
+      OutOfLinePCRanges: [0x4b1460..0x4b1657]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4b03c0..0x4b05a4
+            - Range: 0x4b1460..0x4b1644
               Pieces: []
-            - Range: 0x4b05a4..0x4b05a5
+            - Range: 0x4b1644..0x4b1645
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4b05a5..0x4b05b7
+            - Range: 0x4b1645..0x4b1657
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0x4af0a0..0x4af102]
+      OutOfLinePCRanges: [0x4af680..0x4af6e2]
       InlinePCRanges:
         - Ranges: [0x4ae4ee..0x4ae52f]
-          RootRanges: [0x4ae360..0x4aed78]
+          RootRanges: [0x4ae360..0x4af35f]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4ae4ee..0x4ae52f
               Pieces: []
-            - Range: 0x4af0a0..0x4af0b9
+            - Range: 0x4af680..0x4af699
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
@@ -2452,7 +2452,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4ae726..0x4ae765]
-          RootRanges: [0x4ae360..0x4aed78]
+          RootRanges: [0x4ae360..0x4af35f]
       Variables:
         - Name: ptr
           Type: 129 PointerType *****int
@@ -2465,7 +2465,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4ae770..0x4ae7aa]
-          RootRanges: [0x4ae360..0x4aed78]
+          RootRanges: [0x4ae360..0x4af35f]
       Variables:
         - Name: ptr
           Type: 131 PointerType **int
@@ -2478,28 +2478,28 @@ Types:
       ID: 129
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36800
+      GoRuntimeType: 37024
       GoKind: 22
       Pointee: 130 PointerType ****int
     - __kind: PointerType
       ID: 130
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36736
+      GoRuntimeType: 36960
       GoKind: 22
       Pointee: 186 PointerType ***int
     - __kind: PointerType
       ID: 186
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36672
+      GoRuntimeType: 36896
       GoKind: 22
       Pointee: 131 PointerType **int
     - __kind: PointerType
       ID: 131
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36608
+      GoRuntimeType: 36832
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -2542,7 +2542,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 41600
+      GoRuntimeType: 41760
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2564,63 +2564,63 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30912
+      GoRuntimeType: 31008
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 102
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29824
+      GoRuntimeType: 29920
       GoKind: 22
       Pointee: 13 GoInterfaceType error
     - __kind: PointerType
       ID: 104
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30784
+      GoRuntimeType: 30880
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 98
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30848
+      GoRuntimeType: 30944
       GoKind: 22
       Pointee: 15 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 30464
+      GoRuntimeType: 30560
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 30208
+      GoRuntimeType: 30304
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 100
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 30336
+      GoRuntimeType: 30432
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 159
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 28288
+      GoRuntimeType: 28384
       GoKind: 22
       Pointee: 160 StructureType main.bigStruct
     - __kind: PointerType
       ID: 123
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 28160
+      GoRuntimeType: 28192
       GoKind: 22
       Pointee: 121 StructureType main.condFields
     - __kind: PointerType
@@ -2667,84 +2667,84 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 31104
+      GoRuntimeType: 31200
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 84832
+      GoRuntimeType: 84992
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31744
+      GoRuntimeType: 31840
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31808
+      GoRuntimeType: 31904
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 62272
+      GoRuntimeType: 62432
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 85472
+      GoRuntimeType: 85632
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 69376
+      GoRuntimeType: 69536
       GoKind: 22
       Pointee: 138 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 32448
+      GoRuntimeType: 32544
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 97760
+      GoRuntimeType: 97920
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 129344
+      GoRuntimeType: 129760
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 103776
+      GoRuntimeType: 103936
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29888
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2776,42 +2776,42 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30528
+      GoRuntimeType: 30624
       GoKind: 22
       Pointee: 17 BaseType uint
     - __kind: PointerType
       ID: 106
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 30144
+      GoRuntimeType: 30240
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 30272
+      GoRuntimeType: 30368
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 30400
+      GoRuntimeType: 30496
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 30016
+      GoRuntimeType: 30112
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30592
+      GoRuntimeType: 30688
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3220,7 +3220,7 @@ Types:
     - __kind: EventRootType
       ID: 295
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3243,16 +3243,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 282
       Name: Probe[main.condNilPtrStruct]
@@ -4160,7 +4150,7 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 55424
+      GoRuntimeType: 55584
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4169,7 +4159,7 @@ Types:
       ID: 185
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 49280
+      GoRuntimeType: 49440
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4178,7 +4168,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 55040
+      GoRuntimeType: 55200
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4187,7 +4177,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 55136
+      GoRuntimeType: 55296
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4196,7 +4186,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 55328
+      GoRuntimeType: 55488
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4205,7 +4195,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 51008
+      GoRuntimeType: 51168
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4214,7 +4204,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 57728
+      GoRuntimeType: 57888
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4223,7 +4213,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 54848
+      GoRuntimeType: 55008
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4232,7 +4222,7 @@ Types:
       ID: 108
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 48896
+      GoRuntimeType: 49152
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4241,7 +4231,7 @@ Types:
       ID: 122
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 48704
+      GoRuntimeType: 48864
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4250,7 +4240,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 54272
+      GoRuntimeType: 54432
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4259,7 +4249,7 @@ Types:
       ID: 110
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 48992
+      GoRuntimeType: 49248
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4268,7 +4258,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 56768
+      GoRuntimeType: 56928
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4277,7 +4267,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 53600
+      GoRuntimeType: 53760
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4286,7 +4276,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 55232
+      GoRuntimeType: 55392
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4295,7 +4285,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 41152
+      GoRuntimeType: 41312
       GoKind: 23
       RawFields:
         - Name: array
@@ -4342,7 +4332,7 @@ Types:
       ID: 107
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 39552
+      GoRuntimeType: 39712
       GoKind: 23
       RawFields:
         - Name: array
@@ -4393,7 +4383,7 @@ Types:
       ID: 109
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39808
+      GoRuntimeType: 39968
       GoKind: 23
       RawFields:
         - Name: array
@@ -4416,7 +4406,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 39168
+      GoRuntimeType: 39328
       GoKind: 23
       RawFields:
         - Name: array
@@ -4439,7 +4429,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 39680
+      GoRuntimeType: 39840
       GoKind: 23
       RawFields:
         - Name: array
@@ -4462,25 +4452,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 44832
+      GoRuntimeType: 44992
       GoKind: 1
     - __kind: BaseType
       ID: 97
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 44640
+      GoRuntimeType: 44800
       GoKind: 16
     - __kind: BaseType
       ID: 96
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 44576
+      GoRuntimeType: 44736
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 13
       Name: error
       ByteSize: 16
-      GoRuntimeType: 67712
+      GoRuntimeType: 67872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4493,25 +4483,25 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 44704
+      GoRuntimeType: 44864
       GoKind: 13
     - __kind: BaseType
       ID: 15
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 44768
+      GoRuntimeType: 44928
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 37248
+      GoRuntimeType: 37408
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 60096
+      GoRuntimeType: 60256
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 177
@@ -4573,37 +4563,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 44384
+      GoRuntimeType: 44544
       GoKind: 2
     - __kind: BaseType
       ID: 103
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 44000
+      GoRuntimeType: 44160
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 44128
+      GoRuntimeType: 44288
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 44256
+      GoRuntimeType: 44416
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 43872
+      GoRuntimeType: 44032
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 120384
+      GoRuntimeType: 120544
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4625,7 +4615,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 78208
+      GoRuntimeType: 78368
       GoKind: 25
       RawFields:
         - Name: u
@@ -4635,7 +4625,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 106848
+      GoRuntimeType: 107008
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4651,7 +4641,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 96032
+      GoRuntimeType: 96192
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4664,7 +4654,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 95872
+      GoRuntimeType: 96032
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4677,7 +4667,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 96192
+      GoRuntimeType: 96352
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4689,27 +4679,27 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 66016
+      GoRuntimeType: 66176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 65920
+      GoRuntimeType: 66080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 182
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 73856
+      GoRuntimeType: 74016
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 160
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 127872
+      GoRuntimeType: 128288
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4740,7 +4730,7 @@ Types:
       ID: 121
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 135488
+      GoRuntimeType: 135904
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4926,35 +4916,35 @@ Types:
       ID: 169
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71936
+      GoRuntimeType: 72224
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 72064
+      GoRuntimeType: 72096
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 72192
+      GoRuntimeType: 72352
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 124
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 72448
+      GoRuntimeType: 72608
       GoKind: 21
       HeaderType: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 180
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 49088
+      GoRuntimeType: 49344
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4963,7 +4953,7 @@ Types:
       ID: 157
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 49376
+      GoRuntimeType: 49536
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4972,7 +4962,7 @@ Types:
       ID: 149
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 49184
+      GoRuntimeType: 48960
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4981,7 +4971,7 @@ Types:
       ID: 167
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 49568
+      GoRuntimeType: 49728
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4990,7 +4980,7 @@ Types:
       ID: 179
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 79616
+      GoRuntimeType: 80032
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5003,7 +4993,7 @@ Types:
       ID: 148
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 79872
+      GoRuntimeType: 79776
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5016,7 +5006,7 @@ Types:
       ID: 156
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 80128
+      GoRuntimeType: 80288
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5029,7 +5019,7 @@ Types:
       ID: 166
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 80640
+      GoRuntimeType: 80800
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5042,7 +5032,7 @@ Types:
       ID: 181
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 79488
+      GoRuntimeType: 79904
       GoKind: 25
       RawFields:
         - Name: key
@@ -5055,7 +5045,7 @@ Types:
       ID: 158
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 80000
+      GoRuntimeType: 80160
       GoKind: 25
       RawFields:
         - Name: key
@@ -5068,7 +5058,7 @@ Types:
       ID: 150
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 79744
+      GoRuntimeType: 79648
       GoKind: 25
       RawFields:
         - Name: key
@@ -5081,7 +5071,7 @@ Types:
       ID: 168
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 80512
+      GoRuntimeType: 80672
       GoKind: 25
       RawFields:
         - Name: key
@@ -5109,14 +5099,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 65152
+      GoRuntimeType: 65312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 150560
+      GoRuntimeType: 150976
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5306,7 +5296,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 76672
+      GoRuntimeType: 76832
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5316,7 +5306,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 123552
+      GoRuntimeType: 123968
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5341,7 +5331,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 93152
+      GoRuntimeType: 93312
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5354,7 +5344,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 112224
+      GoRuntimeType: 112384
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5373,13 +5363,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 58560
+      GoRuntimeType: 58720
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 92992
+      GoRuntimeType: 93152
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5392,7 +5382,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 124320
+      GoRuntimeType: 124736
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5417,13 +5407,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 58464
+      GoRuntimeType: 58624
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 153856
+      GoRuntimeType: 154272
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5643,7 +5633,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 124064
+      GoRuntimeType: 124480
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5668,7 +5658,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 119264
+      GoRuntimeType: 119424
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5690,7 +5680,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 119040
+      GoRuntimeType: 119200
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5712,7 +5702,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 92672
+      GoRuntimeType: 92832
       GoKind: 25
       RawFields:
         - Name: next
@@ -5725,13 +5715,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 58176
+      GoRuntimeType: 58336
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 76416
+      GoRuntimeType: 76576
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -5742,7 +5732,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 92832
+      GoRuntimeType: 92992
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5755,7 +5745,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 113184
+      GoRuntimeType: 113344
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5774,13 +5764,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 58368
+      GoRuntimeType: 58528
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 61792
+      GoRuntimeType: 61952
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5789,7 +5779,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 90912
+      GoRuntimeType: 91072
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5810,7 +5800,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 45088
+      GoRuntimeType: 45248
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5820,7 +5810,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 45152
+      GoRuntimeType: 45312
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -5830,7 +5820,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 91872
+      GoRuntimeType: 92032
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5843,19 +5833,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 79232
+      GoRuntimeType: 79392
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 65056
+      GoRuntimeType: 65216
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 43808
+      GoRuntimeType: 43968
       GoKind: 24
       RawFields:
         - Name: str
@@ -5970,43 +5960,43 @@ Types:
       ID: 17
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 44448
+      GoRuntimeType: 44608
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 44064
+      GoRuntimeType: 44224
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 44192
+      GoRuntimeType: 44352
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 44320
+      GoRuntimeType: 44480
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 43936
+      GoRuntimeType: 44096
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 44512
+      GoRuntimeType: 44672
       GoKind: 12
     - __kind: VoidPointerType
       ID: 14
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 44896
+      GoRuntimeType: 45056
       GoKind: 26
 MaxTypeID: 301
 Issues:
@@ -6250,7 +6240,7 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x5903a0", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x5923a0", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 371 EventRootType Probe[main.PointerChainArg]
+          Type: 387 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4ae726", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 372 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 388 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4ae770", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 217 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4af98a", Frameless: false}]
           Condition:
-            Type: 103 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 221 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 223 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4afa4a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 227 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4afb0a", Frameless: false}]
           Condition:
-            Type: 12 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 213 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4af8ca", Frameless: false}]
           Condition:
-            Type: 16 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 297 EventRootType Probe[main.condLine]Line
+          Type: 301 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 298 EventRootType Probe[main.condLine]Line
+          Type: 302 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4b06a1", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condNilPtrStruct]
+          Type: 289 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condNilPtrStruct]
+          Type: 291 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4b046e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 292 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4b04ee", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.condOnly]
+          Type: 297 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 294 EventRootType Probe[main.condOnly]Return
+          Type: 298 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.condOnly]
+          Type: 299 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4b05ca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.condOnly]Return
+          Type: 300 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4b063a", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condPtrStructArg]
+          Type: 283 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condPtrStructArg]
+          Type: 285 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 286 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condPtrStructArg]
+          Type: 287 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4b030e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 288 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4b0425", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.condReturnAndLocal]
+          Type: 293 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 290 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.condReturnAndLocal]
+          Type: 295 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4b052a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 296 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4b0595", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 259 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 261 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 263 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 264 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 265 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 266 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condString]
+          Type: 267 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condString]Return
+          Type: 268 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condString]
+          Type: 269 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4b010a", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condString]Return
+          Type: 270 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4b017f", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condStructArg]
+          Type: 271 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condStructArg]Return
+          Type: 272 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 273 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 274 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condStructArg]
+          Type: 275 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
-            Type: 15 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condStructArg]Return
+          Type: 276 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condStructArg]
+          Type: 277 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condStructArg]Return
+          Type: 278 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condStructArg]
+          Type: 279 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condStructArg]Return
+          Type: 280 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condStructArg]
+          Type: 281 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4b01ce", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condStructArg]Return
+          Type: 282 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4b02cf", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 237 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4afc8a", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 241 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4afd4a", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 245 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4afe0a", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 231 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 233 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4afbca", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 369 EventRootType Probe[main.inlined]
+          Type: 385 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4ae4ee"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 370 EventRootType Probe[main.inlined]Return
+          Type: 386 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4af6ca", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 359 EventRootType Probe[main.lenErrInt]
+          Type: 375 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 360 EventRootType Probe[main.lenErrInt]Return
+          Type: 376 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 363 EventRootType Probe[main.lenErrStruct]
+          Type: 379 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 364 EventRootType Probe[main.lenErrStruct]Return
+          Type: 380 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 361 EventRootType Probe[main.lenErrInt]
+          Type: 377 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4b1213", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 362 EventRootType Probe[main.lenErrInt]Return
+          Type: 378 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4b12ec", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 365 EventRootType Probe[main.lenErrStruct]
+          Type: 381 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4b1333", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 366 EventRootType Probe[main.lenErrStruct]Return
+          Type: 382 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4b1436", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenMap]
+          Type: 333 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenMap]Return
+          Type: 334 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 335 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 336 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenMap]
+          Type: 337 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenMap]Return
+          Type: 338 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenMap]
+          Type: 339 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenMap]Return
+          Type: 340 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenMap]
+          Type: 341 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenMap]Return
+          Type: 342 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenMap]
+          Type: 343 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4b0c6e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenMap]Return
+          Type: 344 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4b0d4c", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenPtrString]
+          Type: 345 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenPtrString]Return
+          Type: 346 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenPtrString]
+          Type: 347 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4b0d8e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenPtrString]Return
+          Type: 348 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4b0e58", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.lenPtrStructFields]
+          Type: 367 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 368 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 353 EventRootType Probe[main.lenPtrStructFields]
+          Type: 369 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 354 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 370 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 355 EventRootType Probe[main.lenPtrStructFields]
+          Type: 371 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 356 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 372 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 357 EventRootType Probe[main.lenPtrStructFields]
+          Type: 373 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4b1093", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 358 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 374 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4b11cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenSlice]
+          Type: 321 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenSlice]Return
+          Type: 322 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenSlice]
+          Type: 325 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenSlice]Return
+          Type: 326 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenSlice]
+          Type: 327 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenSlice]Return
+          Type: 328 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenSlice]
+          Type: 329 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenSlice]Return
+          Type: 330 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenSlice]
+          Type: 331 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4b0b13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenSlice]Return
+          Type: 332 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4b0c07", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenString]
+          Type: 309 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenString]Return
+          Type: 310 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenString]
+          Type: 313 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenString]Return
+          Type: 314 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenString]
+          Type: 315 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenString]Return
+          Type: 316 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenString]
+          Type: 317 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenString]Return
+          Type: 318 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenString]
+          Type: 319 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4b09d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenString]Return
+          Type: 320 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4b0abc", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenStructFields]
+          Type: 349 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          Type: 350 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenStructFields]
+          Type: 351 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenStructFields]Return
+          Type: 352 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenStructFields]
+          Type: 353 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenStructFields]Return
+          Type: 354 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenStructFields]
+          Type: 355 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenStructFields]Return
+          Type: 356 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenStructFields]
+          Type: 357 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenStructFields]Return
+          Type: 358 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenStructFields]
+          Type: 359 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenStructFields]Return
+          Type: 360 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.lenStructFields]
+          Type: 361 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 346 EventRootType Probe[main.lenStructFields]Return
+          Type: 362 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.lenStructFields]
+          Type: 363 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 348 EventRootType Probe[main.lenStructFields]Return
+          Type: 364 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.lenStructFields]
+          Type: 365 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4b0eb3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 350 EventRootType Probe[main.lenStructFields]Return
+          Type: 366 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4b1048", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 367 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 383 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4b1476", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 368 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 384 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4b1644", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4105,7 +4317,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 371
+      ID: 387
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4131,7 +4343,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 388
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4492,7 +4704,7 @@ Types:
       ID: 216
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 301
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4508,7 +4720,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 302
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4534,7 +4746,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
+      ID: 289
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4550,7 +4762,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 291
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4576,13 +4788,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 286
+      ID: 290
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 288
+      ID: 292
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4608,7 +4820,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 299
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4634,45 +4846,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 298
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 300
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 279
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 281
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 283
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4698,16 +4910,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 284
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 286
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 293
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4723,7 +4935,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4749,10 +4961,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4802,6 +5014,48 @@ Types:
     - __kind: EventRootType
       ID: 263
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4826,7 +5080,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 269
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4864,7 +5118,13 @@ Types:
       ID: 266
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 268
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 271
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4872,38 +5132,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 269
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 271
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -4946,6 +5174,38 @@ Types:
     - __kind: EventRootType
       ID: 277
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4970,12 +5230,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 270
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 272
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4986,6 +5240,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 278
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 282
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 237
@@ -5199,7 +5459,7 @@ Types:
       ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 369
+      ID: 385
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5215,7 +5475,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 386
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 190
@@ -5275,7 +5535,7 @@ Types:
       ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5301,16 +5561,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5336,16 +5596,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 333
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5361,7 +5621,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 321
+      ID: 335
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5380,7 +5665,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5396,7 +5681,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5415,7 +5700,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5441,22 +5726,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 334
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 322
+      ID: 336
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 338
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 326
+      ID: 340
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 342
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 344
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 345
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5475,7 +5763,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5501,13 +5789,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5533,7 +5821,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5555,7 +5843,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5574,7 +5862,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5593,19 +5881,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5621,7 +5909,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
+      ID: 323
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 325
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5637,7 +5947,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 327
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5653,7 +5963,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 329
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5669,7 +5979,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 331
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5695,22 +6005,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 322
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 312
+      ID: 324
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 328
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 332
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5726,7 +6105,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 301
+      ID: 311
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 313
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5742,7 +6143,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 315
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5758,7 +6159,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5774,7 +6175,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5800,12 +6201,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 304
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5815,7 +6210,25 @@ Types:
       ID: 308
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 310
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 349
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5841,7 +6254,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5860,7 +6273,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5879,7 +6292,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5898,7 +6311,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5914,7 +6327,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5930,7 +6343,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5946,7 +6359,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5962,7 +6375,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5977,32 +6390,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 342
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 350
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 352
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 354
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 364
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 366
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 207
@@ -6148,10 +6561,10 @@ Types:
       ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 368
+      ID: 384
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8043,7 +8456,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45056
       GoKind: 26
-MaxTypeID: 372
+MaxTypeID: 388
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8121,7 +8534,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8151,7 +8564,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8166,7 +8579,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8181,7 +8594,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.PointerChainArg]
+          Type: 376 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4c1f34", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 361 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 377 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4c1f79", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.inlined]
+          Type: 374 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4c1c4a"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.inlined]Return
+          Type: 375 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4c2eea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenErrInt]
+          Type: 364 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenErrInt]Return
+          Type: 365 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenErrStruct]
+          Type: 368 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenErrStruct]Return
+          Type: 369 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenErrInt]
+          Type: 366 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenErrInt]Return
+          Type: 367 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenErrStruct]
+          Type: 370 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenErrStruct]Return
+          Type: 371 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenMap]
+          Type: 330 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenMap]Return
+          Type: 331 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenMap]
+          Type: 332 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenMap]Return
+          Type: 333 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenPtrString]
+          Type: 334 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenPtrString]Return
+          Type: 335 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenPtrString]
+          Type: 336 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          Type: 337 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenPtrStructFields]
+          Type: 356 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 357 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenPtrStructFields]
+          Type: 358 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 359 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenPtrStructFields]
+          Type: 360 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 361 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          Type: 362 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenSlice]
+          Type: 320 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenSlice]Return
+          Type: 321 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenSlice]
+          Type: 322 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenSlice]Return
+          Type: 323 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenStructFields]
+          Type: 338 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 340 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 341 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenStructFields]
+          Type: 342 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          Type: 343 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenStructFields]
+          Type: 346 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          Type: 347 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenStructFields]
+          Type: 348 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          Type: 349 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 350 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 351 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 352 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 353 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 372 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4c4c96", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 373 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4c4e60", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3874,7 +4179,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3900,7 +4205,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4968,7 +5273,7 @@ Types:
       ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4984,7 +5289,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 195
@@ -5044,7 +5349,7 @@ Types:
       ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5070,16 +5375,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5105,19 +5410,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 324
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 326
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5143,13 +5515,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 319
+      ID: 325
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 327
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 322
+      ID: 329
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 334
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5168,7 +5549,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 336
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5194,13 +5575,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 325
+      ID: 337
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5226,10 +5607,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5248,7 +5648,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5267,19 +5667,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 314
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 320
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5295,7 +5743,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 322
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5325,6 +5773,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 317
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 323
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 304
@@ -5432,7 +5889,7 @@ Types:
       ID: 313
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 326
+      ID: 338
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5458,10 +5915,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 328
+      ID: 340
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 342
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5480,7 +5953,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 344
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5499,7 +5972,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 346
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5515,7 +5988,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 348
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5531,7 +6004,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 350
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5547,25 +6020,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.lenStructFields]Return
+      ID: 352
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 331
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.lenStructFields]Return
+      ID: 354
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 355
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 212
@@ -5711,10 +6222,10 @@ Types:
       ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7633,7 +8144,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47552
       GoKind: 26
-MaxTypeID: 361
+MaxTypeID: 377
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 376 EventRootType Probe[main.PointerChainArg]
+          Type: 392 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4c1f34", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 377 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 393 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4c1f79", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 222 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4c316a", Frameless: false}]
           Condition:
-            Type: 108 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 226 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 228 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 232 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4c32ea", Frameless: false}]
           Condition:
-            Type: 12 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 218 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4c30aa", Frameless: false}]
           Condition:
-            Type: 20 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 302 EventRootType Probe[main.condLine]Line
+          Type: 306 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 303 EventRootType Probe[main.condLine]Line
+          Type: 307 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condNilPtrStruct]
+          Type: 294 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 295 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 292 EventRootType Probe[main.condNilPtrStruct]
+          Type: 296 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 293 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 297 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.condOnly]
+          Type: 302 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 299 EventRootType Probe[main.condOnly]Return
+          Type: 303 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.condOnly]
+          Type: 304 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 301 EventRootType Probe[main.condOnly]Return
+          Type: 305 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condPtrStructArg]
+          Type: 288 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condPtrStructArg]
+          Type: 290 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 291 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condPtrStructArg]
+          Type: 292 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 293 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 294 EventRootType Probe[main.condReturnAndLocal]
+          Type: 298 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 295 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 299 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.condReturnAndLocal]
+          Type: 300 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 301 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 266 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 268 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 269 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 270 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 271 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condString]
+          Type: 272 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condString]Return
+          Type: 273 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condString]
+          Type: 274 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condString]Return
+          Type: 275 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condStructArg]
+          Type: 278 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condStructArg]Return
+          Type: 279 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condStructArg]
+          Type: 280 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
-            Type: 13 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condStructArg]Return
+          Type: 281 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condStructArg]
+          Type: 282 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
-            Type: 10 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condStructArg]Return
+          Type: 283 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condStructArg]
+          Type: 284 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condStructArg]Return
+          Type: 285 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condStructArg]
+          Type: 286 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condStructArg]Return
+          Type: 287 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 242 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4c346a", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 246 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4c352a", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 250 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4c35ea", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 236 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 238 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 374 EventRootType Probe[main.inlined]
+          Type: 390 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4c1c4a"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 375 EventRootType Probe[main.inlined]Return
+          Type: 391 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4c2eea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 364 EventRootType Probe[main.lenErrInt]
+          Type: 380 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 365 EventRootType Probe[main.lenErrInt]Return
+          Type: 381 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 368 EventRootType Probe[main.lenErrStruct]
+          Type: 384 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 369 EventRootType Probe[main.lenErrStruct]Return
+          Type: 385 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 366 EventRootType Probe[main.lenErrInt]
+          Type: 382 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 367 EventRootType Probe[main.lenErrInt]Return
+          Type: 383 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 370 EventRootType Probe[main.lenErrStruct]
+          Type: 386 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 371 EventRootType Probe[main.lenErrStruct]Return
+          Type: 387 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenMap]
+          Type: 338 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenMap]Return
+          Type: 339 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenMap]
+          Type: 342 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenMap]Return
+          Type: 343 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenMap]
+          Type: 344 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenMap]Return
+          Type: 345 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenMap]
+          Type: 346 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenMap]Return
+          Type: 347 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenMap]
+          Type: 348 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenMap]Return
+          Type: 349 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenPtrString]
+          Type: 350 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenPtrString]Return
+          Type: 351 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenPtrString]
+          Type: 352 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenPtrString]Return
+          Type: 353 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.lenPtrStructFields]
+          Type: 372 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 373 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.lenPtrStructFields]
+          Type: 374 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 375 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.lenPtrStructFields]
+          Type: 376 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 361 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 377 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 362 EventRootType Probe[main.lenPtrStructFields]
+          Type: 378 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 379 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenSlice]
+          Type: 326 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenSlice]Return
+          Type: 327 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenSlice]
+          Type: 330 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenSlice]Return
+          Type: 331 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenSlice]
+          Type: 332 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenSlice]Return
+          Type: 333 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenSlice]
+          Type: 334 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenSlice]Return
+          Type: 335 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenSlice]
+          Type: 336 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenSlice]Return
+          Type: 337 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenString]
+          Type: 314 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenString]Return
+          Type: 315 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenString]
+          Type: 318 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenString]Return
+          Type: 319 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenString]
+          Type: 320 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenString]Return
+          Type: 321 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenString]
+          Type: 322 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenString]Return
+          Type: 323 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenString]
+          Type: 324 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenString]Return
+          Type: 325 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenStructFields]
+          Type: 356 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          Type: 357 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenStructFields]
+          Type: 358 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          Type: 359 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenStructFields]
+          Type: 360 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenStructFields]Return
+          Type: 361 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenStructFields]
+          Type: 362 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenStructFields]Return
+          Type: 363 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenStructFields]
+          Type: 364 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenStructFields]Return
+          Type: 365 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenStructFields]
+          Type: 366 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenStructFields]Return
+          Type: 367 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenStructFields]
+          Type: 368 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenStructFields]Return
+          Type: 369 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenStructFields]
+          Type: 370 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenStructFields]Return
+          Type: 371 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 372 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 388 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4c4c96", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 373 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 389 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4c4e60", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4179,7 +4391,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 376
+      ID: 392
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4205,7 +4417,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 393
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4566,7 +4778,7 @@ Types:
       ID: 221
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 302
+      ID: 306
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4582,7 +4794,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 307
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4608,7 +4820,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4624,7 +4836,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4650,13 +4862,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 302
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4682,7 +4894,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 304
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4708,45 +4920,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 303
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 301
+      ID: 305
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 288
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4772,16 +4984,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 289
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 291
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 298
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4797,7 +5009,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 300
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4823,10 +5035,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 299
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 301
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4876,6 +5088,48 @@ Types:
     - __kind: EventRootType
       ID: 268
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4900,7 +5154,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 274
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4938,7 +5192,13 @@ Types:
       ID: 271
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 273
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 276
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4946,38 +5206,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -5020,6 +5248,38 @@ Types:
     - __kind: EventRootType
       ID: 282
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -5044,12 +5304,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -5060,6 +5314,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 283
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 242
@@ -5273,7 +5533,7 @@ Types:
       ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 374
+      ID: 390
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5289,7 +5549,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 391
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 195
@@ -5349,7 +5609,7 @@ Types:
       ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5375,16 +5635,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 368
+      ID: 384
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5410,16 +5670,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 370
+      ID: 386
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 369
+      ID: 385
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 371
+      ID: 387
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 338
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5435,7 +5695,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 340
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 342
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5454,7 +5739,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 344
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5470,7 +5755,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5489,7 +5774,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5515,22 +5800,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 339
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 327
+      ID: 341
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 343
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 331
+      ID: 345
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 347
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 334
+      ID: 349
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 350
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5549,7 +5837,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5575,13 +5863,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5607,7 +5895,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5629,7 +5917,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5648,7 +5936,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5667,19 +5955,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5695,7 +5983,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 328
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 330
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5711,7 +6021,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 332
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5727,7 +6037,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 334
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5743,7 +6053,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 336
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5769,22 +6079,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 327
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 329
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 331
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 333
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 337
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5800,7 +6179,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 306
+      ID: 316
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5816,7 +6217,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 320
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5832,7 +6233,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 322
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5848,7 +6249,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 324
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5874,12 +6275,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 309
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5889,7 +6284,25 @@ Types:
       ID: 313
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 315
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 354
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5915,7 +6328,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5934,7 +6347,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5953,7 +6366,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5972,7 +6385,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5988,7 +6401,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6004,7 +6417,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6020,7 +6433,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6036,7 +6449,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6051,32 +6464,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 339
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 349
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 355
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 357
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 367
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 369
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 371
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 212
@@ -6222,10 +6635,10 @@ Types:
       ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 372
+      ID: 388
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 373
+      ID: 389
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8144,7 +8557,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47552
       GoKind: 26
-MaxTypeID: 377
+MaxTypeID: 393
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8222,7 +8635,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8252,7 +8665,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8267,7 +8680,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8282,7 +8695,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.PointerChainArg]
+          Type: 360 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0x4c1f34", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 361 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0x4c1f79", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 211 EventRootType Probe[main.bigMapArg]
+          Type: 214 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0x4c2fca", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 212 EventRootType Probe[main.bigMapArg]Return
+          Type: 215 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0x4c301f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condBool]
+          Type: 258 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condBool]Return
+          Type: 259 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condBool]
+          Type: 260 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condBool]Return
+          Type: 261 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condBool]
+          Type: 262 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condBool]Return
+          Type: 263 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condFloat32]
+          Type: 254 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0x4c36ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condFloat32]Return
+          Type: 255 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0x4c3725", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condFloat64]
+          Type: 256 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0x4c376e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condFloat64]Return
+          Type: 257 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0x4c37e5", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 219 EventRootType Probe[main.condInt16]
+          Type: 222 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4c316a", Frameless: false}]
           Condition:
             Type: 108 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 220 EventRootType Probe[main.condInt16]Return
+          Type: 223 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4c31dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 221 EventRootType Probe[main.condInt16]
+          Type: 224 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0x4c316a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 222 EventRootType Probe[main.condInt16]Return
+          Type: 225 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0x4c31dc", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 223 EventRootType Probe[main.condInt32]
+          Type: 226 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 224 EventRootType Probe[main.condInt32]Return
+          Type: 227 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 225 EventRootType Probe[main.condInt32]
+          Type: 228 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 226 EventRootType Probe[main.condInt32]Return
+          Type: 229 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 227 EventRootType Probe[main.condInt32]
+          Type: 230 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 228 EventRootType Probe[main.condInt32]Return
+          Type: 231 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 229 EventRootType Probe[main.condInt64]
+          Type: 232 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4c32ea", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 230 EventRootType Probe[main.condInt64]Return
+          Type: 233 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4c335c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 231 EventRootType Probe[main.condInt64]
+          Type: 234 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0x4c32ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 232 EventRootType Probe[main.condInt64]Return
+          Type: 235 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0x4c335c", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 215 EventRootType Probe[main.condInt8]
+          Type: 218 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4c30aa", Frameless: false}]
           Condition:
             Type: 20 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 216 EventRootType Probe[main.condInt8]Return
+          Type: 219 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4c311c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 217 EventRootType Probe[main.condInt8]
+          Type: 220 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0x4c30aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 218 EventRootType Probe[main.condInt8]Return
+          Type: 221 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0x4c311c", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 299 EventRootType Probe[main.condLine]Line
+          Type: 302 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 300 EventRootType Probe[main.condLine]Line
+          Type: 303 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condNilPtrStruct]
+          Type: 290 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 291 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.condNilPtrStruct]
+          Type: 292 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 293 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.condOnly]
+          Type: 298 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 296 EventRootType Probe[main.condOnly]Return
+          Type: 299 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.condOnly]
+          Type: 300 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 298 EventRootType Probe[main.condOnly]Return
+          Type: 301 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condPtrStructArg]
+          Type: 284 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 285 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condPtrStructArg]
+          Type: 286 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 287 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condPtrStructArg]
+          Type: 288 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.condReturnAndLocal]
+          Type: 294 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 295 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.condReturnAndLocal]
+          Type: 296 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 297 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condString]
+          Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condString]Return
+          Type: 265 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condString]
+          Type: 266 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condString]Return
+          Type: 267 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condString]
+          Type: 268 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condString]Return
+          Type: 269 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condString]
+          Type: 270 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condString]Return
+          Type: 271 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condStructArg]
+          Type: 274 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condStructArg]Return
+          Type: 275 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 13 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condStructArg]
+          Type: 278 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condStructArg]Return
+          Type: 279 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condStructArg]
+          Type: 280 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condStructArg]Return
+          Type: 281 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condStructArg]
+          Type: 282 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condStructArg]Return
+          Type: 283 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 239 EventRootType Probe[main.condUint16]
+          Type: 242 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4c346a", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 240 EventRootType Probe[main.condUint16]Return
+          Type: 243 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4c34dc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condUint16]
+          Type: 244 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0x4c346a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condUint16]Return
+          Type: 245 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0x4c34dc", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condUint32]
+          Type: 246 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4c352a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condUint32]Return
+          Type: 247 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4c359c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condUint32]
+          Type: 248 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0x4c352a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condUint32]Return
+          Type: 249 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0x4c359c", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condUint64]
+          Type: 250 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4c35ea", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condUint64]Return
+          Type: 251 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4c365c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condUint64]
+          Type: 252 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0x4c35ea", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condUint64]Return
+          Type: 253 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0x4c365c", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 233 EventRootType Probe[main.condUint8]
+          Type: 236 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 234 EventRootType Probe[main.condUint8]Return
+          Type: 237 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 235 EventRootType Probe[main.condUint8]
+          Type: 238 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 236 EventRootType Probe[main.condUint8]Return
+          Type: 239 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 237 EventRootType Probe[main.condUint8]
+          Type: 240 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 238 EventRootType Probe[main.condUint8]Return
+          Type: 241 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.inlined]
+          Type: 358 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0x4c1c4a"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.inlined]Return
+          Type: 359 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0x4c2eea", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.intArg]
+          Type: 195 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0x4c2b8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 193 EventRootType Probe[main.intArg]Return
+          Type: 196 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0x4c2bca", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 202 EventRootType Probe[main.intArrayArg]
+          Type: 205 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0x4c2d0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 203 EventRootType Probe[main.intArrayArg]Return
+          Type: 206 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0x4c2d56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 211 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0x4c2e80", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 200 EventRootType Probe[main.intSliceArg]
+          Type: 203 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0x4c2c8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 201 EventRootType Probe[main.intSliceArg]Return
+          Type: 204 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0x4c2ccf", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 348 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 349 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 352 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 353 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 350 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0x4c4a13", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 351 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0x4c4aee", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 354 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0x4c4b33", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 355 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0x4c4c4f", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 320 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0x4c446e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 321 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0x4c454e", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 322 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 323 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0x4c458e", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0x4c465a", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 344 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 345 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0x4c4893", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0x4c49cb", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0x4c4313", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0x4c4409", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0x4c41d3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0x4c42bc", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 332 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 334 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 336 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 338 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0x4c46b3", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0x4c4839", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.stringArg]
+          Type: 197 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.stringArg]Return
+          Type: 198 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArg]
+          Type: 199 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 197 EventRootType Probe[main.stringArg]Return
+          Type: 200 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 209 EventRootType Probe[main.mapArg]
+          Type: 212 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0x4c2f6a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 210 EventRootType Probe[main.mapArg]Return
+          Type: 213 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0x4c2f9f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 213 EventRootType Probe[main.noArgs]
+          Type: 216 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0x4c304a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 214 EventRootType Probe[main.noArgs]Return
+          Type: 217 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0x4c3086", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.stringArg]
+          Type: 201 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 199 EventRootType Probe[main.stringArg]Return
+          Type: 202 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.stringArrayArg]
+          Type: 209 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0x4c2e0a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 207 EventRootType Probe[main.stringArrayArg]Return
+          Type: 210 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0x4c2e56", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.stringSliceArg]
+          Type: 207 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0x4c2d8a", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.stringSliceArg]Return
+          Type: 208 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0x4c2dcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 356 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0x4c4c96", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 357 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0x4c4e60", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2478,12 +3145,316 @@ Subprograms:
                   Op: {CfaOffset: 88}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0x4c41c0..0x4c42f7]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c41c0..0x4c423b
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c423b..0x4c4240
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+            - Range: 0x4c4240..0x4c42f7
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c41c0..0x4c4243
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+            - Range: 0x4c4243..0x4c4248
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0x4c4248..0x4c42f7
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0x4c4300..0x4c444e]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 112 GoSliceHeaderType []int
+          Locations:
+            - Range: 0x4c4300..0x4c438a
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c438a..0x4c438f
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c438f..0x4c4392
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c4392..0x4c444e
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4300..0x4c4397
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 5, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0x4c4397..0x4c444e
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0x4c4460..0x4c457c]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0x4c4460..0x4c44c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c44c0..0x4c457c
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4460..0x4c44c5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c44c5..0x4c44c8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c44c8..0x4c457c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0x4c4580..0x4c4689]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 101 PointerType *string
+          Locations:
+            - Range: 0x4c4580..0x4c45e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c45e0..0x4c4689
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4580..0x4c45e5
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c45e5..0x4c45e8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c45e8..0x4c4689
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0x4c46a0..0x4c4865]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 129 StructureType main.lenFields
+          Locations:
+            - Range: 0x4c46a0..0x4c4865
+              Pieces: [{Size: 72, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c46a0..0x4c4755
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c4755..0x4c475a
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+            - Range: 0x4c475a..0x4c4865
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 72}
+                - Size: 8
+                  Op: {CfaOffset: 80}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0x4c4880..0x4c49fc]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 131 PointerType *main.lenFields
+          Locations:
+            - Range: 0x4c4880..0x4c48f1
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c48f1..0x4c49fc
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4880..0x4c48f6
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c48f6..0x4c48f9
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c48f9..0x4c49fc
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0x4c4a00..0x4c4b1c]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0x4c4a00..0x4c4a6f
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0x4c4a6f..0x4c4b1c
+              Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4a00..0x4c4a74
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0x4c4a74..0x4c4a77
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+            - Range: 0x4c4a77..0x4c4b1c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 8}
+                - Size: 8
+                  Op: {CfaOffset: 16}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0x4c4b20..0x4c4c76]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 StructureType main.condFields
+          Locations:
+            - Range: 0x4c4b20..0x4c4c76
+              Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0x4c4b20..0x4c4bc9
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0x4c4bc9..0x4c4bce
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0x4c4bce..0x4c4c76
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0x4c4c80..0x4c4e73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0x4c4c80..0x4c4e60
               Pieces: []
@@ -2492,7 +3463,7 @@ Subprograms:
             - Range: 0x4c4e61..0x4c4e73
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0x4c2ea0..0x4c2f02]
       InlinePCRanges:
@@ -2507,7 +3478,7 @@ Subprograms:
             - Range: 0x4c2ea0..0x4c2eb9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2515,12 +3486,12 @@ Subprograms:
           RootRanges: [0x4c1aa0..0x4c2b7a]
       Variables:
         - Name: ptr
-          Type: 134 PointerType *****int
+          Type: 137 PointerType *****int
           Locations:
             - Range: 0x4c1f09..0x4c1f59
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2528,35 +3499,35 @@ Subprograms:
           RootRanges: [0x4c1aa0..0x4c2b7a]
       Variables:
         - Name: ptr
-          Type: 136 PointerType **int
+          Type: 139 PointerType **int
           Locations:
             - Range: 0x4c1f79..0x4c1fb3
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 134
+      ID: 137
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 39136
       GoKind: 22
-      Pointee: 135 PointerType ****int
+      Pointee: 138 PointerType ****int
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 39072
       GoKind: 22
-      Pointee: 191 PointerType ***int
+      Pointee: 194 PointerType ***int
     - __kind: PointerType
-      ID: 191
+      ID: 194
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 39008
       GoKind: 22
-      Pointee: 136 PointerType **int
+      Pointee: 139 PointerType **int
     - __kind: PointerType
-      ID: 136
+      ID: 139
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 38944
@@ -2569,10 +3540,10 @@ Types:
       GoKind: 22
       Pointee: 68 PointerType *runtime.p
     - __kind: PointerType
-      ID: 177
+      ID: 180
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 181 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 119
       Name: '**table<string,int>'
@@ -2584,20 +3555,27 @@ Types:
       ByteSize: 8
       Pointee: 125 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 132
+      ID: 135
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 133 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 136 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 145
+      ID: 148
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []*runtime.p.array
+      Pointee: 147 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 147
+      ID: 130
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 38880
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 150
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 146 GoSliceDataType []int.array
+      Pointee: 149 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 40
       Name: '*[]runtime.ancestorInfo'
@@ -2606,20 +3584,20 @@ Types:
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 149
+      ID: 152
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 148 GoSliceDataType []string.array
+      Pointee: 151 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []uint8.array
+      Pointee: 142 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []uintptr.array
+      Pointee: 144 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -2677,12 +3655,12 @@ Types:
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 164
+      ID: 167
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 30176
       GoKind: 22
-      Pointee: 165 StructureType main.bigStruct
+      Pointee: 168 StructureType main.bigStruct
     - __kind: PointerType
       ID: 128
       Name: '*main.condFields'
@@ -2691,10 +3669,17 @@ Types:
       GoKind: 22
       Pointee: 126 StructureType main.condFields
     - __kind: PointerType
-      ID: 175
+      ID: 131
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 30048
+      GoKind: 22
+      Pointee: 129 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 178
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 179 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 117
       Name: '*map<string,int>'
@@ -2706,30 +3691,30 @@ Types:
       ByteSize: 8
       Pointee: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 183
+      ID: 186
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 152
+      ID: 155
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]int
+      Pointee: 156 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 161 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 170
+      ID: 173
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
@@ -2778,7 +3763,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 73408
       GoKind: 22
-      Pointee: 143 UnresolvedPointeeType runtime.p
+      Pointee: 146 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
@@ -2822,30 +3807,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 138
+      ID: 141
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 137 GoStringDataType string.str
+      Pointee: 140 GoStringDataType string.str
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 181 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 184 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 120
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 150 StructureType table<string,int>
+      Pointee: 153 StructureType table<string,int>
     - __kind: PointerType
       ID: 125
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 158 StructureType table<string,main.bigStruct>
+      Pointee: 161 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 168 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 171 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 110
       Name: '*uint'
@@ -2889,7 +3874,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 305
+      ID: 360
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2898,24 +3883,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 134 PointerType *****int
+            Type: 137 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 134 PointerType *****int
+            Type: 137 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 361
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2924,14 +3909,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 136 PointerType **int
+            Type: 139 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2957,10 +3942,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2976,7 +3961,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 260
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2992,7 +3977,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 259
+      ID: 262
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3018,16 +4003,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3043,10 +4028,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3062,10 +4047,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 257
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 219
+      ID: 222
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3081,7 +4066,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3107,13 +4092,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 222
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 223
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 225
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 226
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3129,7 +4114,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3145,7 +4130,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3171,16 +4156,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 226
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 228
+      ID: 227
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 229
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 232
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3196,7 +4181,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3222,13 +4207,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 215
+      ID: 218
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3244,7 +4229,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 220
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3270,13 +4255,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 216
+      ID: 219
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 218
+      ID: 221
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 302
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3292,7 +4277,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 303
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3318,7 +4303,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 290
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3334,7 +4319,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3360,71 +4345,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 291
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 290
+      ID: 293
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 298
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 299
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 301
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 284
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3440,7 +4425,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3456,7 +4441,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
+      ID: 288
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3482,16 +4467,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 286
+      ID: 289
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 294
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3507,7 +4492,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 296
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3533,10 +4518,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 295
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 297
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3552,7 +4537,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3568,7 +4553,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3576,6 +4561,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3585,70 +4622,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 265
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 267
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 262
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 268
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 269
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 271
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 272
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3664,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 271
+      ID: 274
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3680,7 +4665,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3696,7 +4681,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3712,7 +4697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3728,7 +4713,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3754,25 +4739,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 279
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 239
+      ID: 242
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3788,7 +4773,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 241
+      ID: 244
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3814,13 +4799,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 240
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 242
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 243
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 246
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3836,7 +4821,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3862,13 +4847,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 247
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 250
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3884,7 +4869,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3910,13 +4895,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3932,7 +4917,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
+      ID: 238
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3948,7 +4933,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 240
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3974,16 +4959,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 238
+      ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 303
+      ID: 358
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3995,14 +4980,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 359
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4018,10 +5003,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4037,10 +5022,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4056,10 +5041,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 348
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 352
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 354
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 101 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 131 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 129 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 212
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4085,16 +5594,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 213
+      ID: 216
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4110,10 +5619,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4139,16 +5648,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 202
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4164,7 +5673,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4180,10 +5689,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4199,13 +5708,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 301
+      ID: 356
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 302
+      ID: 357
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4214,10 +5723,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4230,7 +5739,7 @@ Types:
       HasCount: true
       Element: 96 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 190
+      ID: 193
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 52192
@@ -4371,37 +5880,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 144 GoSliceDataType []*runtime.p.array
+      Data: 147 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 147
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 68 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 191
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 178 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 181 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 159
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 120 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 169
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 125 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 182
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 133 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 136 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 112
       Name: '[]int'
@@ -4418,37 +5927,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 146 GoSliceDataType []int.array
+      Data: 149 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 149
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 192
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 153 StructureType noalg.map.group[string]int
+      Element: 156 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 170
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 161 StructureType noalg.map.group[string]main.bigStruct
+      Element: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 183
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 41
       Name: '[]runtime.ancestorInfo'
@@ -4469,9 +5978,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 148 GoSliceDataType []string.array
+      Data: 151 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 151
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4492,9 +6001,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []uint8.array
+      Data: 142 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 142
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4515,9 +6024,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 141 GoSliceDataType []uintptr.array
+      Data: 144 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 144
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4578,61 +6087,61 @@ Types:
       GoRuntimeType: 63584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 182
+      ID: 185
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 183 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 186 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 189 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 154
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]int
+          Type: 155 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]int
-      GroupSliceType: 157 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 156 StructureType noalg.map.group[string]int
+      GroupSliceType: 160 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 159
+      ID: 162
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 160 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 163 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 161 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 167 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 164 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 169
+      ID: 172
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 170 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 173 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 180 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 183 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4754,14 +6263,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 187
+      ID: 190
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 78144
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 165
+      ID: 168
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 135712
@@ -4790,7 +6299,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 190 ArrayType [128]uint8
+          Type: 193 ArrayType [128]uint8
     - __kind: StructureType
       ID: 126
       Name: main.condFields
@@ -4837,8 +6346,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 127 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 129
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 128992
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 112 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 116 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 101 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 130 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 127 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 179
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4851,7 +6385,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 180 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4870,8 +6404,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 188 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 118
       Name: map<string,int>
@@ -4905,8 +6439,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 156 GoSliceDataType []*table<string,int>.array
-      GroupType: 153 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 159 GoSliceDataType []*table<string,int>.array
+      GroupType: 156 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 123
       Name: map<string,main.bigStruct>
@@ -4940,10 +6474,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 166 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 161 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 131
+      ID: 134
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4956,7 +6490,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 132 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 135 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4975,15 +6509,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 179 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 182 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 174
+      ID: 177
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 76352
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 179 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
@@ -4999,50 +6533,50 @@ Types:
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 129
+      ID: 132
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 76736
       GoKind: 21
-      HeaderType: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 185
+      ID: 188
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 52096
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 186 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 189 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 162
+      ID: 165
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 52288
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 163 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 166 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 154
+      ID: 157
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 51712
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem int }
+      Element: 158 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 172
+      ID: 175
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 52480
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 173 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 176 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 184
+      ID: 187
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 84544
@@ -5053,9 +6587,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 185 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 84288
@@ -5066,9 +6600,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 157 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 84800
@@ -5079,9 +6613,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 162 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 165 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 171
+      ID: 174
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 85312
@@ -5092,9 +6626,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 172 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 175 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 186
+      ID: 189
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 84416
@@ -5105,9 +6639,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 187 StructureType main.aStructNotUsedAsAnArgument
+          Type: 190 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 84672
@@ -5118,9 +6652,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 PointerType *main.bigStruct
+          Type: 167 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 155
+      ID: 158
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 84160
@@ -5133,7 +6667,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 173
+      ID: 176
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 85184
@@ -5144,7 +6678,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 174 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 177 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 28
       Name: runtime._defer
@@ -5812,7 +7346,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 143
+      ID: 146
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -5951,18 +7485,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 138 PointerType *string.str
+          Type: 141 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 137 GoStringDataType string.str
+      Data: 140 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 137
+      ID: 140
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 181
+      ID: 184
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5984,9 +7518,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 182 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 185 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -6008,9 +7542,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,int>
+          Type: 154 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -6032,9 +7566,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 159 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 162 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 168
+      ID: 171
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -6056,7 +7590,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 169 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 172 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 14
       Name: uint
@@ -6099,7 +7633,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47552
       GoKind: 26
-MaxTypeID: 306
+MaxTypeID: 361
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6330,6 +7864,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 211 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0x4c2a0a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2fca", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 212 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0x4c2a5f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c301f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 255 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4c326a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 256 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4c32dc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 257 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4c326a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 258 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4c32dc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 259 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0x4c326a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c382a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 260 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0x4c32dc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c389c", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 251 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0x4c30ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c36ae", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 252 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0x4c3165", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3725", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 253 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0x4c31ae", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c376e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 254 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0x4c3225", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c37e5", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 219 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4c2baa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c316a", Frameless: false}]
           Condition:
             Type: 108 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 220 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4c2c1c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c31dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 221 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0x4c2baa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c316a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 222 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0x4c2c1c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c31dc", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 223 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4c2c6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 224 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4c2cdc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 225 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4c2c6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 226 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4c2cdc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 227 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0x4c2c6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c322a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 228 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0x4c2cdc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c329c", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 229 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4c2d2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c32ea", Frameless: false}]
           Condition:
             Type: 12 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 230 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4c2d9c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c335c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 231 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0x4c2d2a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c32ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 232 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0x4c2d9c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c335c", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 215 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4c2aea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c30aa", Frameless: false}]
           Condition:
             Type: 20 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 216 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4c2b5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c311c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 217 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0x4c2aea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c30aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 218 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0x4c2b5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c311c", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 299 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4c38c4", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 300 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0x4c38c4", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3e81", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 287 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4c368e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4c370f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 289 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0x4c368e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3c4e", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0x4c370f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ccf", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 295 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4c37ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 296 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4c385c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 297 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0x4c37ea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3daa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 298 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0x4c385c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3e1c", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 281 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4c352e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 282 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4c3636", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 283 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4c352e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 284 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4c3636", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 285 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0x4c352e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3aee", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 286 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0x4c3636", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 291 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4c374a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4c37bb", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 293 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0x4c374a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3d0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0x4c37bb", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3d7b", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 261 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4c332e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 262 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4c33a5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 263 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4c332e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 264 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4c33a5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 265 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4c332e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 266 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4c33a5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 267 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0x4c332e", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c38ee", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 268 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0x4c33a5", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3965", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 269 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 270 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 271 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 272 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 273 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 13 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 274 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 275 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 10 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 276 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 277 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 278 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 279 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0x4c33ee", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c39ae", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 280 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0x4c34f0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3ab0", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 239 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4c2eaa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c346a", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 240 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4c2f1c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c34dc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 241 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0x4c2eaa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c346a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 242 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0x4c2f1c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c34dc", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 243 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4c2f6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c352a", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 244 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4c2fdc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c359c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 245 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0x4c2f6a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c352a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 246 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0x4c2fdc", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c359c", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 247 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4c302a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c35ea", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 248 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4c309c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c365c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 249 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0x4c302a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c35ea", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 250 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0x4c309c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c365c", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 233 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4c2dea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 234 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4c2e5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 235 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4c2dea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 236 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4c2e5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 237 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0x4c2dea", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c33aa", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 238 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0x4c2e5c", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c341c", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0x4c1c4a"
               Frameless: false
-            - PC: "0x4c28ea"
+            - PC: "0x4c2eaa"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 304 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0x4c292a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2eea", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0x4c25ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2b8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 193 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0x4c260a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2bca", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 202 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0x4c274a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2d0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 203 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0x4c2796", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2d56", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0x4c28c0", Frameless: true}]
+          InjectionPoints: [{PC: "0x4c2e80", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 200 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0x4c26ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 201 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0x4c270f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2ccf", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4c264a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4c268f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4c264a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 197 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4c268f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 209 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0x4c29aa", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2f6a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 210 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0x4c29df", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2f9f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 213 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0x4c2a8a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c304a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 214 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0x4c2ac6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c3086", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0x4c264a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 199 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0x4c268f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2c4f", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0x4c284a", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2e0a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 207 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0x4c2896", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2e56", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0x4c27ca", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2d8a", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0x4c280f", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c2dcf", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 301 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0x4c3bf6", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c4c96", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 302 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0x4c3dc0", Frameless: false}]
+          InjectionPoints: [{PC: "0x4c4e60", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0x4c25c0..0x4c2622]
+      OutOfLinePCRanges: [0x4c2b80..0x4c2be2]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c25c0..0x4c25d9
+            - Range: 0x4c2b80..0x4c2b99
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0x4c2640..0x4c26b1]
+      OutOfLinePCRanges: [0x4c2c00..0x4c2c71]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2640..0x4c265e
+            - Range: 0x4c2c00..0x4c2c1e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0x4c26c0..0x4c273a]
+      OutOfLinePCRanges: [0x4c2c80..0x4c2cfa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c26c0..0x4c26de
+            - Range: 0x4c2c80..0x4c2c9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0x4c2740..0x4c27a7]
+      OutOfLinePCRanges: [0x4c2d00..0x4c2d67]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 113 ArrayType [3]int
           Locations:
-            - Range: 0x4c2740..0x4c27a7
+            - Range: 0x4c2d00..0x4c2d67
               Pieces: [{Size: 24, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0x4c27c0..0x4c283a]
+      OutOfLinePCRanges: [0x4c2d80..0x4c2dfa]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 114 GoSliceHeaderType []string
           Locations:
-            - Range: 0x4c27c0..0x4c27de
+            - Range: 0x4c2d80..0x4c2d9e
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0x4c2840..0x4c28a7]
+      OutOfLinePCRanges: [0x4c2e00..0x4c2e67]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0x4c2840..0x4c28a7
+            - Range: 0x4c2e00..0x4c2e67
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0x4c28c0..0x4c28c1]
+      OutOfLinePCRanges: [0x4c2e80..0x4c2e81]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0x4c28c0..0x4c28c1
+            - Range: 0x4c2e80..0x4c2e81
               Pieces: [{Size: 48, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0x4c29a0..0x4c29f6]
+      OutOfLinePCRanges: [0x4c2f60..0x4c2fb6]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c29a0..0x4c29cd
+            - Range: 0x4c2f60..0x4c2f8d
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0x4c2a00..0x4c2a76]
+      OutOfLinePCRanges: [0x4c2fc0..0x4c3036]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 121 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0x4c2a00..0x4c2a24
+            - Range: 0x4c2fc0..0x4c2fe4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c2a24..0x4c2a76
+            - Range: 0x4c2fe4..0x4c3036
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0x4c2a80..0x4c2ad3]
+      OutOfLinePCRanges: [0x4c3040..0x4c3093]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0x4c2ae0..0x4c2b89]
+      OutOfLinePCRanges: [0x4c30a0..0x4c3149]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 20 BaseType int8
           Locations:
-            - Range: 0x4c2ae0..0x4c2b23
+            - Range: 0x4c30a0..0x4c30e3
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2ae0..0x4c2b26
+            - Range: 0x4c30a0..0x4c30e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2b26..0x4c2b2b
+            - Range: 0x4c30e6..0x4c30eb
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,31 +1827,31 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0x4c2ba0..0x4c2c4a]
+      OutOfLinePCRanges: [0x4c3160..0x4c320a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 108 BaseType int16
           Locations:
-            - Range: 0x4c2ba0..0x4c2bcb
+            - Range: 0x4c3160..0x4c318b
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2ba0..0x4c2bbd
+            - Range: 0x4c3160..0x4c317d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2bbd..0x4c2bcb
+            - Range: 0x4c317d..0x4c318b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c2bcb..0x4c2c4a
+            - Range: 0x4c318b..0x4c320a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1860,31 +1860,31 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0x4c2c60..0x4c2d08]
+      OutOfLinePCRanges: [0x4c3220..0x4c32c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 BaseType int32
           Locations:
-            - Range: 0x4c2c60..0x4c2c8b
+            - Range: 0x4c3220..0x4c324b
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2c60..0x4c2c7d
+            - Range: 0x4c3220..0x4c323d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2c7d..0x4c2c8b
+            - Range: 0x4c323d..0x4c324b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c2c8b..0x4c2d08
+            - Range: 0x4c324b..0x4c32c8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1893,31 +1893,31 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0x4c2d20..0x4c2dca]
+      OutOfLinePCRanges: [0x4c32e0..0x4c338a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int64
           Locations:
-            - Range: 0x4c2d20..0x4c2d4b
+            - Range: 0x4c32e0..0x4c330b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2d20..0x4c2d3d
+            - Range: 0x4c32e0..0x4c32fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2d3d..0x4c2d4b
+            - Range: 0x4c32fd..0x4c330b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c2d4b..0x4c2dca
+            - Range: 0x4c330b..0x4c338a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1926,25 +1926,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0x4c2de0..0x4c2e89]
+      OutOfLinePCRanges: [0x4c33a0..0x4c3449]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0x4c2de0..0x4c2e23
+            - Range: 0x4c33a0..0x4c33e3
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2de0..0x4c2e26
+            - Range: 0x4c33a0..0x4c33e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2e26..0x4c2e2b
+            - Range: 0x4c33e6..0x4c33eb
               Pieces:
                 - Size: 8
                   Op: null
@@ -1953,31 +1953,31 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0x4c2ea0..0x4c2f4a]
+      OutOfLinePCRanges: [0x4c3460..0x4c350a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0x4c2ea0..0x4c2ecb
+            - Range: 0x4c3460..0x4c348b
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2ea0..0x4c2ebd
+            - Range: 0x4c3460..0x4c347d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2ebd..0x4c2ecb
+            - Range: 0x4c347d..0x4c348b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c2ecb..0x4c2f4a
+            - Range: 0x4c348b..0x4c350a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -1986,31 +1986,31 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0x4c2f60..0x4c3008]
+      OutOfLinePCRanges: [0x4c3520..0x4c35c8]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0x4c2f60..0x4c2f8b
+            - Range: 0x4c3520..0x4c354b
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c2f60..0x4c2f7d
+            - Range: 0x4c3520..0x4c353d
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c2f7d..0x4c2f8b
+            - Range: 0x4c353d..0x4c354b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c2f8b..0x4c3008
+            - Range: 0x4c354b..0x4c35c8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2019,31 +2019,31 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0x4c3020..0x4c30ca]
+      OutOfLinePCRanges: [0x4c35e0..0x4c368a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0x4c3020..0x4c304b
+            - Range: 0x4c35e0..0x4c360b
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3020..0x4c303d
+            - Range: 0x4c35e0..0x4c35fd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c303d..0x4c304b
+            - Range: 0x4c35fd..0x4c360b
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c304b..0x4c30ca
+            - Range: 0x4c360b..0x4c368a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2052,31 +2052,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0x4c30e0..0x4c319a]
+      OutOfLinePCRanges: [0x4c36a0..0x4c375a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0x4c30e0..0x4c3113
+            - Range: 0x4c36a0..0x4c36d3
               Pieces: [{Size: 4, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c30e0..0x4c310e
+            - Range: 0x4c36a0..0x4c36ce
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c310e..0x4c3113
+            - Range: 0x4c36ce..0x4c36d3
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c3113..0x4c319a
+            - Range: 0x4c36d3..0x4c375a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2085,31 +2085,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0x4c31a0..0x4c325a]
+      OutOfLinePCRanges: [0x4c3760..0x4c381a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType float64
           Locations:
-            - Range: 0x4c31a0..0x4c31d4
+            - Range: 0x4c3760..0x4c3794
               Pieces: [{Size: 8, Op: {RegNo: 17, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c31a0..0x4c31cf
+            - Range: 0x4c3760..0x4c378f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c31cf..0x4c31d4
+            - Range: 0x4c378f..0x4c3794
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c31d4..0x4c325a
+            - Range: 0x4c3794..0x4c381a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2118,25 +2118,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0x4c3260..0x4c3309]
+      OutOfLinePCRanges: [0x4c3820..0x4c38c9]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0x4c3260..0x4c32a3
+            - Range: 0x4c3820..0x4c3863
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3260..0x4c32a6
+            - Range: 0x4c3820..0x4c3866
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c32a6..0x4c32ab
+            - Range: 0x4c3866..0x4c386b
               Pieces:
                 - Size: 8
                   Op: null
@@ -2145,13 +2145,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0x4c3320..0x4c33de]
+      OutOfLinePCRanges: [0x4c38e0..0x4c399e]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3320..0x4c3354
+            - Range: 0x4c38e0..0x4c3914
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2161,19 +2161,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3320..0x4c3346
+            - Range: 0x4c38e0..0x4c3906
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
-            - Range: 0x4c3346..0x4c3354
+            - Range: 0x4c3906..0x4c3914
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0x4c3354..0x4c33de
+            - Range: 0x4c3914..0x4c399e
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2182,31 +2182,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0x4c33e0..0x4c3514]
+      OutOfLinePCRanges: [0x4c39a0..0x4c3ad4]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0x4c33e0..0x4c3514
+            - Range: 0x4c39a0..0x4c3ad4
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c33e0..0x4c3426
+            - Range: 0x4c39a0..0x4c39e6
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c3426..0x4c342b
+            - Range: 0x4c39e6..0x4c39eb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4c342b..0x4c3514
+            - Range: 0x4c39eb..0x4c3ad4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2215,33 +2215,33 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0x4c3520..0x4c3665]
+      OutOfLinePCRanges: [0x4c3ae0..0x4c3c25]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0x4c3520..0x4c356a
+            - Range: 0x4c3ae0..0x4c3b2a
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c356a..0x4c3665
+            - Range: 0x4c3b2a..0x4c3c25
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3520..0x4c354f
+            - Range: 0x4c3ae0..0x4c3b0f
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c354f..0x4c356f
+            - Range: 0x4c3b0f..0x4c3b2f
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c356f..0x4c3665
+            - Range: 0x4c3b2f..0x4c3c25
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2250,25 +2250,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0x4c3680..0x4c373d]
+      OutOfLinePCRanges: [0x4c3c40..0x4c3cfd]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0x4c3680..0x4c36d6
+            - Range: 0x4c3c40..0x4c3c96
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3680..0x4c36d9
+            - Range: 0x4c3c40..0x4c3c99
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c36d9..0x4c36de
+            - Range: 0x4c3c99..0x4c3c9e
               Pieces:
                 - Size: 8
                   Op: null
@@ -2277,66 +2277,66 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0x4c3740..0x4c37df]
+      OutOfLinePCRanges: [0x4c3d00..0x4c3d9f]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c3740..0x4c3751
+            - Range: 0x4c3d00..0x4c3d11
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c3740..0x4c3785
+            - Range: 0x4c3d00..0x4c3d45
               Pieces: [{Size: 8, Op: {RegNo: 3, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c3740..0x4c37bb
+            - Range: 0x4c3d00..0x4c3d7b
               Pieces: []
-            - Range: 0x4c37bb..0x4c37bc
+            - Range: 0x4c3d7b..0x4c3d7c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c37bc..0x4c37df
+            - Range: 0x4c3d7c..0x4c3d9f
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c3751..0x4c3785
+            - Range: 0x4c3d11..0x4c3d45
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c3785..0x4c37df
+            - Range: 0x4c3d45..0x4c3d9f
               Pieces: [{Size: 8, Op: {CfaOffset: -56}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0x4c37e0..0x4c388a]
+      OutOfLinePCRanges: [0x4c3da0..0x4c3e4a]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c37e0..0x4c380b
+            - Range: 0x4c3da0..0x4c3dcb
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c37e0..0x4c37fd
+            - Range: 0x4c3da0..0x4c3dbd
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c37fd..0x4c380b
+            - Range: 0x4c3dbd..0x4c3dcb
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c380b..0x4c388a
+            - Range: 0x4c3dcb..0x4c3e4a
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2345,33 +2345,33 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0x4c38a0..0x4c3979]
+      OutOfLinePCRanges: [0x4c3e60..0x4c3f39]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c38a0..0x4c38c4
+            - Range: 0x4c3e60..0x4c3e84
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c38c4..0x4c3979
+            - Range: 0x4c3e84..0x4c3f39
               Pieces: [{Size: 8, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c38a0..0x4c38c9
+            - Range: 0x4c3e60..0x4c3e89
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c38c9..0x4c38dc
+            - Range: 0x4c3e89..0x4c3e9c
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
                 - Size: 8
                   Op: {CfaOffset: 16}
-            - Range: 0x4c38dc..0x4c3979
+            - Range: 0x4c3e9c..0x4c3f39
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 8}
@@ -2381,18 +2381,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0x4c38c4..0x4c38dc
+            - Range: 0x4c3e84..0x4c3e9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0x4c3980..0x4c3a47]
+      OutOfLinePCRanges: [0x4c3f40..0x4c4007]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0x4c3980..0x4c39b4
+            - Range: 0x4c3f40..0x4c3f74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2404,13 +2404,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3980..0x4c39b4
+            - Range: 0x4c3f40..0x4c3f74
               Pieces:
                 - Size: 8
                   Op: {RegNo: 5, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0x4c39b4..0x4c3a47
+            - Range: 0x4c3f74..0x4c4007
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2419,25 +2419,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0x4c3a60..0x4c3afc]
+      OutOfLinePCRanges: [0x4c4020..0x4c40bc]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0x4c3a60..0x4c3a95
+            - Range: 0x4c4020..0x4c4055
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3a60..0x4c3a98
+            - Range: 0x4c4020..0x4c4058
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0x4c3a98..0x4c3a9d
+            - Range: 0x4c4058..0x4c405d
               Pieces:
                 - Size: 8
                   Op: null
@@ -2446,31 +2446,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0x4c3b00..0x4c3bc5]
+      OutOfLinePCRanges: [0x4c40c0..0x4c4185]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0x4c3b00..0x4c3bc5
+            - Range: 0x4c40c0..0x4c4185
               Pieces: [{Size: 80, Op: {CfaOffset: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0x4c3b00..0x4c3b37
+            - Range: 0x4c40c0..0x4c40f7
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0x4c3b37..0x4c3b3c
+            - Range: 0x4c40f7..0x4c40fc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
                 - Size: 8
                   Op: {CfaOffset: 88}
-            - Range: 0x4c3b3c..0x4c3bc5
+            - Range: 0x4c40fc..0x4c4185
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 80}
@@ -2479,32 +2479,32 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0x4c3be0..0x4c3dd3]
+      OutOfLinePCRanges: [0x4c4c80..0x4c4e73]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0x4c3be0..0x4c3dc0
+            - Range: 0x4c4c80..0x4c4e60
               Pieces: []
-            - Range: 0x4c3dc0..0x4c3dc1
+            - Range: 0x4c4e60..0x4c4e61
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0x4c3dc1..0x4c3dd3
+            - Range: 0x4c4e61..0x4c4e73
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0x4c28e0..0x4c2942]
+      OutOfLinePCRanges: [0x4c2ea0..0x4c2f02]
       InlinePCRanges:
         - Ranges: [0x4c1c4a..0x4c1c8b]
-          RootRanges: [0x4c1aa0..0x4c25aa]
+          RootRanges: [0x4c1aa0..0x4c2b7a]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
             - Range: 0x4c1c4a..0x4c1c8b
               Pieces: []
-            - Range: 0x4c28e0..0x4c28f9
+            - Range: 0x4c2ea0..0x4c2eb9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
@@ -2512,7 +2512,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4c1f34..0x4c1f6e]
-          RootRanges: [0x4c1aa0..0x4c25aa]
+          RootRanges: [0x4c1aa0..0x4c2b7a]
       Variables:
         - Name: ptr
           Type: 134 PointerType *****int
@@ -2525,7 +2525,7 @@ Subprograms:
       OutOfLinePCRanges: []
       InlinePCRanges:
         - Ranges: [0x4c1f79..0x4c1fb3]
-          RootRanges: [0x4c1aa0..0x4c25aa]
+          RootRanges: [0x4c1aa0..0x4c2b7a]
       Variables:
         - Name: ptr
           Type: 136 PointerType **int
@@ -2538,28 +2538,28 @@ Types:
       ID: 134
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 38880
+      GoRuntimeType: 39136
       GoKind: 22
       Pointee: 135 PointerType ****int
     - __kind: PointerType
       ID: 135
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 38816
+      GoRuntimeType: 39072
       GoKind: 22
       Pointee: 191 PointerType ***int
     - __kind: PointerType
       ID: 191
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 38752
+      GoRuntimeType: 39008
       GoKind: 22
       Pointee: 136 PointerType **int
     - __kind: PointerType
       ID: 136
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 38688
+      GoRuntimeType: 38944
       GoKind: 22
       Pointee: 104 PointerType *int
     - __kind: PointerType
@@ -2602,7 +2602,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 42912
+      GoRuntimeType: 43104
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2624,70 +2624,70 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 32672
+      GoRuntimeType: 32800
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 107
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 31584
+      GoRuntimeType: 31712
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
       ID: 109
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 32544
+      GoRuntimeType: 32672
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 103
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 32608
+      GoRuntimeType: 32736
       GoKind: 22
       Pointee: 13 BaseType float64
     - __kind: PointerType
       ID: 104
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 32224
+      GoRuntimeType: 32352
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 31968
+      GoRuntimeType: 32096
       GoKind: 22
       Pointee: 10 BaseType int32
     - __kind: PointerType
       ID: 105
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 32096
+      GoRuntimeType: 32224
       GoKind: 22
       Pointee: 12 BaseType int64
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 105088
+      GoRuntimeType: 105280
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
       ID: 164
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 30048
+      GoRuntimeType: 30176
       GoKind: 22
       Pointee: 165 StructureType main.bigStruct
     - __kind: PointerType
       ID: 128
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 29920
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 126 StructureType main.condFields
     - __kind: PointerType
@@ -2734,91 +2734,91 @@ Types:
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 32864
+      GoRuntimeType: 32992
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 89280
+      GoRuntimeType: 89472
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 34976
+      GoRuntimeType: 35104
       GoKind: 22
       Pointee: 70 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 33696
+      GoRuntimeType: 33824
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 80128
+      GoRuntimeType: 80320
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 89920
+      GoRuntimeType: 90112
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 73216
+      GoRuntimeType: 73408
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 33632
+      GoRuntimeType: 33760
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 102848
+      GoRuntimeType: 103040
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 137024
+      GoRuntimeType: 137472
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 110272
+      GoRuntimeType: 110464
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 53
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 33888
+      GoRuntimeType: 34016
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
       ID: 101
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 31648
+      GoRuntimeType: 31776
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2850,42 +2850,42 @@ Types:
       ID: 110
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 32288
+      GoRuntimeType: 32416
       GoKind: 22
       Pointee: 14 BaseType uint
     - __kind: PointerType
       ID: 111
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 31904
+      GoRuntimeType: 32032
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 32032
+      GoRuntimeType: 32160
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 106
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 32160
+      GoRuntimeType: 32288
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 31776
+      GoRuntimeType: 31904
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 32352
+      GoRuntimeType: 32480
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3294,7 +3294,7 @@ Types:
     - __kind: EventRootType
       ID: 300
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3317,16 +3317,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 287
       Name: Probe[main.condNilPtrStruct]
@@ -4234,7 +4224,7 @@ Types:
       ID: 95
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 55264
+      GoRuntimeType: 55456
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4243,7 +4233,7 @@ Types:
       ID: 190
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 52000
+      GoRuntimeType: 52192
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4252,7 +4242,7 @@ Types:
       ID: 82
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 58336
+      GoRuntimeType: 58528
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4261,7 +4251,7 @@ Types:
       ID: 81
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 58432
+      GoRuntimeType: 58624
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4270,7 +4260,7 @@ Types:
       ID: 87
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 58624
+      GoRuntimeType: 58816
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4279,7 +4269,7 @@ Types:
       ID: 58
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 56704
+      GoRuntimeType: 56896
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4288,7 +4278,7 @@ Types:
       ID: 93
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 61024
+      GoRuntimeType: 61216
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4297,7 +4287,7 @@ Types:
       ID: 73
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 55168
+      GoRuntimeType: 55360
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4306,7 +4296,7 @@ Types:
       ID: 113
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 51616
+      GoRuntimeType: 51904
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4315,7 +4305,7 @@ Types:
       ID: 127
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 51424
+      GoRuntimeType: 51616
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4324,7 +4314,7 @@ Types:
       ID: 57
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 56608
+      GoRuntimeType: 56800
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4333,7 +4323,7 @@ Types:
       ID: 115
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 51712
+      GoRuntimeType: 52000
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4342,7 +4332,7 @@ Types:
       ID: 94
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 60064
+      GoRuntimeType: 60256
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4351,7 +4341,7 @@ Types:
       ID: 62
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 55072
+      GoRuntimeType: 55264
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4360,7 +4350,7 @@ Types:
       ID: 88
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 58528
+      GoRuntimeType: 58720
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4369,7 +4359,7 @@ Types:
       ID: 66
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40160
+      GoRuntimeType: 40352
       GoKind: 23
       RawFields:
         - Name: array
@@ -4416,7 +4406,7 @@ Types:
       ID: 112
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 41952
+      GoRuntimeType: 42144
       GoKind: 23
       RawFields:
         - Name: array
@@ -4467,7 +4457,7 @@ Types:
       ID: 114
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 42208
+      GoRuntimeType: 42400
       GoKind: 23
       RawFields:
         - Name: array
@@ -4490,7 +4480,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 41568
+      GoRuntimeType: 41760
       GoKind: 23
       RawFields:
         - Name: array
@@ -4513,7 +4503,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 42080
+      GoRuntimeType: 42272
       GoKind: 23
       RawFields:
         - Name: array
@@ -4536,25 +4526,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 47296
+      GoRuntimeType: 47488
       GoKind: 1
     - __kind: BaseType
       ID: 18
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 47104
+      GoRuntimeType: 47296
       GoKind: 16
     - __kind: BaseType
       ID: 102
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 47040
+      GoRuntimeType: 47232
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 71680
+      GoRuntimeType: 71872
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4567,25 +4557,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 47168
+      GoRuntimeType: 47360
       GoKind: 13
     - __kind: BaseType
       ID: 13
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 47232
+      GoRuntimeType: 47424
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 63
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 39328
+      GoRuntimeType: 39520
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 78
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 63392
+      GoRuntimeType: 63584
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 182
@@ -4647,37 +4637,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 46848
+      GoRuntimeType: 47040
       GoKind: 2
     - __kind: BaseType
       ID: 108
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 46464
+      GoRuntimeType: 46656
       GoKind: 4
     - __kind: BaseType
       ID: 10
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 46592
+      GoRuntimeType: 46784
       GoKind: 5
     - __kind: BaseType
       ID: 12
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 46720
+      GoRuntimeType: 46912
       GoKind: 6
     - __kind: BaseType
       ID: 20
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 46336
+      GoRuntimeType: 46528
       GoKind: 3
     - __kind: StructureType
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 126912
+      GoRuntimeType: 127104
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4699,7 +4689,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 82688
+      GoRuntimeType: 82880
       GoKind: 25
       RawFields:
         - Name: u
@@ -4709,7 +4699,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 112960
+      GoRuntimeType: 113152
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4729,7 +4719,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 101120
+      GoRuntimeType: 101312
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4742,7 +4732,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 100960
+      GoRuntimeType: 101152
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4754,27 +4744,27 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 69984
+      GoRuntimeType: 70176
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 69888
+      GoRuntimeType: 70080
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 187
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 77952
+      GoRuntimeType: 78144
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 165
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 135264
+      GoRuntimeType: 135712
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4805,7 +4795,7 @@ Types:
       ID: 126
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 142816
+      GoRuntimeType: 143264
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4991,35 +4981,35 @@ Types:
       ID: 174
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 76032
+      GoRuntimeType: 76352
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 76160
+      GoRuntimeType: 76224
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 121
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 76288
+      GoRuntimeType: 76480
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 129
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 76544
+      GoRuntimeType: 76736
       GoKind: 21
       HeaderType: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 185
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 51808
+      GoRuntimeType: 52096
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5028,7 +5018,7 @@ Types:
       ID: 162
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 52096
+      GoRuntimeType: 52288
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5037,7 +5027,7 @@ Types:
       ID: 154
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 51904
+      GoRuntimeType: 51712
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5046,7 +5036,7 @@ Types:
       ID: 172
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 52288
+      GoRuntimeType: 52480
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5055,7 +5045,7 @@ Types:
       ID: 184
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 84096
+      GoRuntimeType: 84544
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5068,7 +5058,7 @@ Types:
       ID: 153
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 84352
+      GoRuntimeType: 84288
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5081,7 +5071,7 @@ Types:
       ID: 161
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 84608
+      GoRuntimeType: 84800
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5094,7 +5084,7 @@ Types:
       ID: 171
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 85120
+      GoRuntimeType: 85312
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5107,7 +5097,7 @@ Types:
       ID: 186
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 83968
+      GoRuntimeType: 84416
       GoKind: 25
       RawFields:
         - Name: key
@@ -5120,7 +5110,7 @@ Types:
       ID: 163
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 84480
+      GoRuntimeType: 84672
       GoKind: 25
       RawFields:
         - Name: key
@@ -5133,7 +5123,7 @@ Types:
       ID: 155
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 84224
+      GoRuntimeType: 84160
       GoKind: 25
       RawFields:
         - Name: key
@@ -5146,7 +5136,7 @@ Types:
       ID: 173
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 84992
+      GoRuntimeType: 85184
       GoKind: 25
       RawFields:
         - Name: key
@@ -5174,14 +5164,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 69120
+      GoRuntimeType: 69312
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 159520
+      GoRuntimeType: 159968
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5383,7 +5373,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 80000
+      GoRuntimeType: 80192
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5393,7 +5383,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 130080
+      GoRuntimeType: 130528
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5418,7 +5408,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 95840
+      GoRuntimeType: 96032
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5431,7 +5421,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 118336
+      GoRuntimeType: 118528
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5450,13 +5440,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 61472
+      GoRuntimeType: 61664
       GoKind: 12
     - __kind: StructureType
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 98240
+      GoRuntimeType: 98432
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5469,7 +5459,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 97440
+      GoRuntimeType: 97632
       GoKind: 25
       RawFields:
         - Name: prev
@@ -5482,13 +5472,13 @@ Types:
       ID: 97
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 61856
+      GoRuntimeType: 62048
       GoKind: 2
     - __kind: StructureType
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 164800
+      GoRuntimeType: 165248
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5717,7 +5707,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 130592
+      GoRuntimeType: 131040
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5742,7 +5732,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 126240
+      GoRuntimeType: 126432
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5764,7 +5754,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 130848
+      GoRuntimeType: 131296
       GoKind: 25
       RawFields:
         - Name: writing
@@ -5789,7 +5779,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 97920
+      GoRuntimeType: 98112
       GoKind: 25
       RawFields:
         - Name: next
@@ -5802,7 +5792,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 103328
+      GoRuntimeType: 103520
       GoKind: 25
       RawFields:
         - Name: m
@@ -5812,13 +5802,13 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 61568
+      GoRuntimeType: 61760
       GoKind: 12
     - __kind: StructureType
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 81024
+      GoRuntimeType: 81216
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -5829,7 +5819,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 98080
+      GoRuntimeType: 98272
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5842,7 +5832,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 119296
+      GoRuntimeType: 119488
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5861,13 +5851,13 @@ Types:
       ID: 64
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 61760
+      GoRuntimeType: 61952
       GoKind: 12
     - __kind: ArrayType
       ID: 61
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 65376
+      GoRuntimeType: 65568
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5876,7 +5866,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 94560
+      GoRuntimeType: 94752
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5897,7 +5887,7 @@ Types:
       ID: 65
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 47488
+      GoRuntimeType: 47680
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 46
@@ -5907,7 +5897,7 @@ Types:
       ID: 79
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 47552
+      GoRuntimeType: 47744
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 84
@@ -5917,7 +5907,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 96160
+      GoRuntimeType: 96352
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5930,19 +5920,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 105568
+      GoRuntimeType: 105760
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 69024
+      GoRuntimeType: 69216
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 79872
+      GoRuntimeType: 80064
       GoKind: 25
       RawFields:
         - Name: state
@@ -5956,7 +5946,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 46272
+      GoRuntimeType: 46464
       GoKind: 24
       RawFields:
         - Name: str
@@ -6071,43 +6061,43 @@ Types:
       ID: 14
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 46912
+      GoRuntimeType: 47104
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 46528
+      GoRuntimeType: 46720
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 46656
+      GoRuntimeType: 46848
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 46784
+      GoRuntimeType: 46976
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 46400
+      GoRuntimeType: 46592
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 46976
+      GoRuntimeType: 47168
       GoKind: 12
     - __kind: VoidPointerType
       ID: 16
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 47360
+      GoRuntimeType: 47552
       GoKind: 26
 MaxTypeID: 306
 Issues:
@@ -6351,7 +6341,7 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x5ba320", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x5bc320", TypesOffset: 296}
 CommonTypes:
     G: 23 StructureType runtime.g
     M: 30 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.PointerChainArg]
+          Type: 349 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5494", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 350 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb54cc", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.inlined]
+          Type: 347 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb52a4"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.inlined]Return
+          Type: 348 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6210", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenErrInt]
+          Type: 337 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenErrInt]Return
+          Type: 338 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenErrStruct]
+          Type: 341 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenErrStruct]Return
+          Type: 342 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenErrInt]
+          Type: 339 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenErrInt]Return
+          Type: 340 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenErrStruct]
+          Type: 343 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenErrStruct]Return
+          Type: 344 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 297 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 298 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.lenMap]
+          Type: 303 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.lenMap]Return
+          Type: 304 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.lenMap]
+          Type: 305 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.lenMap]Return
+          Type: 306 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.lenPtrString]
+          Type: 307 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb771c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.lenPtrString]Return
+          Type: 308 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.lenPtrString]
+          Type: 309 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb771c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 298 EventRootType Probe[main.lenPtrString]Return
+          Type: 310 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenPtrStructFields]
+          Type: 329 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 330 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenPtrStructFields]
+          Type: 331 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 332 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenPtrStructFields]
+          Type: 333 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 334 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenPtrStructFields]
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 287 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 288 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 291 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 292 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.lenSlice]
+          Type: 293 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.lenSlice]Return
+          Type: 294 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.lenSlice]
+          Type: 295 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.lenSlice]Return
+          Type: 296 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenStructFields]
+          Type: 311 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenStructFields]Return
+          Type: 312 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenStructFields]
+          Type: 313 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenStructFields]Return
+          Type: 314 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenStructFields]
+          Type: 315 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenStructFields]Return
+          Type: 316 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenStructFields]
+          Type: 317 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenStructFields]Return
+          Type: 318 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenStructFields]
+          Type: 319 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenStructFields]Return
+          Type: 320 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenStructFields]
+          Type: 321 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenStructFields]Return
+          Type: 322 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenStructFields]
+          Type: 327 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 345 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7cf0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7e64", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3750,7 +4055,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3776,7 +4081,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4844,7 +5149,7 @@ Types:
       ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4860,7 +5165,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 168
@@ -4920,7 +5225,7 @@ Types:
       ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 337
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4946,16 +5251,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 322
+      ID: 338
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 340
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -4981,19 +5286,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 326
+      ID: 342
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 344
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 297
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 299
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5019,13 +5391,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 298
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 300
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 295
+      ID: 302
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 307
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5044,7 +5425,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 297
+      ID: 309
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5070,13 +5451,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 308
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 310
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 329
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5102,10 +5483,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 331
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 333
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5124,7 +5524,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 335
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5143,19 +5543,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 330
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 332
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 334
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 320
+      ID: 336
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 287
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 293
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5171,7 +5619,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 289
+      ID: 295
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5201,6 +5649,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 290
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 296
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 277
@@ -5308,7 +5765,7 @@ Types:
       ID: 286
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 311
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5334,10 +5791,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 301
+      ID: 313
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 11 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 315
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5356,7 +5829,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5375,7 +5848,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5391,7 +5864,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5407,7 +5880,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 323
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5423,25 +5896,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.lenStructFields]Return
+      ID: 325
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 304
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 306
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 308
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 310
-      Name: Probe[main.lenStructFields]Return
+      ID: 327
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 312
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 328
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 185
@@ -5587,10 +6098,10 @@ Types:
       ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 345
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7289,7 +7800,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39616
       GoKind: 26
-MaxTypeID: 334
+MaxTypeID: 350
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 278 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb5490", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5494", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'ptr: {ptr}'
@@ -34,7 +34,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 279 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb54c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb54cc", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 184 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5e60", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6310", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 185 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0xb5ed4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6384", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 228 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6668", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 229 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb66d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 230 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6668", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 231 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb66d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 232 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6668", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 233 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb66d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 224 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0xb6508", Frameless: false}]
+          InjectionPoints: [{PC: "0xb69b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 225 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0xb6570", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a20", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 226 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0xb65b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 227 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0xb6620", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ad0", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb6038", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition:
             Type: 89 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 193 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb6098", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6548", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb6038", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb6098", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6548", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb60e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 197 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb6148", Frameless: false}]
+          InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb60e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 199 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb6148", Frameless: false}]
+          InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 200 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb60e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 201 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb6148", Frameless: false}]
+          InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 202 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb6198", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6648", Frameless: false}]
           Condition:
             Type: 14 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 203 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb61f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb6198", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6648", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb61f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66a8", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 188 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb5f88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6438", Frameless: false}]
           Condition:
             Type: 15 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 189 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb5ff0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64a0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 190 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb5f88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6438", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 191 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb5ff0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64a0", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 272 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb6c48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 273 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb6c48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 260 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb6a28", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 261 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb6a9c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 262 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb6a28", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 263 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb6a9c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 268 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb6b88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 269 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb6be8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 270 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb6b88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 271 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb6be8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 254 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb68fc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 255 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb69e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 256 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb68fc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 257 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb69e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 258 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb68fc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 259 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb69e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 264 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb6ae8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition:
             Type: 9 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 265 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 266 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb6ae8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 267 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 234 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 235 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb677c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 236 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 237 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb677c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 238 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 239 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb677c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 240 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 241 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb677c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 242 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 243 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 244 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 245 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 246 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 17 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 247 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 248 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 249 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 250 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 251 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 252 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb67dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 253 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb68b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 212 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb62f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb67a8", Frameless: false}]
           Condition:
             Type: 7 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 213 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb6358", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6808", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 214 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb62f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb67a8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 215 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb6358", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6808", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 216 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6858", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 217 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb6408", Frameless: false}]
+          InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 218 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6858", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 219 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb6408", Frameless: false}]
+          InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 220 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb6458", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6908", Frameless: false}]
           Condition:
             Type: 11 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 221 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb64b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6968", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 222 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb6458", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6908", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 223 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb64b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6968", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6248", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 207 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb62b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6248", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 209 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb62b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 210 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6248", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 211 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb62b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0xb52a4"
               Frameless: false
-            - PC: "0xb5d28"
+            - PC: "0xb61d8"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 277 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0xb5d60", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6210", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 165 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb5a08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5eb8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 166 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0xb5a40", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5ef0", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 175 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb5b88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6038", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 176 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0xb5bcc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb607c", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 181 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb5d00", Frameless: true}]
+          InjectionPoints: [{PC: "0xb61b0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 173 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb5af8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5fa8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 174 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0xb5b34", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5fe4", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 167 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb5a78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 168 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5ab4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 169 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb5a78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 170 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5ab4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 182 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb5de8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 183 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0xb5e18", Frameless: false}]
+          InjectionPoints: [{PC: "0xb62c8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 186 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb5f18", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63c8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 187 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0xb5f50", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6400", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 171 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb5a78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 172 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5ab4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 179 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb5c98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6148", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 180 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0xb5cdc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb618c", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 177 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb5c08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb60b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 178 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb5c44", Frameless: false}]
+          InjectionPoints: [{PC: "0xb60f4", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 274 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb6f20", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7cf0", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 275 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0xb7094", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7e64", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb59f0..0xb5a60]
+      OutOfLinePCRanges: [0xb5ea0..0xb5f10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb59f0..0xb5a10
+            - Range: 0xb5ea0..0xb5ec0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb5a60..0xb5ae0]
+      OutOfLinePCRanges: [0xb5f10..0xb5f90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb5a60..0xb5a84
+            - Range: 0xb5f10..0xb5f34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb5ae0..0xb5b70]
+      OutOfLinePCRanges: [0xb5f90..0xb6020]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5ae0..0xb5b04
+            - Range: 0xb5f90..0xb5fb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb5b70..0xb5bf0]
+      OutOfLinePCRanges: [0xb6020..0xb60a0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 101 ArrayType [3]int
           Locations:
-            - Range: 0xb5b70..0xb5bf0
+            - Range: 0xb6020..0xb60a0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb5bf0..0xb5c80]
+      OutOfLinePCRanges: [0xb60a0..0xb6130]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 102 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb5bf0..0xb5c14
+            - Range: 0xb60a0..0xb60c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5c80..0xb5d00]
+      OutOfLinePCRanges: [0xb6130..0xb61b0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb5c80..0xb5d00
+            - Range: 0xb6130..0xb61b0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb5d00..0xb5d10]
+      OutOfLinePCRanges: [0xb61b0..0xb61c0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 103 ArrayType [3]string
           Locations:
-            - Range: 0xb5d00..0xb5d10
+            - Range: 0xb61b0..0xb61c0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5dd0..0xb5e40]
+      OutOfLinePCRanges: [0xb6280..0xb62f0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb5dd0..0xb5e08
+            - Range: 0xb6280..0xb62b8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5e40..0xb5f00]
+      OutOfLinePCRanges: [0xb62f0..0xb63b0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5e40..0xb5e78
+            - Range: 0xb62f0..0xb6328
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb5e78..0xb5f00
+            - Range: 0xb6328..0xb63b0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb5f00..0xb5f70]
+      OutOfLinePCRanges: [0xb63b0..0xb6420]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xb5f70..0xb6020]
+      OutOfLinePCRanges: [0xb6420..0xb64d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 15 BaseType int8
           Locations:
-            - Range: 0xb5f70..0xb5fb8
+            - Range: 0xb6420..0xb6468
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb5f70..0xb5fbc
+            - Range: 0xb6420..0xb646c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb5fbc..0xb5fc0
+            - Range: 0xb646c..0xb6470
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xb6020..0xb60d0]
+      OutOfLinePCRanges: [0xb64d0..0xb6580]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 89 BaseType int16
           Locations:
-            - Range: 0xb6020..0xb604c
+            - Range: 0xb64d0..0xb64fc
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6020..0xb604c
+            - Range: 0xb64d0..0xb64fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb604c..0xb60d0
+            - Range: 0xb64fc..0xb6580
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xb60d0..0xb6180]
+      OutOfLinePCRanges: [0xb6580..0xb6630]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int32
           Locations:
-            - Range: 0xb60d0..0xb60fc
+            - Range: 0xb6580..0xb65ac
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb60d0..0xb60fc
+            - Range: 0xb6580..0xb65ac
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb60fc..0xb6180
+            - Range: 0xb65ac..0xb6630
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xb6180..0xb6230]
+      OutOfLinePCRanges: [0xb6630..0xb66e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType int64
           Locations:
-            - Range: 0xb6180..0xb61ac
+            - Range: 0xb6630..0xb665c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6180..0xb61ac
+            - Range: 0xb6630..0xb665c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb61ac..0xb6230
+            - Range: 0xb665c..0xb66e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xb6230..0xb62e0]
+      OutOfLinePCRanges: [0xb66e0..0xb6790]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xb6230..0xb6278
+            - Range: 0xb66e0..0xb6728
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6230..0xb627c
+            - Range: 0xb66e0..0xb672c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb627c..0xb6280
+            - Range: 0xb672c..0xb6730
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xb62e0..0xb6390]
+      OutOfLinePCRanges: [0xb6790..0xb6840]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType uint16
           Locations:
-            - Range: 0xb62e0..0xb630c
+            - Range: 0xb6790..0xb67bc
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb62e0..0xb630c
+            - Range: 0xb6790..0xb67bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb630c..0xb6390
+            - Range: 0xb67bc..0xb6840
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xb6390..0xb6440]
+      OutOfLinePCRanges: [0xb6840..0xb68f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xb6390..0xb63bc
+            - Range: 0xb6840..0xb686c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6390..0xb63bc
+            - Range: 0xb6840..0xb686c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb63bc..0xb6440
+            - Range: 0xb686c..0xb68f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xb6440..0xb64f0]
+      OutOfLinePCRanges: [0xb68f0..0xb69a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 11 BaseType uint64
           Locations:
-            - Range: 0xb6440..0xb646c
+            - Range: 0xb68f0..0xb691c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6440..0xb646c
+            - Range: 0xb68f0..0xb691c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb646c..0xb64f0
+            - Range: 0xb691c..0xb69a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xb64f0..0xb65a0]
+      OutOfLinePCRanges: [0xb69a0..0xb6a50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float32
           Locations:
-            - Range: 0xb64f0..0xb6524
+            - Range: 0xb69a0..0xb69d4
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb64f0..0xb6520
+            - Range: 0xb69a0..0xb69d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb6520..0xb6524
+            - Range: 0xb69d0..0xb69d4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb6524..0xb65a0
+            - Range: 0xb69d4..0xb6a50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xb65a0..0xb6650]
+      OutOfLinePCRanges: [0xb6a50..0xb6b00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float64
           Locations:
-            - Range: 0xb65a0..0xb65d4
+            - Range: 0xb6a50..0xb6a84
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb65a0..0xb65d0
+            - Range: 0xb6a50..0xb6a80
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb65d0..0xb65d4
+            - Range: 0xb6a80..0xb6a84
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb65d4..0xb6650
+            - Range: 0xb6a84..0xb6b00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xb6650..0xb6700]
+      OutOfLinePCRanges: [0xb6b00..0xb6bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xb6650..0xb6698
+            - Range: 0xb6b00..0xb6b48
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6650..0xb669c
+            - Range: 0xb6b00..0xb6b4c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb669c..0xb66a0
+            - Range: 0xb6b4c..0xb6b50
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xb6700..0xb67c0]
+      OutOfLinePCRanges: [0xb6bb0..0xb6c70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6700..0xb6730
+            - Range: 0xb6bb0..0xb6be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6700..0xb6730
+            - Range: 0xb6bb0..0xb6be0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb6730..0xb67c0
+            - Range: 0xb6be0..0xb6c70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xb67c0..0xb68e0]
+      OutOfLinePCRanges: [0xb6c70..0xb6d90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0xb67c0..0xb68e0
+            - Range: 0xb6c70..0xb6d90
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb67c0..0xb6804
+            - Range: 0xb6c70..0xb6cb4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb6804..0xb6808
+            - Range: 0xb6cb4..0xb6cb8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb6808..0xb68e0
+            - Range: 0xb6cb8..0xb6d90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xb68e0..0xb6a10]
+      OutOfLinePCRanges: [0xb6d90..0xb6ec0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0xb68e0..0xb6928
+            - Range: 0xb6d90..0xb6dd8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6928..0xb6a10
+            - Range: 0xb6dd8..0xb6ec0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb68e0..0xb692c
+            - Range: 0xb6d90..0xb6ddc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb692c..0xb6a10
+            - Range: 0xb6ddc..0xb6ec0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xb6a10..0xb6ad0]
+      OutOfLinePCRanges: [0xb6ec0..0xb6f80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 118 PointerType *main.condFields
           Locations:
-            - Range: 0xb6a10..0xb6a64
+            - Range: 0xb6ec0..0xb6f14
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6a10..0xb6a68
+            - Range: 0xb6ec0..0xb6f18
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6a68..0xb6a6c
+            - Range: 0xb6f18..0xb6f1c
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xb6ad0..0xb6b70]
+      OutOfLinePCRanges: [0xb6f80..0xb7020]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6ad0..0xb6aec
+            - Range: 0xb6f80..0xb6f9c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6ad0..0xb6b00
+            - Range: 0xb6f80..0xb6fb0
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6ad0..0xb6b48
+            - Range: 0xb6f80..0xb6ff8
               Pieces: []
-            - Range: 0xb6b48..0xb6b49
+            - Range: 0xb6ff8..0xb6ff9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6b49..0xb6b70
+            - Range: 0xb6ff9..0xb7020
               Pieces: []
           Role: Return
         - Name: sum
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6aec..0xb6b14
+            - Range: 0xb6f9c..0xb6fc4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6b14..0xb6b70
+            - Range: 0xb6fc4..0xb7020
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xb6b70..0xb6c20]
+      OutOfLinePCRanges: [0xb7020..0xb70d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6b70..0xb6b9c
+            - Range: 0xb7020..0xb704c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6b70..0xb6b9c
+            - Range: 0xb7020..0xb704c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6b9c..0xb6c20
+            - Range: 0xb704c..0xb70d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2291,27 +2291,27 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xb6c20..0xb6cf0]
+      OutOfLinePCRanges: [0xb70d0..0xb71a0]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb6c20..0xb6c58
+            - Range: 0xb70d0..0xb7108
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6c58..0xb6cf0
+            - Range: 0xb7108..0xb71a0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6c20..0xb6c5c
+            - Range: 0xb70d0..0xb710c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6c5c..0xb6cf0
+            - Range: 0xb710c..0xb71a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2320,13 +2320,13 @@ Subprograms:
           Role: Parameter
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xb6cf0..0xb6db0]
+      OutOfLinePCRanges: [0xb71a0..0xb7260]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 100 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb6cf0..0xb6d20
+            - Range: 0xb71a0..0xb71d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2338,13 +2338,13 @@ Subprograms:
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6cf0..0xb6d20
+            - Range: 0xb71a0..0xb71d0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb6d20..0xb6db0
+            - Range: 0xb71d0..0xb7260
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -2353,25 +2353,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xb6db0..0xb6e50]
+      OutOfLinePCRanges: [0xb7260..0xb7300]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 104 GoMapType map[string]int
           Locations:
-            - Range: 0xb6db0..0xb6de8
+            - Range: 0xb7260..0xb7298
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6db0..0xb6dec
+            - Range: 0xb7260..0xb729c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6dec..0xb6df0
+            - Range: 0xb729c..0xb72a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -2380,31 +2380,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xb6e50..0xb6f00]
+      OutOfLinePCRanges: [0xb7300..0xb73b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 StructureType main.condFields
           Locations:
-            - Range: 0xb6e50..0xb6f00
+            - Range: 0xb7300..0xb73b0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 10 GoStringHeaderType string
           Locations:
-            - Range: 0xb6e50..0xb6e80
+            - Range: 0xb7300..0xb7330
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb6e80..0xb6e84
+            - Range: 0xb7330..0xb7334
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb6e84..0xb6f00
+            - Range: 0xb7334..0xb73b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2413,62 +2413,62 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb6f00..0xb70b0]
+      OutOfLinePCRanges: [0xb7cd0..0xb7e80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xb6f00..0xb7094
+            - Range: 0xb7cd0..0xb7e64
               Pieces: []
-            - Range: 0xb7094..0xb7095
+            - Range: 0xb7e64..0xb7e65
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb7095..0xb70b0
+            - Range: 0xb7e65..0xb7e80
               Pieces: []
           Role: Return
         - Name: m
           Type: 124 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
-          Locations: [{Range: 0xb6f00..0xb70b0, Pieces: []}]
+          Locations: [{Range: 0xb7cd0..0xb7e80, Pieces: []}]
           Role: Local
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0xb5d10..0xb5d80]
+      OutOfLinePCRanges: [0xb61c0..0xb6230]
       InlinePCRanges:
-        - Ranges: [0xb52a4..0xb52e4]
-          RootRanges: [0xb5100..0xb59f0]
+        - Ranges: [0xb52a4..0xb52e8]
+          RootRanges: [0xb5100..0xb5ea0]
       Variables:
         - Name: x
           Type: 9 BaseType int
           Locations:
-            - Range: 0xb52a4..0xb52e4
+            - Range: 0xb52a4..0xb52e8
               Pieces: []
-            - Range: 0xb5d10..0xb5d30
+            - Range: 0xb61c0..0xb61e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5490..0xb54c0]
-          RootRanges: [0xb5100..0xb59f0]
+        - Ranges: [0xb5494..0xb54c4]
+          RootRanges: [0xb5100..0xb5ea0]
       Variables:
         - Name: ptr
           Type: 129 PointerType *****int
           Locations:
-            - Range: 0xb5468..0xb54b0
+            - Range: 0xb546c..0xb54b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 35
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb54c8..0xb54f8]
-          RootRanges: [0xb5100..0xb59f0]
+        - Ranges: [0xb54cc..0xb54fc]
+          RootRanges: [0xb5100..0xb5ea0]
       Variables:
         - Name: ptr
           Type: 131 PointerType **int
           Locations:
-            - Range: 0xb54c8..0xb54f8
+            - Range: 0xb54cc..0xb54fc
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
@@ -2476,28 +2476,28 @@ Types:
       ID: 129
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 33120
+      GoRuntimeType: 33280
       GoKind: 22
       Pointee: 130 PointerType ****int
     - __kind: PointerType
       ID: 130
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 33056
+      GoRuntimeType: 33216
       GoKind: 22
       Pointee: 164 PointerType ***int
     - __kind: PointerType
       ID: 164
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 32992
+      GoRuntimeType: 33152
       GoKind: 22
       Pointee: 131 PointerType **int
     - __kind: PointerType
       ID: 131
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 32928
+      GoRuntimeType: 33088
       GoKind: 22
       Pointee: 94 PointerType *int
     - __kind: PointerType
@@ -2509,7 +2509,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 36640
+      GoRuntimeType: 36800
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2531,7 +2531,7 @@ Types:
       ID: 5
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 27552
+      GoRuntimeType: 27648
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
@@ -2563,21 +2563,21 @@ Types:
       ID: 96
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 26464
+      GoRuntimeType: 26560
       GoKind: 22
       Pointee: 18 GoInterfaceType error
     - __kind: PointerType
       ID: 97
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 27424
+      GoRuntimeType: 27520
       GoKind: 22
       Pointee: 16 BaseType float32
     - __kind: PointerType
       ID: 92
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 27488
+      GoRuntimeType: 27584
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
@@ -2609,112 +2609,112 @@ Types:
       ID: 94
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 27104
+      GoRuntimeType: 27200
       GoKind: 22
       Pointee: 9 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 26848
+      GoRuntimeType: 26944
       GoKind: 22
       Pointee: 13 BaseType int32
     - __kind: PointerType
       ID: 93
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 26976
+      GoRuntimeType: 27072
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
       ID: 147
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 24864
+      GoRuntimeType: 24960
       GoKind: 22
       Pointee: 148 StructureType main.bigStruct
     - __kind: PointerType
       ID: 118
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 24736
+      GoRuntimeType: 24768
       GoKind: 22
       Pointee: 116 StructureType main.condFields
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 27744
+      GoRuntimeType: 27840
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 71584
+      GoRuntimeType: 71744
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 60
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 28384
+      GoRuntimeType: 28480
       GoKind: 22
       Pointee: 61 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 28448
+      GoRuntimeType: 28544
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 53
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 54528
+      GoRuntimeType: 54688
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 62176
+      GoRuntimeType: 62336
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 109
       Name: '*runtime.mapextra'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30464
       GoKind: 22
       Pointee: 110 UnresolvedPointeeType runtime.mapextra
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 29152
+      GoRuntimeType: 29248
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 114528
+      GoRuntimeType: 114944
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 72
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 87904
+      GoRuntimeType: 88064
       GoKind: 22
       Pointee: 73 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 88
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 26528
+      GoRuntimeType: 26624
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
@@ -2726,42 +2726,42 @@ Types:
       ID: 98
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 27168
+      GoRuntimeType: 27264
       GoKind: 22
       Pointee: 12 BaseType uint
     - __kind: PointerType
       ID: 99
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 26784
+      GoRuntimeType: 26880
       GoKind: 22
       Pointee: 7 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 26912
+      GoRuntimeType: 27008
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 95
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 27040
+      GoRuntimeType: 27136
       GoKind: 22
       Pointee: 11 BaseType uint64
     - __kind: PointerType
       ID: 6
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 26656
+      GoRuntimeType: 26752
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 8
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 27232
+      GoRuntimeType: 27328
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -4100,7 +4100,7 @@ Types:
       ID: 85
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 48768
+      GoRuntimeType: 48928
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4109,7 +4109,7 @@ Types:
       ID: 163
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 43008
+      GoRuntimeType: 43168
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4118,7 +4118,7 @@ Types:
       ID: 71
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 48480
+      GoRuntimeType: 48640
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4127,7 +4127,7 @@ Types:
       ID: 77
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 48672
+      GoRuntimeType: 48832
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4136,7 +4136,7 @@ Types:
       ID: 52
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 44736
+      GoRuntimeType: 44896
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4145,7 +4145,7 @@ Types:
       ID: 83
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 50592
+      GoRuntimeType: 50752
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4154,7 +4154,7 @@ Types:
       ID: 63
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 48288
+      GoRuntimeType: 48448
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4163,7 +4163,7 @@ Types:
       ID: 101
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 42432
+      GoRuntimeType: 42880
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4172,7 +4172,7 @@ Types:
       ID: 117
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 42240
+      GoRuntimeType: 42400
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4181,7 +4181,7 @@ Types:
       ID: 51
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 48000
+      GoRuntimeType: 48160
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4190,7 +4190,7 @@ Types:
       ID: 103
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 42528
+      GoRuntimeType: 42976
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4199,7 +4199,7 @@ Types:
       ID: 84
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 49728
+      GoRuntimeType: 49888
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4208,7 +4208,7 @@ Types:
       ID: 56
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 47232
+      GoRuntimeType: 47392
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4217,7 +4217,7 @@ Types:
       ID: 78
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 48576
+      GoRuntimeType: 48736
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4226,7 +4226,7 @@ Types:
       ID: 142
       Name: '[8]uint8'
       ByteSize: 8
-      GoRuntimeType: 42624
+      GoRuntimeType: 42496
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4265,7 +4265,7 @@ Types:
       ID: 100
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 34784
+      GoRuntimeType: 34944
       GoKind: 23
       RawFields:
         - Name: array
@@ -4313,7 +4313,7 @@ Types:
       ID: 102
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 35104
+      GoRuntimeType: 35264
       GoKind: 23
       RawFields:
         - Name: array
@@ -4336,7 +4336,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 34400
+      GoRuntimeType: 34560
       GoKind: 23
       RawFields:
         - Name: array
@@ -4359,7 +4359,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 34912
+      GoRuntimeType: 35072
       GoKind: 23
       RawFields:
         - Name: array
@@ -4410,7 +4410,7 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 39392
+      GoRuntimeType: 39552
       GoKind: 1
     - __kind: GoHMapBucketType
       ID: 156
@@ -4511,19 +4511,19 @@ Types:
       ID: 91
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 39200
+      GoRuntimeType: 39360
       GoKind: 16
     - __kind: BaseType
       ID: 90
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 39136
+      GoRuntimeType: 39296
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 18
       Name: error
       ByteSize: 16
-      GoRuntimeType: 60512
+      GoRuntimeType: 60672
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4536,25 +4536,25 @@ Types:
       ID: 16
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 39264
+      GoRuntimeType: 39424
       GoKind: 13
     - __kind: BaseType
       ID: 17
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 39328
+      GoRuntimeType: 39488
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 57
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 33440
+      GoRuntimeType: 33600
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 67
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 52704
+      GoRuntimeType: 52864
       GoKind: 19
     - __kind: GoHMapHeaderType
       ID: 154
@@ -4730,37 +4730,37 @@ Types:
       ID: 9
       Name: int
       ByteSize: 8
-      GoRuntimeType: 38944
+      GoRuntimeType: 39104
       GoKind: 2
     - __kind: BaseType
       ID: 89
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 38560
+      GoRuntimeType: 38720
       GoKind: 4
     - __kind: BaseType
       ID: 13
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 38688
+      GoRuntimeType: 38848
       GoKind: 5
     - __kind: BaseType
       ID: 14
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 38816
+      GoRuntimeType: 38976
       GoKind: 6
     - __kind: BaseType
       ID: 15
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 38432
+      GoRuntimeType: 38592
       GoKind: 3
     - __kind: StructureType
       ID: 82
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 105728
+      GoRuntimeType: 105888
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4782,7 +4782,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 69312
+      GoRuntimeType: 69472
       GoKind: 25
       RawFields:
         - Name: u
@@ -4792,7 +4792,7 @@ Types:
       ID: 65
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 91552
+      GoRuntimeType: 91712
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4808,7 +4808,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 81632
+      GoRuntimeType: 81792
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4821,7 +4821,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 81472
+      GoRuntimeType: 81632
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4834,7 +4834,7 @@ Types:
       ID: 70
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 81792
+      GoRuntimeType: 81952
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4846,27 +4846,27 @@ Types:
     - __kind: StructureType
       ID: 66
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 58944
+      GoRuntimeType: 59104
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 58848
+      GoRuntimeType: 59008
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 161
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 64832
+      GoRuntimeType: 64992
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
       ID: 148
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 112736
+      GoRuntimeType: 113152
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4897,7 +4897,7 @@ Types:
       ID: 116
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 118880
+      GoRuntimeType: 119296
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4943,35 +4943,35 @@ Types:
       ID: 152
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 55872
+      GoRuntimeType: 56128
       GoKind: 21
       HeaderType: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 55968
+      GoRuntimeType: 56032
       GoKind: 21
       HeaderType: 106 GoHMapHeaderType hash<string,int>
     - __kind: GoMapType
       ID: 111
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 56064
+      GoRuntimeType: 56224
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
       ID: 124
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 56160
+      GoRuntimeType: 56320
       GoKind: 21
       HeaderType: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 119
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 56256
+      GoRuntimeType: 56416
       GoKind: 21
       HeaderType: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
@@ -4993,14 +4993,14 @@ Types:
     - __kind: StructureType
       ID: 80
       Name: runtime.dlogPerM
-      GoRuntimeType: 58272
+      GoRuntimeType: 58432
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 432
-      GoRuntimeType: 133152
+      GoRuntimeType: 133568
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5175,7 +5175,7 @@ Types:
       ID: 49
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 67648
+      GoRuntimeType: 67808
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5185,7 +5185,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 110720
+      GoRuntimeType: 111136
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5213,7 +5213,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 79392
+      GoRuntimeType: 79552
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5226,7 +5226,7 @@ Types:
       ID: 54
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 99040
+      GoRuntimeType: 99200
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5245,13 +5245,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 51360
+      GoRuntimeType: 51520
       GoKind: 12
     - __kind: StructureType
       ID: 86
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 79232
+      GoRuntimeType: 79392
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5264,7 +5264,7 @@ Types:
       ID: 74
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 109408
+      GoRuntimeType: 109824
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5289,13 +5289,13 @@ Types:
       ID: 87
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 51264
+      GoRuntimeType: 51424
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1760
-      GoRuntimeType: 136320
+      GoRuntimeType: 136736
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5515,7 +5515,7 @@ Types:
       ID: 64
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 109152
+      GoRuntimeType: 109568
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5540,7 +5540,7 @@ Types:
       ID: 81
       Name: runtime.mOS
       ByteSize: 8
-      GoRuntimeType: 88288
+      GoRuntimeType: 88448
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5556,7 +5556,7 @@ Types:
       ID: 69
       Name: runtime.mTraceState
       ByteSize: 32
-      GoRuntimeType: 88096
+      GoRuntimeType: 88256
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5576,20 +5576,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 50976
+      GoRuntimeType: 51136
       GoKind: 12
     - __kind: StructureType
       ID: 62
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 67264
+      GoRuntimeType: 67424
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 76
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 79072
+      GoRuntimeType: 79232
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5602,7 +5602,7 @@ Types:
       ID: 79
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 99808
+      GoRuntimeType: 99968
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5621,13 +5621,13 @@ Types:
       ID: 58
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 51168
+      GoRuntimeType: 51328
       GoKind: 12
     - __kind: ArrayType
       ID: 55
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 54144
+      GoRuntimeType: 54304
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5636,7 +5636,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 77472
+      GoRuntimeType: 77632
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5653,7 +5653,7 @@ Types:
       ID: 59
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 39648
+      GoRuntimeType: 39808
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5663,7 +5663,7 @@ Types:
       ID: 68
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 39712
+      GoRuntimeType: 39872
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 73
@@ -5673,7 +5673,7 @@ Types:
       ID: 50
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 78432
+      GoRuntimeType: 78592
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5686,19 +5686,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 64480
+      GoRuntimeType: 64640
       GoKind: 8
     - __kind: StructureType
       ID: 75
       Name: runtime.winlibcall
-      GoRuntimeType: 58176
+      GoRuntimeType: 58336
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 10
       Name: string
       ByteSize: 16
-      GoRuntimeType: 38368
+      GoRuntimeType: 38528
       GoKind: 24
       RawFields:
         - Name: str
@@ -5717,43 +5717,43 @@ Types:
       ID: 12
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 39008
+      GoRuntimeType: 39168
       GoKind: 7
     - __kind: BaseType
       ID: 7
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 38624
+      GoRuntimeType: 38784
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 38752
+      GoRuntimeType: 38912
       GoKind: 10
     - __kind: BaseType
       ID: 11
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 38880
+      GoRuntimeType: 39040
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 38496
+      GoRuntimeType: 38656
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 39072
+      GoRuntimeType: 39232
       GoKind: 12
     - __kind: VoidPointerType
       ID: 19
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 39456
+      GoRuntimeType: 39616
       GoKind: 26
 MaxTypeID: 279
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.PointerChainArg]
+          Type: 365 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5494", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 366 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb54cc", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 195 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition:
-            Type: 89 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 199 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 201 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 205 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6648", Frameless: false}]
           Condition:
-            Type: 14 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 191 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6438", Frameless: false}]
           Condition:
-            Type: 15 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 275 EventRootType Probe[main.condLine]Line
+          Type: 279 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 276 EventRootType Probe[main.condLine]Line
+          Type: 280 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condNilPtrStruct]
+          Type: 267 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 268 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condNilPtrStruct]
+          Type: 269 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 270 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condOnly]
+          Type: 275 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condOnly]Return
+          Type: 276 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condOnly]
+          Type: 277 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condOnly]Return
+          Type: 278 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condPtrStructArg]
+          Type: 261 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condPtrStructArg]
+          Type: 263 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 264 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condPtrStructArg]
+          Type: 265 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 266 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condReturnAndLocal]
+          Type: 271 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 272 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condReturnAndLocal]
+          Type: 273 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 274 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 237 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 239 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 241 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 242 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 243 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 244 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condString]
+          Type: 245 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condString]Return
+          Type: 246 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condString]
+          Type: 247 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condString]Return
+          Type: 248 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condStructArg]
+          Type: 249 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condStructArg]Return
+          Type: 250 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condStructArg]
+          Type: 251 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condStructArg]Return
+          Type: 252 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condStructArg]
+          Type: 253 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
-            Type: 17 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condStructArg]Return
+          Type: 254 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condStructArg]
+          Type: 255 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
-            Type: 13 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condStructArg]Return
+          Type: 256 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condStructArg]
+          Type: 257 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
-            Type: 10 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condStructArg]Return
+          Type: 258 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condStructArg]
+          Type: 259 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condStructArg]Return
+          Type: 260 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 215 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb67a8", Frameless: false}]
           Condition:
-            Type: 7 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 219 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6858", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 223 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6908", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 209 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 211 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.inlined]
+          Type: 363 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb52a4"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 348 EventRootType Probe[main.inlined]Return
+          Type: 364 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6210", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenErrInt]
+          Type: 353 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenErrInt]Return
+          Type: 354 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenErrStruct]
+          Type: 357 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenErrStruct]Return
+          Type: 358 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenErrInt]
+          Type: 355 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenErrInt]Return
+          Type: 356 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenErrStruct]
+          Type: 359 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenErrStruct]Return
+          Type: 360 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.lenMap]
+          Type: 311 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 298 EventRootType Probe[main.lenMap]Return
+          Type: 312 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenMap]
+          Type: 315 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenMap]Return
+          Type: 316 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenMap]
+          Type: 317 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenMap]Return
+          Type: 318 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenMap]
+          Type: 319 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenMap]Return
+          Type: 320 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenMap]
+          Type: 321 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb760c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenMap]Return
+          Type: 322 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenPtrString]
+          Type: 323 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb771c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenPtrString]Return
+          Type: 324 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenPtrString]
+          Type: 325 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb771c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenPtrString]Return
+          Type: 326 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenPtrStructFields]
+          Type: 345 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenPtrStructFields]
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 348 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenPtrStructFields]
+          Type: 349 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 350 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb797c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.lenSlice]
+          Type: 299 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 288 EventRootType Probe[main.lenSlice]Return
+          Type: 300 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.lenSlice]
+          Type: 303 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.lenSlice]Return
+          Type: 304 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.lenSlice]
+          Type: 305 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 292 EventRootType Probe[main.lenSlice]Return
+          Type: 306 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.lenSlice]
+          Type: 307 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.lenSlice]Return
+          Type: 308 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.lenSlice]
+          Type: 309 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.lenSlice]Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 281 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 282 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 283 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 284 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 285 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 286 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.lenString]
+          Type: 287 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.lenString]Return
+          Type: 288 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.lenString]
+          Type: 291 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.lenString]Return
+          Type: 292 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.lenString]
+          Type: 293 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.lenString]Return
+          Type: 294 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.lenString]
+          Type: 295 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.lenString]Return
+          Type: 296 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.lenString]
+          Type: 297 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 286 EventRootType Probe[main.lenString]Return
+          Type: 298 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7490", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenStructFields]
+          Type: 327 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenStructFields]
+          Type: 329 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenStructFields]Return
+          Type: 330 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenStructFields]
+          Type: 331 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenStructFields]Return
+          Type: 332 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenStructFields]
+          Type: 333 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenStructFields]Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenStructFields]
+          Type: 335 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenStructFields]Return
+          Type: 336 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenStructFields]
+          Type: 337 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          Type: 338 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenStructFields]
+          Type: 339 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition:
-            Type: 11 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          Type: 340 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenStructFields]
+          Type: 341 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          Type: 342 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenStructFields]
+          Type: 343 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb781c", Frameless: false}]
           Condition:
-            Type: 9 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          Type: 344 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb7930", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 361 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7cf0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7e64", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4055,7 +4267,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4081,7 +4293,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4442,7 +4654,7 @@ Types:
       ID: 194
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 275
+      ID: 279
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4458,7 +4670,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 276
+      ID: 280
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4484,7 +4696,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 267
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4500,7 +4712,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 269
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4526,13 +4738,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 264
+      ID: 268
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 266
+      ID: 270
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 275
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4558,7 +4770,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 277
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4584,45 +4796,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 276
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 278
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 261
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 265
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4648,16 +4860,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 260
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 262
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 264
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 271
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4673,7 +4885,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 269
+      ID: 273
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4699,10 +4911,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 268
+      ID: 272
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 270
+      ID: 274
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4752,6 +4964,48 @@ Types:
     - __kind: EventRootType
       ID: 241
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4776,7 +5030,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 247
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4814,7 +5068,13 @@ Types:
       ID: 244
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 246
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 248
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 249
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4822,38 +5082,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 247
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 249
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -4896,6 +5124,38 @@ Types:
     - __kind: EventRootType
       ID: 255
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 257
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 259
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4920,12 +5180,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 248
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 250
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4936,6 +5190,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 256
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 260
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 215
@@ -5149,7 +5409,7 @@ Types:
       ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5165,7 +5425,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 168
@@ -5225,7 +5485,7 @@ Types:
       ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5251,16 +5511,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5286,16 +5546,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 311
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5311,7 +5571,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 313
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 315
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5330,7 +5615,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 317
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5346,7 +5631,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 319
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5365,7 +5650,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 305
+      ID: 321
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5391,22 +5676,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 312
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 300
+      ID: 314
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 302
+      ID: 316
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 318
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 306
+      ID: 320
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 307
+      ID: 322
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 323
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5425,7 +5713,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 309
+      ID: 325
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5451,13 +5739,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 308
+      ID: 324
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 310
+      ID: 326
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 345
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5483,7 +5771,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5505,7 +5793,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5524,7 +5812,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,19 +5831,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 287
+      ID: 299
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5571,7 +5859,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 301
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5587,7 +5897,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 305
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5603,7 +5913,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 307
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5619,7 +5929,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 309
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5645,22 +5955,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 300
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 290
+      ID: 302
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 304
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 306
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 308
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 277
+      ID: 310
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5676,7 +6055,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 289
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 291
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5692,7 +6093,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 281
+      ID: 293
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5708,7 +6109,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 295
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5724,7 +6125,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 297
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5750,12 +6151,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 282
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5765,7 +6160,25 @@ Types:
       ID: 286
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 288
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 327
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5791,7 +6204,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 329
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5810,7 +6223,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 315
+      ID: 331
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5829,7 +6242,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 333
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5848,7 +6261,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 335
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5864,7 +6277,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 321
+      ID: 337
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5880,7 +6293,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5896,7 +6309,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5912,7 +6325,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5927,32 +6340,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 312
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 314
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 316
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 318
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 320
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 328
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 344
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 185
@@ -6098,10 +6511,10 @@ Types:
       ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7800,7 +8213,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39616
       GoKind: 26
-MaxTypeID: 350
+MaxTypeID: 366
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -7878,7 +8291,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -7908,7 +8321,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -7923,7 +8336,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -7938,7 +8351,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.PointerChainArg]
+          Type: 333 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5494", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 334 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb54cc", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 184 EventRootType Probe[main.bigMapArg]
+          Type: 187 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb6310", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 185 EventRootType Probe[main.bigMapArg]Return
+          Type: 188 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb6384", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 228 EventRootType Probe[main.condBool]
+          Type: 231 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 229 EventRootType Probe[main.condBool]Return
+          Type: 232 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 230 EventRootType Probe[main.condBool]
+          Type: 233 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 231 EventRootType Probe[main.condBool]Return
+          Type: 234 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 232 EventRootType Probe[main.condBool]
+          Type: 235 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6b18", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 233 EventRootType Probe[main.condBool]Return
+          Type: 236 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6b80", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 224 EventRootType Probe[main.condFloat32]
+          Type: 227 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0xb69b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 225 EventRootType Probe[main.condFloat32]Return
+          Type: 228 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0xb6a20", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 226 EventRootType Probe[main.condFloat64]
+          Type: 229 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0xb6a68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 227 EventRootType Probe[main.condFloat64]Return
+          Type: 230 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0xb6ad0", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.condInt16]
+          Type: 195 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition:
             Type: 89 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 193 EventRootType Probe[main.condInt16]Return
+          Type: 196 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb6548", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.condInt16]
+          Type: 197 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.condInt16]Return
+          Type: 198 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb6548", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.condInt32]
+          Type: 199 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 197 EventRootType Probe[main.condInt32]Return
+          Type: 200 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.condInt32]
+          Type: 201 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 199 EventRootType Probe[main.condInt32]Return
+          Type: 202 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 200 EventRootType Probe[main.condInt32]
+          Type: 203 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb6598", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 201 EventRootType Probe[main.condInt32]Return
+          Type: 204 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb65f8", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 202 EventRootType Probe[main.condInt64]
+          Type: 205 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6648", Frameless: false}]
           Condition:
             Type: 14 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 203 EventRootType Probe[main.condInt64]Return
+          Type: 206 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb66a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.condInt64]
+          Type: 207 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6648", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.condInt64]Return
+          Type: 208 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb66a8", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 188 EventRootType Probe[main.condInt8]
+          Type: 191 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6438", Frameless: false}]
           Condition:
             Type: 15 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 189 EventRootType Probe[main.condInt8]Return
+          Type: 192 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb64a0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 190 EventRootType Probe[main.condInt8]
+          Type: 193 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6438", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 191 EventRootType Probe[main.condInt8]Return
+          Type: 194 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb64a0", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 272 EventRootType Probe[main.condLine]Line
+          Type: 275 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 273 EventRootType Probe[main.condLine]Line
+          Type: 276 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb70f4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condNilPtrStruct]
+          Type: 263 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 264 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condNilPtrStruct]
+          Type: 265 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ed8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 266 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6f4c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condOnly]
+          Type: 271 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condOnly]Return
+          Type: 272 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condOnly]
+          Type: 273 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb7038", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condOnly]Return
+          Type: 274 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb7098", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 254 EventRootType Probe[main.condPtrStructArg]
+          Type: 257 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 255 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 258 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 256 EventRootType Probe[main.condPtrStructArg]
+          Type: 259 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 257 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 260 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condPtrStructArg]
+          Type: 261 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 262 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6e90", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condReturnAndLocal]
+          Type: 267 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition:
             Type: 9 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 268 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condReturnAndLocal]
+          Type: 269 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 270 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6ff8", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 234 EventRootType Probe[main.condString]
+          Type: 237 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 235 EventRootType Probe[main.condString]Return
+          Type: 238 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 236 EventRootType Probe[main.condString]
+          Type: 239 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 237 EventRootType Probe[main.condString]Return
+          Type: 240 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 238 EventRootType Probe[main.condString]
+          Type: 241 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 239 EventRootType Probe[main.condString]Return
+          Type: 242 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 240 EventRootType Probe[main.condString]
+          Type: 243 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb6bc8", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 241 EventRootType Probe[main.condString]Return
+          Type: 244 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6c2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 242 EventRootType Probe[main.condStructArg]
+          Type: 245 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 243 EventRootType Probe[main.condStructArg]Return
+          Type: 246 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 244 EventRootType Probe[main.condStructArg]
+          Type: 247 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 245 EventRootType Probe[main.condStructArg]Return
+          Type: 248 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 246 EventRootType Probe[main.condStructArg]
+          Type: 249 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 17 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 247 EventRootType Probe[main.condStructArg]Return
+          Type: 250 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 248 EventRootType Probe[main.condStructArg]
+          Type: 251 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 13 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 249 EventRootType Probe[main.condStructArg]Return
+          Type: 252 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 250 EventRootType Probe[main.condStructArg]
+          Type: 253 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition:
             Type: 10 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 251 EventRootType Probe[main.condStructArg]Return
+          Type: 254 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 252 EventRootType Probe[main.condStructArg]
+          Type: 255 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6c8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 253 EventRootType Probe[main.condStructArg]Return
+          Type: 256 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6d60", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 212 EventRootType Probe[main.condUint16]
+          Type: 215 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb67a8", Frameless: false}]
           Condition:
             Type: 7 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 213 EventRootType Probe[main.condUint16]Return
+          Type: 216 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb6808", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 214 EventRootType Probe[main.condUint16]
+          Type: 217 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb67a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 215 EventRootType Probe[main.condUint16]Return
+          Type: 218 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb6808", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 216 EventRootType Probe[main.condUint32]
+          Type: 219 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6858", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 217 EventRootType Probe[main.condUint32]Return
+          Type: 220 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 218 EventRootType Probe[main.condUint32]
+          Type: 221 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6858", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 219 EventRootType Probe[main.condUint32]Return
+          Type: 222 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 220 EventRootType Probe[main.condUint64]
+          Type: 223 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6908", Frameless: false}]
           Condition:
             Type: 11 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 221 EventRootType Probe[main.condUint64]Return
+          Type: 224 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb6968", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 222 EventRootType Probe[main.condUint64]
+          Type: 225 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6908", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 223 EventRootType Probe[main.condUint64]Return
+          Type: 226 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb6968", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.condUint8]
+          Type: 209 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 207 EventRootType Probe[main.condUint8]Return
+          Type: 210 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.condUint8]
+          Type: 211 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 209 EventRootType Probe[main.condUint8]Return
+          Type: 212 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 210 EventRootType Probe[main.condUint8]
+          Type: 213 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb66f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 211 EventRootType Probe[main.condUint8]Return
+          Type: 214 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6760", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.inlined]
+          Type: 331 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb52a4"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 277 EventRootType Probe[main.inlined]Return
+          Type: 332 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6210", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 165 EventRootType Probe[main.intArg]
+          Type: 168 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5eb8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 166 EventRootType Probe[main.intArg]Return
+          Type: 169 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5ef0", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 175 EventRootType Probe[main.intArrayArg]
+          Type: 178 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb6038", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 176 EventRootType Probe[main.intArrayArg]Return
+          Type: 179 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb607c", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 181 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 184 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb61b0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 173 EventRootType Probe[main.intSliceArg]
+          Type: 176 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5fa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 174 EventRootType Probe[main.intSliceArg]Return
+          Type: 177 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5fe4", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xb7acc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xb7b80", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 327 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xb7bcc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 328 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xb7c9c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 291 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 292 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 293 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb760c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 294 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb76cc", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 295 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb771c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 296 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 297 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb771c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 298 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb77c4", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb797c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 315 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb797c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 316 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 317 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb797c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 318 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb797c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb7a74", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 287 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 288 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 289 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb74ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 290 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb75ac", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 277 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 278 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 279 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 280 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 281 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 282 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 283 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 284 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 285 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb73dc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 286 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7490", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb781c", Frameless: false}]
+          Condition:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb7930", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 167 EventRootType Probe[main.stringArg]
+          Type: 170 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 168 EventRootType Probe[main.stringArg]Return
+          Type: 171 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 169 EventRootType Probe[main.stringArg]
+          Type: 172 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 170 EventRootType Probe[main.stringArg]Return
+          Type: 173 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 182 EventRootType Probe[main.mapArg]
+          Type: 185 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 183 EventRootType Probe[main.mapArg]Return
+          Type: 186 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb62c8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 186 EventRootType Probe[main.noArgs]
+          Type: 189 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb63c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 187 EventRootType Probe[main.noArgs]Return
+          Type: 190 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb6400", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 171 EventRootType Probe[main.stringArg]
+          Type: 174 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 172 EventRootType Probe[main.stringArg]Return
+          Type: 175 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 179 EventRootType Probe[main.stringArrayArg]
+          Type: 182 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb6148", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 180 EventRootType Probe[main.stringArrayArg]Return
+          Type: 183 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb618c", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 177 EventRootType Probe[main.stringSliceArg]
+          Type: 180 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb60b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 178 EventRootType Probe[main.stringSliceArg]Return
+          Type: 181 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb60f4", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 329 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7cf0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 275 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 330 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7e64", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2412,12 +3079,316 @@ Subprograms:
                   Op: {CfaOffset: 96}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0xb73c0..0xb74d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb73c0..0xb7428
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb7428..0xb742c
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb742c..0xb74d0
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb73c0..0xb7430
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xb7430..0xb7434
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xb7434..0xb74d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0xb74d0..0xb75f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 100 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb74d0..0xb7544
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7544..0xb7548
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7548..0xb754c
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: null
+            - Range: 0xb754c..0xb75f0
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb74d0..0xb7550
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb7550..0xb75f0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0xb75f0..0xb7700]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 104 GoMapType map[string]int
+          Locations:
+            - Range: 0xb75f0..0xb7650
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7650..0xb7700
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb75f0..0xb7654
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7654..0xb7658
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb7658..0xb7700
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0xb7700..0xb7800]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 88 PointerType *string
+          Locations:
+            - Range: 0xb7700..0xb7760
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7760..0xb7800
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7700..0xb7764
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7764..0xb7768
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb7768..0xb7800
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xb7800..0xb7960]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 StructureType main.lenFields
+          Locations:
+            - Range: 0xb7800..0xb7960
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7800..0xb788c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb788c..0xb7890
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xb7890..0xb7960
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xb7960..0xb7ab0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 PointerType *main.lenFields
+          Locations:
+            - Range: 0xb7960..0xb79c0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb79c0..0xb7ab0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7960..0xb79c4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb79c4..0xb79c8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb79c8..0xb7ab0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xb7ab0..0xb7bb0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 9 BaseType int
+          Locations:
+            - Range: 0xb7ab0..0xb7b18
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7b18..0xb7bb0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7ab0..0xb7b1c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7b1c..0xb7b20
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb7b20..0xb7bb0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0xb7bb0..0xb7cd0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 116 StructureType main.condFields
+          Locations:
+            - Range: 0xb7bb0..0xb7cd0
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 10 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7bb0..0xb7c30
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb7c30..0xb7c34
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xb7c34..0xb7cd0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0xb7cd0..0xb7e80]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0xb7cd0..0xb7e64
               Pieces: []
@@ -2427,10 +3398,10 @@ Subprograms:
               Pieces: []
           Role: Return
         - Name: m
-          Type: 124 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
+          Type: 127 GoMapType map[string]map[int]main.aStructNotUsedAsAnArgument
           Locations: [{Range: 0xb7cd0..0xb7e80, Pieces: []}]
           Role: Local
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0xb61c0..0xb6230]
       InlinePCRanges:
@@ -2445,7 +3416,7 @@ Subprograms:
             - Range: 0xb61c0..0xb61e0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2453,12 +3424,12 @@ Subprograms:
           RootRanges: [0xb5100..0xb5ea0]
       Variables:
         - Name: ptr
-          Type: 129 PointerType *****int
+          Type: 132 PointerType *****int
           Locations:
             - Range: 0xb546c..0xb54b4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2466,45 +3437,52 @@ Subprograms:
           RootRanges: [0xb5100..0xb5ea0]
       Variables:
         - Name: ptr
-          Type: 131 PointerType **int
+          Type: 134 PointerType **int
           Locations:
             - Range: 0xb54cc..0xb54fc
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 33280
       GoKind: 22
-      Pointee: 130 PointerType ****int
+      Pointee: 133 PointerType ****int
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 33216
       GoKind: 22
-      Pointee: 164 PointerType ***int
+      Pointee: 167 PointerType ***int
     - __kind: PointerType
-      ID: 164
+      ID: 167
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 33152
       GoKind: 22
-      Pointee: 131 PointerType **int
+      Pointee: 134 PointerType **int
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 33088
       GoKind: 22
       Pointee: 94 PointerType *int
     - __kind: PointerType
-      ID: 139
+      ID: 120
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 33024
+      GoKind: 22
+      Pointee: 100 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 142
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 138 GoSliceDataType []int.array
+      Pointee: 141 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2513,20 +3491,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 141
+      ID: 144
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 140 GoSliceDataType []string.array
+      Pointee: 143 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uint8.array
+      Pointee: 137 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []uintptr.array
+      Pointee: 139 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 5
       Name: '*bool'
@@ -2535,10 +3513,10 @@ Types:
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*bucket<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 107
       Name: '*bucket<string,int>'
@@ -2550,15 +3528,15 @@ Types:
       ByteSize: 8
       Pointee: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*bucket<string,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 122
+      ID: 125
       Name: '*bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 96
       Name: '*error'
@@ -2581,10 +3559,10 @@ Types:
       GoKind: 22
       Pointee: 17 BaseType float64
     - __kind: PointerType
-      ID: 153
+      ID: 156
       Name: '*hash<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 157 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*hash<string,int>'
@@ -2596,15 +3574,15 @@ Types:
       ByteSize: 8
       Pointee: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*hash<string,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 120
+      ID: 123
       Name: '*hash<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 94
       Name: '*int'
@@ -2627,12 +3605,12 @@ Types:
       GoKind: 22
       Pointee: 14 BaseType int64
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 24960
       GoKind: 22
-      Pointee: 148 StructureType main.bigStruct
+      Pointee: 151 StructureType main.bigStruct
     - __kind: PointerType
       ID: 118
       Name: '*main.condFields'
@@ -2640,6 +3618,13 @@ Types:
       GoRuntimeType: 24768
       GoKind: 22
       Pointee: 116 StructureType main.condFields
+    - __kind: PointerType
+      ID: 121
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 24832
+      GoKind: 22
+      Pointee: 119 StructureType main.lenFields
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2718,10 +3703,10 @@ Types:
       GoKind: 22
       Pointee: 10 GoStringHeaderType string
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 135 GoStringDataType string.str
     - __kind: PointerType
       ID: 98
       Name: '*uint'
@@ -2765,7 +3750,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 278
+      ID: 333
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2774,24 +3759,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 279
+      ID: 334
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2800,14 +3785,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 131 PointerType **int
+            Type: 134 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 184
+      ID: 187
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2833,10 +3818,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 185
+      ID: 188
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2852,7 +3837,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2868,7 +3853,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2894,16 +3879,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 224
+      ID: 227
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2919,10 +3904,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2938,10 +3923,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2957,7 +3942,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -2983,13 +3968,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 193
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 195
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 196
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 198
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 199
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3005,7 +3990,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3021,7 +4006,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3047,16 +4032,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 197
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 199
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 201
+      ID: 200
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 202
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 204
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 205
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3072,7 +4057,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3098,13 +4083,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3120,7 +4105,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3146,13 +4131,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3168,7 +4153,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3194,7 +4179,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3210,7 +4195,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 262
+      ID: 265
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3236,71 +4221,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 270
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 269
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 271
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 273
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 272
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 254
+      ID: 274
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 257
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3316,7 +4301,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3332,7 +4317,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3358,16 +4343,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 257
+      ID: 260
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 259
+      ID: 262
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 264
+      ID: 267
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3383,7 +4368,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3409,10 +4394,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3428,7 +4413,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3444,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3452,6 +4437,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 241
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 243
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -3461,70 +4498,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 238
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 240
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 10 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 241
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 242
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 245
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3540,7 +4525,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3556,7 +4541,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3572,7 +4557,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3588,7 +4573,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3604,7 +4589,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3630,25 +4615,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3664,7 +4649,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3690,13 +4675,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 213
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 216
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 218
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 219
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3712,7 +4697,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 218
+      ID: 221
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3738,13 +4723,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 219
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 220
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 222
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 223
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3760,7 +4745,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3786,13 +4771,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 223
+      ID: 226
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3808,7 +4793,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3824,7 +4809,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3850,16 +4835,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 331
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3871,14 +4856,14 @@ Types:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 277
+      ID: 332
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 165
+      ID: 168
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3894,10 +4879,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 166
+      ID: 169
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 175
+      ID: 178
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3913,10 +4898,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 176
+      ID: 179
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 173
+      ID: 176
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3932,10 +4917,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 174
+      ID: 177
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 321
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 291
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 104 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 88 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 287
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 289
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 100 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 277
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 278
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 282
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 119 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 10 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 185
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3961,16 +5470,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 186
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 186
+      ID: 189
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 167
+      ID: 170
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3986,10 +5495,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 169
+      ID: 172
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 171
+      ID: 174
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4015,16 +5524,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 168
+      ID: 171
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 170
+      ID: 173
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 172
+      ID: 175
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 181
+      ID: 184
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4040,7 +5549,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 179
+      ID: 182
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4056,10 +5565,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 180
+      ID: 183
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 177
+      ID: 180
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4075,13 +5584,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 178
+      ID: 181
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 329
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 275
+      ID: 330
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4090,10 +5599,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 119 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4106,7 +5615,7 @@ Types:
       HasCount: true
       Element: 86 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 163
+      ID: 166
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 43168
@@ -4223,7 +5732,7 @@ Types:
       HasCount: true
       Element: 79 StructureType runtime.pcvalueCacheEnt
     - __kind: ArrayType
-      ID: 142
+      ID: 145
       Name: '[8]uint8'
       ByteSize: 8
       GoRuntimeType: 42496
@@ -4232,35 +5741,35 @@ Types:
       HasCount: true
       Element: 3 BaseType uint8
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 165
       Name: '[]bucket<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 144
-      Element: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      Element: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 145
+      ID: 148
       Name: '[]bucket<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 108 GoHMapBucketType bucket<string,int>
     - __kind: GoSliceDataType
-      ID: 149
+      ID: 152
       Name: '[]bucket<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
       Element: 115 GoHMapBucketType bucket<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 158
+      ID: 161
       Name: '[]bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 208
-      Element: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 88
-      Element: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 100
       Name: '[]int'
@@ -4277,29 +5786,29 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 138 GoSliceDataType []int.array
+      Data: 141 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 141
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 159
+      ID: 162
       Name: '[]key<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 143
+      ID: 146
       Name: '[]key<string>'
       ByteSize: 128
       Count: 8
       HasCount: true
       Element: 10 GoStringHeaderType string
     - __kind: ArrayType
-      ID: 150
+      ID: 153
       Name: '[]key<uint8>'
       ByteSize: 8
       Count: 8
@@ -4325,9 +5834,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 140 GoSliceDataType []string.array
+      Data: 143 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 140
+      ID: 143
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4348,9 +5857,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 134 GoSliceDataType []uint8.array
+      Data: 137 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4371,41 +5880,41 @@ Types:
         - Name: cap
           Offset: 16
           Type: 9 BaseType int
-      Data: 136 GoSliceDataType []uintptr.array
+      Data: 139 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 1 BaseType uintptr
     - __kind: ArrayType
-      ID: 144
+      ID: 147
       Name: '[]val<int>'
       ByteSize: 64
       Count: 8
       HasCount: true
       Element: 9 BaseType int
     - __kind: ArrayType
-      ID: 160
+      ID: 163
       Name: '[]val<main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 161 StructureType main.aStructNotUsedAsAnArgument
+      Element: 164 StructureType main.aStructNotUsedAsAnArgument
     - __kind: ArrayType
-      ID: 146
+      ID: 149
       Name: '[]val<main.bigStruct>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 147 PointerType *main.bigStruct
+      Element: 150 PointerType *main.bigStruct
     - __kind: ArrayType
-      ID: 151
+      ID: 154
       Name: '[]val<map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 64
       Count: 8
       HasCount: true
-      Element: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      Element: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 4
       Name: bool
@@ -4413,24 +5922,24 @@ Types:
       GoRuntimeType: 39552
       GoKind: 1
     - __kind: GoHMapBucketType
-      ID: 156
+      ID: 159
       Name: bucket<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 144
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 159 ArrayType []key<int>
+          Type: 162 ArrayType []key<int>
         - Name: values
           Offset: 72
-          Type: 160 ArrayType []val<main.aStructNotUsedAsAnArgument>
+          Type: 163 ArrayType []val<main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 136
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
       KeyType: 9 BaseType int
-      ValueType: 161 StructureType main.aStructNotUsedAsAnArgument
+      ValueType: 164 StructureType main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
       ID: 108
       Name: bucket<string,int>
@@ -4438,13 +5947,13 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 144 ArrayType []val<int>
+          Type: 147 ArrayType []val<int>
         - Name: overflow
           Offset: 200
           Type: 107 PointerType *bucket<string,int>
@@ -4457,56 +5966,56 @@ Types:
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 146 ArrayType []val<main.bigStruct>
+          Type: 149 ArrayType []val<main.bigStruct>
         - Name: overflow
           Offset: 200
           Type: 114 PointerType *bucket<string,main.bigStruct>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 147 PointerType *main.bigStruct
+      ValueType: 150 PointerType *main.bigStruct
     - __kind: GoHMapBucketType
-      ID: 128
+      ID: 131
       Name: bucket<string,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 208
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 143 ArrayType []key<string>
+          Type: 146 ArrayType []key<string>
         - Name: values
           Offset: 136
-          Type: 151 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 154 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 200
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 10 GoStringHeaderType string
-      ValueType: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoHMapBucketType
-      ID: 123
+      ID: 126
       Name: bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 88
       RawFields:
         - Name: tophash
           Offset: 0
-          Type: 142 ArrayType [8]uint8
+          Type: 145 ArrayType [8]uint8
         - Name: keys
           Offset: 8
-          Type: 150 ArrayType []key<uint8>
+          Type: 153 ArrayType []key<uint8>
         - Name: values
           Offset: 16
-          Type: 151 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
+          Type: 154 ArrayType []val<map[int]main.aStructNotUsedAsAnArgument>
         - Name: overflow
           Offset: 80
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
       KeyType: 3 BaseType uint8
-      ValueType: 152 GoMapType map[int]main.aStructNotUsedAsAnArgument
+      ValueType: 155 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: BaseType
       ID: 91
       Name: complex128
@@ -4557,7 +6066,7 @@ Types:
       GoRuntimeType: 52864
       GoKind: 19
     - __kind: GoHMapHeaderType
-      ID: 154
+      ID: 157
       Name: hash<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4578,18 +6087,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 155 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
+          Type: 158 PointerType *bucket<int,main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 156 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
-      BucketsType: 162 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
+      BucketType: 159 GoHMapBucketType bucket<int,main.aStructNotUsedAsAnArgument>
+      BucketsType: 165 GoSliceDataType []bucket<int,main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
       ID: 106
       Name: hash<string,int>
@@ -4623,7 +6132,7 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 108 GoHMapBucketType bucket<string,int>
-      BucketsType: 145 GoSliceDataType []bucket<string,int>.array
+      BucketsType: 148 GoSliceDataType []bucket<string,int>.array
     - __kind: GoHMapHeaderType
       ID: 113
       Name: hash<string,main.bigStruct>
@@ -4657,9 +6166,9 @@ Types:
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
       BucketType: 115 GoHMapBucketType bucket<string,main.bigStruct>
-      BucketsType: 149 GoSliceDataType []bucket<string,main.bigStruct>.array
+      BucketsType: 152 GoSliceDataType []bucket<string,main.bigStruct>.array
     - __kind: GoHMapHeaderType
-      ID: 126
+      ID: 129
       Name: hash<string,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4680,20 +6189,20 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 127 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType *bucket<string,map[int]main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 128 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 158 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketType: 131 GoHMapBucketType bucket<string,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 161 GoSliceDataType []bucket<string,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: GoHMapHeaderType
-      ID: 121
+      ID: 124
       Name: hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       RawFields:
@@ -4714,18 +6223,18 @@ Types:
           Type: 2 BaseType uint32
         - Name: buckets
           Offset: 16
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: oldbuckets
           Offset: 24
-          Type: 122 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 125 PointerType *bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: nevacuate
           Offset: 32
           Type: 1 BaseType uintptr
         - Name: extra
           Offset: 40
           Type: 109 PointerType *runtime.mapextra
-      BucketType: 123 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
-      BucketsType: 157 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      BucketType: 126 GoHMapBucketType bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      BucketsType: 160 GoSliceDataType []bucket<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
     - __kind: BaseType
       ID: 9
       Name: int
@@ -4856,14 +6365,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 64992
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 9 BaseType int}]
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 113152
@@ -4892,7 +6401,7 @@ Types:
           Type: 9 BaseType int
         - Name: data
           Offset: 56
-          Type: 163 ArrayType [128]uint8
+          Type: 166 ArrayType [128]uint8
     - __kind: StructureType
       ID: 116
       Name: main.condFields
@@ -4939,13 +6448,38 @@ Types:
         - Name: arr
           Offset: 72
           Type: 117 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 119
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 107776
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 10 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 100 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 104 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 88 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 120 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 117 ArrayType [3]int16
     - __kind: GoMapType
-      ID: 152
+      ID: 155
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56128
       GoKind: 21
-      HeaderType: 154 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 157 GoHMapHeaderType hash<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 104
       Name: map[string]int
@@ -4961,19 +6495,19 @@ Types:
       GoKind: 21
       HeaderType: 113 GoHMapHeaderType hash<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 124
+      ID: 127
       Name: map[string]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56320
       GoKind: 21
-      HeaderType: 126 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 129 GoHMapHeaderType hash<string,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
-      ID: 119
+      ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 56416
       GoKind: 21
-      HeaderType: 121 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 124 GoHMapHeaderType hash<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5703,13 +7237,13 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 136 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 9 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 135 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 132
+      ID: 135
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
@@ -5755,7 +7289,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 39616
       GoKind: 26
-MaxTypeID: 279
+MaxTypeID: 334
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -5986,6 +7520,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 295 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb5310", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5314", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'ptr: {ptr}'
@@ -34,7 +34,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 296 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb5348", Frameless: false}]
+          InjectionPoints: [{PC: "0xb534c", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 201 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb5cc0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6170", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 202 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0xb5d34", Frameless: false}]
+          InjectionPoints: [{PC: "0xb61e4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 245 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6468", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 246 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb64d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 247 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6468", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 248 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb64d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 249 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb6468", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 250 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb64d0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 241 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0xb6308", Frameless: false}]
+          InjectionPoints: [{PC: "0xb67b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 242 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0xb636c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb681c", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 243 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0xb63b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6868", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 244 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0xb641c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb68cc", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 209 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb5e98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6348", Frameless: false}]
           Condition:
             Type: 94 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 210 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb5ef8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 211 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb5e98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6348", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 212 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb5ef8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 213 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb5f38", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 214 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb5f98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 215 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb5f38", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 216 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb5f98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 217 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb5f38", Frameless: false}]
+          InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 218 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb5f98", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 219 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb5fd8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6488", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 220 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb6038", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 221 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb5fd8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6488", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 222 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb6038", Frameless: false}]
+          InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 205 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb5de8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition:
             Type: 16 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 206 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb5e50", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6300", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 207 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb5de8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 208 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb5e50", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6300", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 289 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb6a08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 290 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb6a08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 277 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb67f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 278 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb686c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 279 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb67f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 280 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb686c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 285 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb6958", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 286 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb69b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 287 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb6958", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 288 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb69b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 271 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb66dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 272 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb67b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 273 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb66dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 274 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb67b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 275 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb66dc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 276 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb67b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 281 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 282 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb6918", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 283 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb68b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 284 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb6918", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 251 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6518", Frameless: false}]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 252 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb657c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 253 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6518", Frameless: false}]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 254 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb657c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 255 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6518", Frameless: false}]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 256 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb657c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 257 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb6518", Frameless: false}]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 258 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb657c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 259 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 260 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 261 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 262 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 263 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 18 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 264 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 265 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 266 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 267 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 268 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 269 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb65cc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 270 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb6698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 229 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb6128", Frameless: false}]
+          InjectionPoints: [{PC: "0xb65d8", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 230 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb6188", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6638", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 231 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb6128", Frameless: false}]
+          InjectionPoints: [{PC: "0xb65d8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 232 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb6188", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6638", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 233 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb61c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6678", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 234 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb6228", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66d8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 235 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb61c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6678", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 236 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb6228", Frameless: false}]
+          InjectionPoints: [{PC: "0xb66d8", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 237 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb6268", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 238 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb62c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6778", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 239 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb6268", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6718", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 240 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb62c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6778", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 223 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6078", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 224 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb60e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 225 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6078", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 226 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb60e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 227 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb6078", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 228 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb60e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0xb5130"
               Frameless: false
-            - PC: "0xb5b88"
+            - PC: "0xb6038"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 294 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0xb5bc0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6070", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 182 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb5888", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5d38", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 183 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0xb58c0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5d70", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb59f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5ea8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 193 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0xb5a3c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5eec", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb5b60", Frameless: true}]
+          InjectionPoints: [{PC: "0xb6010", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 190 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb5978", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5e28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 191 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0xb59b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5e64", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 184 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb58f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 185 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5934", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 186 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb58f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 187 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5934", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 199 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb5c48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb60f8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 200 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0xb5c78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6128", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 203 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb5d78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6228", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 204 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0xb5db0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb6260", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 188 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb58f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 189 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb5934", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb5af8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5fa8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 197 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0xb5b3c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5fec", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb5a78", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb5ab4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 291 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb6cd0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7a40", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 292 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0xb6e50", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7bc0", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb5870..0xb58e0]
+      OutOfLinePCRanges: [0xb5d20..0xb5d90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb5870..0xb5890
+            - Range: 0xb5d20..0xb5d40
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb58e0..0xb5960]
+      OutOfLinePCRanges: [0xb5d90..0xb5e10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb58e0..0xb5904
+            - Range: 0xb5d90..0xb5db4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb5960..0xb59e0]
+      OutOfLinePCRanges: [0xb5e10..0xb5e90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb5960..0xb5984
+            - Range: 0xb5e10..0xb5e34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb59e0..0xb5a60]
+      OutOfLinePCRanges: [0xb5e90..0xb5f10]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 106 ArrayType [3]int
           Locations:
-            - Range: 0xb59e0..0xb5a60
+            - Range: 0xb5e90..0xb5f10
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb5a60..0xb5ae0]
+      OutOfLinePCRanges: [0xb5f10..0xb5f90]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb5a60..0xb5a84
+            - Range: 0xb5f10..0xb5f34
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb5ae0..0xb5b60]
+      OutOfLinePCRanges: [0xb5f90..0xb6010]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb5ae0..0xb5b60
+            - Range: 0xb5f90..0xb6010
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb5b60..0xb5b70]
+      OutOfLinePCRanges: [0xb6010..0xb6020]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]string
           Locations:
-            - Range: 0xb5b60..0xb5b70
+            - Range: 0xb6010..0xb6020
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb5c30..0xb5ca0]
+      OutOfLinePCRanges: [0xb60e0..0xb6150]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb5c30..0xb5c68
+            - Range: 0xb60e0..0xb6118
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb5ca0..0xb5d60]
+      OutOfLinePCRanges: [0xb6150..0xb6210]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 114 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb5ca0..0xb5cd8
+            - Range: 0xb6150..0xb6188
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb5cd8..0xb5d60
+            - Range: 0xb6188..0xb6210
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb5d60..0xb5dd0]
+      OutOfLinePCRanges: [0xb6210..0xb6280]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xb5dd0..0xb5e80]
+      OutOfLinePCRanges: [0xb6280..0xb6330]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType int8
           Locations:
-            - Range: 0xb5dd0..0xb5e18
+            - Range: 0xb6280..0xb62c8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb5dd0..0xb5e1c
+            - Range: 0xb6280..0xb62cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb5e1c..0xb5e20
+            - Range: 0xb62cc..0xb62d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xb5e80..0xb5f20]
+      OutOfLinePCRanges: [0xb6330..0xb63d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 94 BaseType int16
           Locations:
-            - Range: 0xb5e80..0xb5eac
+            - Range: 0xb6330..0xb635c
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb5e80..0xb5eac
+            - Range: 0xb6330..0xb635c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb5eac..0xb5f20
+            - Range: 0xb635c..0xb63d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xb5f20..0xb5fc0]
+      OutOfLinePCRanges: [0xb63d0..0xb6470]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xb5f20..0xb5f4c
+            - Range: 0xb63d0..0xb63fc
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb5f20..0xb5f4c
+            - Range: 0xb63d0..0xb63fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb5f4c..0xb5fc0
+            - Range: 0xb63fc..0xb6470
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xb5fc0..0xb6060]
+      OutOfLinePCRanges: [0xb6470..0xb6510]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xb5fc0..0xb5fec
+            - Range: 0xb6470..0xb649c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb5fc0..0xb5fec
+            - Range: 0xb6470..0xb649c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb5fec..0xb6060
+            - Range: 0xb649c..0xb6510
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xb6060..0xb6110]
+      OutOfLinePCRanges: [0xb6510..0xb65c0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xb6060..0xb60a8
+            - Range: 0xb6510..0xb6558
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6060..0xb60ac
+            - Range: 0xb6510..0xb655c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb60ac..0xb60b0
+            - Range: 0xb655c..0xb6560
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xb6110..0xb61b0]
+      OutOfLinePCRanges: [0xb65c0..0xb6660]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xb6110..0xb613c
+            - Range: 0xb65c0..0xb65ec
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6110..0xb613c
+            - Range: 0xb65c0..0xb65ec
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb613c..0xb61b0
+            - Range: 0xb65ec..0xb6660
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xb61b0..0xb6250]
+      OutOfLinePCRanges: [0xb6660..0xb6700]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xb61b0..0xb61dc
+            - Range: 0xb6660..0xb668c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb61b0..0xb61dc
+            - Range: 0xb6660..0xb668c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb61dc..0xb6250
+            - Range: 0xb668c..0xb6700
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xb6250..0xb62f0]
+      OutOfLinePCRanges: [0xb6700..0xb67a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xb6250..0xb627c
+            - Range: 0xb6700..0xb672c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6250..0xb627c
+            - Range: 0xb6700..0xb672c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb627c..0xb62f0
+            - Range: 0xb672c..0xb67a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xb62f0..0xb63a0]
+      OutOfLinePCRanges: [0xb67a0..0xb6850]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xb62f0..0xb6320
+            - Range: 0xb67a0..0xb67d0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb62f0..0xb631c
+            - Range: 0xb67a0..0xb67cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb631c..0xb6320
+            - Range: 0xb67cc..0xb67d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb6320..0xb63a0
+            - Range: 0xb67d0..0xb6850
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xb63a0..0xb6450]
+      OutOfLinePCRanges: [0xb6850..0xb6900]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float64
           Locations:
-            - Range: 0xb63a0..0xb63d0
+            - Range: 0xb6850..0xb6880
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb63a0..0xb63cc
+            - Range: 0xb6850..0xb687c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb63cc..0xb63d0
+            - Range: 0xb687c..0xb6880
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb63d0..0xb6450
+            - Range: 0xb6880..0xb6900
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xb6450..0xb6500]
+      OutOfLinePCRanges: [0xb6900..0xb69b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xb6450..0xb6498
+            - Range: 0xb6900..0xb6948
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6450..0xb649c
+            - Range: 0xb6900..0xb694c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb649c..0xb64a0
+            - Range: 0xb694c..0xb6950
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xb6500..0xb65b0]
+      OutOfLinePCRanges: [0xb69b0..0xb6a60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6500..0xb6530
+            - Range: 0xb69b0..0xb69e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6500..0xb6530
+            - Range: 0xb69b0..0xb69e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb6530..0xb65b0
+            - Range: 0xb69e0..0xb6a60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xb65b0..0xb66c0]
+      OutOfLinePCRanges: [0xb6a60..0xb6b70]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0xb65b0..0xb66c0
+            - Range: 0xb6a60..0xb6b70
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb65b0..0xb65f0
+            - Range: 0xb6a60..0xb6aa0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb65f0..0xb65f4
+            - Range: 0xb6aa0..0xb6aa4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb65f4..0xb66c0
+            - Range: 0xb6aa4..0xb6b70
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xb66c0..0xb67e0]
+      OutOfLinePCRanges: [0xb6b70..0xb6c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0xb66c0..0xb6704
+            - Range: 0xb6b70..0xb6bb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6704..0xb67e0
+            - Range: 0xb6bb4..0xb6c90
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb66c0..0xb6708
+            - Range: 0xb6b70..0xb6bb8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6708..0xb67e0
+            - Range: 0xb6bb8..0xb6c90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xb67e0..0xb68a0]
+      OutOfLinePCRanges: [0xb6c90..0xb6d50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 PointerType *main.condFields
           Locations:
-            - Range: 0xb67e0..0xb6834
+            - Range: 0xb6c90..0xb6ce4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb67e0..0xb6838
+            - Range: 0xb6c90..0xb6ce8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6838..0xb683c
+            - Range: 0xb6ce8..0xb6cec
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xb68a0..0xb6940]
+      OutOfLinePCRanges: [0xb6d50..0xb6df0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb68a0..0xb68bc
+            - Range: 0xb6d50..0xb6d6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb68a0..0xb68d0
+            - Range: 0xb6d50..0xb6d80
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb68a0..0xb6918
+            - Range: 0xb6d50..0xb6dc8
               Pieces: []
-            - Range: 0xb6918..0xb6919
+            - Range: 0xb6dc8..0xb6dc9
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6919..0xb6940
+            - Range: 0xb6dc9..0xb6df0
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb68bc..0xb68e4
+            - Range: 0xb6d6c..0xb6d94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb68e4..0xb6940
+            - Range: 0xb6d94..0xb6df0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xb6940..0xb69e0]
+      OutOfLinePCRanges: [0xb6df0..0xb6e90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb6940..0xb696c
+            - Range: 0xb6df0..0xb6e1c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6940..0xb696c
+            - Range: 0xb6df0..0xb6e1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb696c..0xb69e0
+            - Range: 0xb6e1c..0xb6e90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2291,27 +2291,27 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xb69e0..0xb6ab0]
+      OutOfLinePCRanges: [0xb6e90..0xb6f60]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb69e0..0xb6a08
+            - Range: 0xb6e90..0xb6eb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6a08..0xb6ab0
+            - Range: 0xb6eb8..0xb6f60
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb69e0..0xb6a18
+            - Range: 0xb6e90..0xb6ec8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6a18..0xb6ab0
+            - Range: 0xb6ec8..0xb6f60
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2321,18 +2321,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb6a08..0xb6a18
+            - Range: 0xb6eb8..0xb6ec8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xb6ab0..0xb6b60]
+      OutOfLinePCRanges: [0xb6f60..0xb7010]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 105 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb6ab0..0xb6ae0
+            - Range: 0xb6f60..0xb6f90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2344,13 +2344,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6ab0..0xb6ae0
+            - Range: 0xb6f60..0xb6f90
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb6ae0..0xb6b60
+            - Range: 0xb6f90..0xb7010
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -2359,25 +2359,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xb6b60..0xb6c00]
+      OutOfLinePCRanges: [0xb7010..0xb70b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 109 GoMapType map[string]int
           Locations:
-            - Range: 0xb6b60..0xb6b98
+            - Range: 0xb7010..0xb7048
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6b60..0xb6b9c
+            - Range: 0xb7010..0xb704c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb6b9c..0xb6ba0
+            - Range: 0xb704c..0xb7050
               Pieces:
                 - Size: 8
                   Op: null
@@ -2386,31 +2386,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xb6c00..0xb6cb0]
+      OutOfLinePCRanges: [0xb70b0..0xb7160]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 119 StructureType main.condFields
           Locations:
-            - Range: 0xb6c00..0xb6cb0
+            - Range: 0xb70b0..0xb7160
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb6c00..0xb6c30
+            - Range: 0xb70b0..0xb70e0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb6c30..0xb6c34
+            - Range: 0xb70e0..0xb70e4
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb6c34..0xb6cb0
+            - Range: 0xb70e4..0xb7160
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2419,58 +2419,58 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb6cb0..0xb6e70]
+      OutOfLinePCRanges: [0xb7a20..0xb7be0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xb6cb0..0xb6e50
+            - Range: 0xb7a20..0xb7bc0
               Pieces: []
-            - Range: 0xb6e50..0xb6e51
+            - Range: 0xb7bc0..0xb7bc1
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb6e51..0xb6e70
+            - Range: 0xb7bc1..0xb7be0
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0xb5b70..0xb5be0]
+      OutOfLinePCRanges: [0xb6020..0xb6090]
       InlinePCRanges:
-        - Ranges: [0xb5130..0xb516c]
-          RootRanges: [0xb4f90..0xb5870]
+        - Ranges: [0xb5130..0xb5170]
+          RootRanges: [0xb4f90..0xb5d20]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb5130..0xb516c
+            - Range: 0xb5130..0xb5170
               Pieces: []
-            - Range: 0xb5b70..0xb5b90
+            - Range: 0xb6020..0xb6040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5310..0xb5340]
-          RootRanges: [0xb4f90..0xb5870]
+        - Ranges: [0xb5314..0xb5344]
+          RootRanges: [0xb4f90..0xb5d20]
       Variables:
         - Name: ptr
           Type: 127 PointerType *****int
           Locations:
-            - Range: 0xb52e8..0xb5330
+            - Range: 0xb52ec..0xb5334
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 35
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb5348..0xb5378]
-          RootRanges: [0xb4f90..0xb5870]
+        - Ranges: [0xb534c..0xb537c]
+          RootRanges: [0xb4f90..0xb5d20]
       Variables:
         - Name: ptr
           Type: 129 PointerType **int
           Locations:
-            - Range: 0xb5348..0xb5378
+            - Range: 0xb534c..0xb537c
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
@@ -2478,28 +2478,28 @@ Types:
       ID: 127
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 35680
+      GoRuntimeType: 35936
       GoKind: 22
       Pointee: 128 PointerType ****int
     - __kind: PointerType
       ID: 128
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 35616
+      GoRuntimeType: 35872
       GoKind: 22
       Pointee: 181 PointerType ***int
     - __kind: PointerType
       ID: 181
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 35552
+      GoRuntimeType: 35808
       GoKind: 22
       Pointee: 129 PointerType **int
     - __kind: PointerType
       ID: 129
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 35488
+      GoRuntimeType: 35744
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
@@ -2531,7 +2531,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 40160
+      GoRuntimeType: 40352
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2553,63 +2553,63 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30112
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 101
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 28896
+      GoRuntimeType: 29024
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 102
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 29856
+      GoRuntimeType: 29984
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 97
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 29920
+      GoRuntimeType: 30048
       GoKind: 22
       Pointee: 18 BaseType float64
     - __kind: PointerType
       ID: 99
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 29536
+      GoRuntimeType: 29664
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 29280
+      GoRuntimeType: 29408
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 98
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 29408
+      GoRuntimeType: 29536
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 154
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 27360
+      GoRuntimeType: 27488
       GoKind: 22
       Pointee: 155 StructureType main.bigStruct
     - __kind: PointerType
       ID: 121
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 27232
+      GoRuntimeType: 27296
       GoKind: 22
       Pointee: 119 StructureType main.condFields
     - __kind: PointerType
@@ -2656,77 +2656,77 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 30176
+      GoRuntimeType: 30304
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 82080
+      GoRuntimeType: 82272
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 62
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 30816
+      GoRuntimeType: 30944
       GoKind: 22
       Pointee: 63 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 30880
+      GoRuntimeType: 31008
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 59936
+      GoRuntimeType: 60128
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 66656
+      GoRuntimeType: 66848
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 31584
+      GoRuntimeType: 31712
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestGroup'
       ByteSize: 8
-      GoRuntimeType: 94048
+      GoRuntimeType: 94240
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestGroup
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 125088
+      GoRuntimeType: 125536
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 76
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 99232
+      GoRuntimeType: 99424
       GoKind: 22
       Pointee: 77 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 93
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 28960
+      GoRuntimeType: 29088
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2758,42 +2758,42 @@ Types:
       ID: 103
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 29600
+      GoRuntimeType: 29728
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 104
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 29216
+      GoRuntimeType: 29344
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 29344
+      GoRuntimeType: 29472
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 100
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 29472
+      GoRuntimeType: 29600
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29088
+      GoRuntimeType: 29216
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 29664
+      GoRuntimeType: 29792
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3202,7 +3202,7 @@ Types:
     - __kind: EventRootType
       ID: 290
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3225,16 +3225,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 277
       Name: Probe[main.condNilPtrStruct]
@@ -4141,7 +4131,7 @@ Types:
     - __kind: ArrayType
       ID: 92
       Name: '[0]uint8'
-      GoRuntimeType: 53728
+      GoRuntimeType: 53920
       GoKind: 17
       HasCount: true
       Element: 3 BaseType uint8
@@ -4149,7 +4139,7 @@ Types:
       ID: 89
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 53632
+      GoRuntimeType: 53824
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4158,7 +4148,7 @@ Types:
       ID: 180
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 47776
+      GoRuntimeType: 47968
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4167,7 +4157,7 @@ Types:
       ID: 75
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 53248
+      GoRuntimeType: 53440
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4176,7 +4166,7 @@ Types:
       ID: 74
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 53344
+      GoRuntimeType: 53536
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4185,7 +4175,7 @@ Types:
       ID: 81
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 53536
+      GoRuntimeType: 53728
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4194,7 +4184,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 49504
+      GoRuntimeType: 49696
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4203,7 +4193,7 @@ Types:
       ID: 87
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 55744
+      GoRuntimeType: 55936
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4212,7 +4202,7 @@ Types:
       ID: 65
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 53056
+      GoRuntimeType: 53248
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4221,7 +4211,7 @@ Types:
       ID: 106
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 47392
+      GoRuntimeType: 47680
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4230,7 +4220,7 @@ Types:
       ID: 120
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 47200
+      GoRuntimeType: 47392
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4239,7 +4229,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 52768
+      GoRuntimeType: 52960
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4248,7 +4238,7 @@ Types:
       ID: 108
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 47488
+      GoRuntimeType: 47776
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4257,7 +4247,7 @@ Types:
       ID: 88
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 54880
+      GoRuntimeType: 55072
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4266,7 +4256,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 52000
+      GoRuntimeType: 52192
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4275,7 +4265,7 @@ Types:
       ID: 82
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 53440
+      GoRuntimeType: 53632
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4308,7 +4298,7 @@ Types:
       ID: 105
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 38368
+      GoRuntimeType: 38560
       GoKind: 23
       RawFields:
         - Name: array
@@ -4359,7 +4349,7 @@ Types:
       ID: 107
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 38624
+      GoRuntimeType: 38816
       GoKind: 23
       RawFields:
         - Name: array
@@ -4382,7 +4372,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 37984
+      GoRuntimeType: 38176
       GoKind: 23
       RawFields:
         - Name: array
@@ -4405,7 +4395,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 38496
+      GoRuntimeType: 38688
       GoKind: 23
       RawFields:
         - Name: array
@@ -4428,25 +4418,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 43392
+      GoRuntimeType: 43584
       GoKind: 1
     - __kind: BaseType
       ID: 96
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 43200
+      GoRuntimeType: 43392
       GoKind: 16
     - __kind: BaseType
       ID: 95
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 43136
+      GoRuntimeType: 43328
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 64864
+      GoRuntimeType: 65056
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4459,25 +4449,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 43264
+      GoRuntimeType: 43456
       GoKind: 13
     - __kind: BaseType
       ID: 18
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 43328
+      GoRuntimeType: 43520
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 36128
+      GoRuntimeType: 36320
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 70
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 58016
+      GoRuntimeType: 58208
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 172
@@ -4539,37 +4529,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 42944
+      GoRuntimeType: 43136
       GoKind: 2
     - __kind: BaseType
       ID: 94
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 42560
+      GoRuntimeType: 42752
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 42688
+      GoRuntimeType: 42880
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 42816
+      GoRuntimeType: 43008
       GoKind: 6
     - __kind: BaseType
       ID: 16
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 42432
+      GoRuntimeType: 42624
       GoKind: 3
     - __kind: StructureType
       ID: 86
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 115008
+      GoRuntimeType: 115200
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4591,7 +4581,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 75456
+      GoRuntimeType: 75648
       GoKind: 25
       RawFields:
         - Name: u
@@ -4601,7 +4591,7 @@ Types:
       ID: 68
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 102304
+      GoRuntimeType: 102496
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4617,7 +4607,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 92608
+      GoRuntimeType: 92800
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4630,7 +4620,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 92448
+      GoRuntimeType: 92640
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4643,7 +4633,7 @@ Types:
       ID: 73
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 92768
+      GoRuntimeType: 92960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4655,27 +4645,27 @@ Types:
     - __kind: StructureType
       ID: 69
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 63296
+      GoRuntimeType: 63488
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 63200
+      GoRuntimeType: 63392
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 177
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71104
+      GoRuntimeType: 71296
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 155
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 122720
+      GoRuntimeType: 123168
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4706,7 +4696,7 @@ Types:
       ID: 119
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 129792
+      GoRuntimeType: 130240
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4880,35 +4870,35 @@ Types:
       ID: 164
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 68960
+      GoRuntimeType: 69280
       GoKind: 21
       HeaderType: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 69088
+      GoRuntimeType: 69152
       GoKind: 21
       HeaderType: 111 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 114
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 69216
+      GoRuntimeType: 69408
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 122
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 69472
+      GoRuntimeType: 69664
       GoKind: 21
       HeaderType: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 175
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 47584
+      GoRuntimeType: 47872
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4917,7 +4907,7 @@ Types:
       ID: 152
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 47872
+      GoRuntimeType: 48064
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4926,7 +4916,7 @@ Types:
       ID: 144
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 47680
+      GoRuntimeType: 47488
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4935,7 +4925,7 @@ Types:
       ID: 162
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 48064
+      GoRuntimeType: 48256
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4944,7 +4934,7 @@ Types:
       ID: 174
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 76864
+      GoRuntimeType: 77312
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4957,7 +4947,7 @@ Types:
       ID: 143
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 77120
+      GoRuntimeType: 77056
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4970,7 +4960,7 @@ Types:
       ID: 151
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 77376
+      GoRuntimeType: 77568
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4983,7 +4973,7 @@ Types:
       ID: 161
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 77888
+      GoRuntimeType: 78080
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -4996,7 +4986,7 @@ Types:
       ID: 176
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 76736
+      GoRuntimeType: 77184
       GoKind: 25
       RawFields:
         - Name: key
@@ -5009,7 +4999,7 @@ Types:
       ID: 153
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 77248
+      GoRuntimeType: 77440
       GoKind: 25
       RawFields:
         - Name: key
@@ -5022,7 +5012,7 @@ Types:
       ID: 145
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 76992
+      GoRuntimeType: 76928
       GoKind: 25
       RawFields:
         - Name: key
@@ -5035,7 +5025,7 @@ Types:
       ID: 163
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 77760
+      GoRuntimeType: 77952
       GoKind: 25
       RawFields:
         - Name: key
@@ -5063,14 +5053,14 @@ Types:
     - __kind: StructureType
       ID: 84
       Name: runtime.dlogPerM
-      GoRuntimeType: 62432
+      GoRuntimeType: 62624
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 144992
+      GoRuntimeType: 145440
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5251,7 +5241,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 73920
+      GoRuntimeType: 74112
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5261,7 +5251,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 56
-      GoRuntimeType: 120704
+      GoRuntimeType: 121152
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5289,7 +5279,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 90048
+      GoRuntimeType: 90240
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5302,7 +5292,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 107488
+      GoRuntimeType: 107680
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5321,13 +5311,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 56576
+      GoRuntimeType: 56768
       GoKind: 12
     - __kind: StructureType
       ID: 90
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 89888
+      GoRuntimeType: 90080
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5340,7 +5330,7 @@ Types:
       ID: 78
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 118880
+      GoRuntimeType: 119328
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5365,13 +5355,13 @@ Types:
       ID: 91
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 56480
+      GoRuntimeType: 56672
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1808
-      GoRuntimeType: 150048
+      GoRuntimeType: 150496
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5594,7 +5584,7 @@ Types:
       ID: 67
       Name: runtime.mLockProfile
       ByteSize: 64
-      GoRuntimeType: 120992
+      GoRuntimeType: 121440
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5622,7 +5612,7 @@ Types:
       ID: 85
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 113664
+      GoRuntimeType: 113856
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5644,7 +5634,7 @@ Types:
       ID: 72
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 113440
+      GoRuntimeType: 113632
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5666,7 +5656,7 @@ Types:
       ID: 66
       Name: runtime.mWaitList
       ByteSize: 8
-      GoRuntimeType: 73664
+      GoRuntimeType: 73856
       GoKind: 25
       RawFields:
         - Name: next
@@ -5676,20 +5666,20 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 56192
+      GoRuntimeType: 56384
       GoKind: 12
     - __kind: StructureType
       ID: 64
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 73536
+      GoRuntimeType: 73728
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: StructureType
       ID: 80
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 89728
+      GoRuntimeType: 89920
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5702,7 +5692,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 108256
+      GoRuntimeType: 108448
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5721,13 +5711,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 56384
+      GoRuntimeType: 56576
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 59552
+      GoRuntimeType: 59744
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5736,7 +5726,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 88128
+      GoRuntimeType: 88320
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5757,7 +5747,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 43648
+      GoRuntimeType: 43840
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5767,7 +5757,7 @@ Types:
       ID: 71
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 43712
+      GoRuntimeType: 43904
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 77
@@ -5777,7 +5767,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 89088
+      GoRuntimeType: 89280
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5790,19 +5780,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 76480
+      GoRuntimeType: 76672
       GoKind: 8
     - __kind: StructureType
       ID: 79
       Name: runtime.winlibcall
-      GoRuntimeType: 62336
+      GoRuntimeType: 62528
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 42368
+      GoRuntimeType: 42560
       GoKind: 24
       RawFields:
         - Name: str
@@ -5917,43 +5907,43 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 43008
+      GoRuntimeType: 43200
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 42624
+      GoRuntimeType: 42816
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 42752
+      GoRuntimeType: 42944
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 42880
+      GoRuntimeType: 43072
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 42496
+      GoRuntimeType: 42688
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 43072
+      GoRuntimeType: 43264
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 43456
+      GoRuntimeType: 43648
       GoKind: 26
 MaxTypeID: 296
 Issues:
@@ -6197,7 +6187,7 @@ Issues:
       issue:
         Kind: 3
         Message: probe kind ProbeKindSpan is not supported
-GoModuledataInfo: {FirstModuledataAddr: "0x191340", TypesOffset: 296}
+GoModuledataInfo: {FirstModuledataAddr: "0x1a1340", TypesOffset: 296}
 CommonTypes:
     G: 22 StructureType runtime.g
     M: 29 StructureType runtime.m

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.PointerChainArg]
+          Type: 350 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5314", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 351 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb534c", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 201 EventRootType Probe[main.bigMapArg]
+          Type: 204 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb6170", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 202 EventRootType Probe[main.bigMapArg]Return
+          Type: 205 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb61e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condBool]
+          Type: 248 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condBool]Return
+          Type: 249 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condBool]
+          Type: 250 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condBool]Return
+          Type: 251 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condBool]
+          Type: 252 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb6918", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condBool]Return
+          Type: 253 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb6980", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condFloat32]
+          Type: 244 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0xb67b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condFloat32]Return
+          Type: 245 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0xb681c", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condFloat64]
+          Type: 246 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0xb6868", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condFloat64]Return
+          Type: 247 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0xb68cc", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 209 EventRootType Probe[main.condInt16]
+          Type: 212 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb6348", Frameless: false}]
           Condition:
             Type: 94 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 210 EventRootType Probe[main.condInt16]Return
+          Type: 213 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 211 EventRootType Probe[main.condInt16]
+          Type: 214 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb6348", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 212 EventRootType Probe[main.condInt16]Return
+          Type: 215 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb63a8", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 213 EventRootType Probe[main.condInt32]
+          Type: 216 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 214 EventRootType Probe[main.condInt32]Return
+          Type: 217 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 215 EventRootType Probe[main.condInt32]
+          Type: 218 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 216 EventRootType Probe[main.condInt32]Return
+          Type: 219 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 217 EventRootType Probe[main.condInt32]
+          Type: 220 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 218 EventRootType Probe[main.condInt32]Return
+          Type: 221 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb6448", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 219 EventRootType Probe[main.condInt64]
+          Type: 222 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6488", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 220 EventRootType Probe[main.condInt64]Return
+          Type: 223 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 221 EventRootType Probe[main.condInt64]
+          Type: 224 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6488", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 222 EventRootType Probe[main.condInt64]Return
+          Type: 225 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb64e8", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 205 EventRootType Probe[main.condInt8]
+          Type: 208 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition:
             Type: 16 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 206 EventRootType Probe[main.condInt8]Return
+          Type: 209 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb6300", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 207 EventRootType Probe[main.condInt8]
+          Type: 210 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 208 EventRootType Probe[main.condInt8]Return
+          Type: 211 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb6300", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 289 EventRootType Probe[main.condLine]Line
+          Type: 292 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 290 EventRootType Probe[main.condLine]Line
+          Type: 293 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condNilPtrStruct]
+          Type: 280 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 281 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condNilPtrStruct]
+          Type: 282 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condOnly]
+          Type: 288 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condOnly]Return
+          Type: 289 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condOnly]
+          Type: 290 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condOnly]Return
+          Type: 291 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condPtrStructArg]
+          Type: 274 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 275 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condPtrStructArg]
+          Type: 276 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condPtrStructArg]
+          Type: 278 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condReturnAndLocal]
+          Type: 284 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 285 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condReturnAndLocal]
+          Type: 286 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condString]
+          Type: 254 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condString]Return
+          Type: 255 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condString]
+          Type: 256 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condString]Return
+          Type: 257 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condString]
+          Type: 258 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condString]Return
+          Type: 259 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condString]
+          Type: 260 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condString]Return
+          Type: 261 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condStructArg]
+          Type: 262 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condStructArg]Return
+          Type: 263 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condStructArg]
+          Type: 264 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condStructArg]Return
+          Type: 265 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condStructArg]
+          Type: 266 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 18 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condStructArg]Return
+          Type: 267 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condStructArg]
+          Type: 268 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condStructArg]Return
+          Type: 269 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condStructArg]
+          Type: 270 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condStructArg]Return
+          Type: 271 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 229 EventRootType Probe[main.condUint16]
+          Type: 232 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb65d8", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 230 EventRootType Probe[main.condUint16]Return
+          Type: 233 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb6638", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 231 EventRootType Probe[main.condUint16]
+          Type: 234 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb65d8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 232 EventRootType Probe[main.condUint16]Return
+          Type: 235 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb6638", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 233 EventRootType Probe[main.condUint32]
+          Type: 236 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6678", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 234 EventRootType Probe[main.condUint32]Return
+          Type: 237 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb66d8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 235 EventRootType Probe[main.condUint32]
+          Type: 238 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6678", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 236 EventRootType Probe[main.condUint32]Return
+          Type: 239 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb66d8", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 237 EventRootType Probe[main.condUint64]
+          Type: 240 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6718", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 238 EventRootType Probe[main.condUint64]Return
+          Type: 241 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb6778", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 239 EventRootType Probe[main.condUint64]
+          Type: 242 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6718", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 240 EventRootType Probe[main.condUint64]Return
+          Type: 243 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb6778", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 223 EventRootType Probe[main.condUint8]
+          Type: 226 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 224 EventRootType Probe[main.condUint8]Return
+          Type: 227 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 225 EventRootType Probe[main.condUint8]
+          Type: 228 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 226 EventRootType Probe[main.condUint8]Return
+          Type: 229 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 227 EventRootType Probe[main.condUint8]
+          Type: 230 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 228 EventRootType Probe[main.condUint8]Return
+          Type: 231 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb6590", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.inlined]
+          Type: 348 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb5130"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.inlined]Return
+          Type: 349 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6070", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 182 EventRootType Probe[main.intArg]
+          Type: 185 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb5d38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 183 EventRootType Probe[main.intArg]Return
+          Type: 186 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb5d70", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.intArrayArg]
+          Type: 195 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb5ea8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 193 EventRootType Probe[main.intArrayArg]Return
+          Type: 196 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb5eec", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 201 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb6010", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 190 EventRootType Probe[main.intSliceArg]
+          Type: 193 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb5e28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 191 EventRootType Probe[main.intSliceArg]Return
+          Type: 194 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb5e64", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 338 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xb782c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 339 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xb792c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xb782c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 344 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xb792c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 345 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb7554", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb7554", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 332 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 333 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 334 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 337 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 294 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 295 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 296 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 297 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 298 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 299 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 300 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 301 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 302 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 303 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 320 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 321 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 322 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 323 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 184 EventRootType Probe[main.stringArg]
+          Type: 187 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 185 EventRootType Probe[main.stringArg]Return
+          Type: 188 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 186 EventRootType Probe[main.stringArg]
+          Type: 189 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 187 EventRootType Probe[main.stringArg]Return
+          Type: 190 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 199 EventRootType Probe[main.mapArg]
+          Type: 202 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb60f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 200 EventRootType Probe[main.mapArg]Return
+          Type: 203 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb6128", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 203 EventRootType Probe[main.noArgs]
+          Type: 206 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb6228", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 204 EventRootType Probe[main.noArgs]Return
+          Type: 207 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb6260", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 188 EventRootType Probe[main.stringArg]
+          Type: 191 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb5da8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 189 EventRootType Probe[main.stringArg]Return
+          Type: 192 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb5de4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArrayArg]
+          Type: 199 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb5fa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 197 EventRootType Probe[main.stringArrayArg]Return
+          Type: 200 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb5fec", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.stringSliceArg]
+          Type: 197 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb5f28", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.stringSliceArg]Return
+          Type: 198 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb5f64", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7a40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 347 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7bc0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2418,12 +3085,322 @@ Subprograms:
                   Op: {CfaOffset: 96}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0xb7170..0xb7270]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7170..0xb71d8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb71d8..0xb71dc
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb71dc..0xb7270
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7170..0xb71d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xb71d0..0xb71e0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xb71e0..0xb7270
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0xb7270..0xb7380]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 105 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb7270..0xb72e4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb72e4..0xb72e8
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb72e8..0xb72ec
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb72ec..0xb7380
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7270..0xb72d4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb72d4..0xb72f0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xb72f0..0xb7380
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0xb7380..0xb7490]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 109 GoMapType map[string]int
+          Locations:
+            - Range: 0xb7380..0xb73e0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb73e0..0xb7490
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7380..0xb73e4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb73e4..0xb73e8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb73e8..0xb7490
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0xb7490..0xb7580]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 93 PointerType *string
+          Locations:
+            - Range: 0xb7490..0xb74f0
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb74f0..0xb7580
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7490..0xb74f4
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb74f4..0xb74f8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb74f8..0xb7580
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xb7580..0xb76d0]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 122 StructureType main.lenFields
+          Locations:
+            - Range: 0xb7580..0xb76d0
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7580..0xb7608
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb7608..0xb760c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xb760c..0xb76d0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xb76d0..0xb7810]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 PointerType *main.lenFields
+          Locations:
+            - Range: 0xb76d0..0xb7730
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7730..0xb7810
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb76d0..0xb7734
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb7734..0xb7738
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb7738..0xb7810
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xb7810..0xb7910]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xb7810..0xb7878
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb7878..0xb7910
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7810..0xb787c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb787c..0xb7880
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb7880..0xb7910
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0xb7910..0xb7a20]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 119 StructureType main.condFields
+          Locations:
+            - Range: 0xb7910..0xb7a20
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb7910..0xb798c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb798c..0xb7990
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xb7990..0xb7a20
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0xb7a20..0xb7be0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0xb7a20..0xb7bc0
               Pieces: []
@@ -2432,7 +3409,7 @@ Subprograms:
             - Range: 0xb7bc1..0xb7be0
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0xb6020..0xb6090]
       InlinePCRanges:
@@ -2447,7 +3424,7 @@ Subprograms:
             - Range: 0xb6020..0xb6040
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2455,12 +3432,12 @@ Subprograms:
           RootRanges: [0xb4f90..0xb5d20]
       Variables:
         - Name: ptr
-          Type: 127 PointerType *****int
+          Type: 130 PointerType *****int
           Locations:
             - Range: 0xb52ec..0xb5334
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2468,45 +3445,45 @@ Subprograms:
           RootRanges: [0xb4f90..0xb5d20]
       Variables:
         - Name: ptr
-          Type: 129 PointerType **int
+          Type: 132 PointerType **int
           Locations:
             - Range: 0xb534c..0xb537c
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 35936
       GoKind: 22
-      Pointee: 128 PointerType ****int
+      Pointee: 131 PointerType ****int
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 35872
       GoKind: 22
-      Pointee: 181 PointerType ***int
+      Pointee: 184 PointerType ***int
     - __kind: PointerType
-      ID: 181
+      ID: 184
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 35808
       GoKind: 22
-      Pointee: 129 PointerType **int
+      Pointee: 132 PointerType **int
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 35744
       GoKind: 22
       Pointee: 99 PointerType *int
     - __kind: PointerType
-      ID: 167
+      ID: 170
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 168 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 171 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '**table<string,int>'
@@ -2518,15 +3495,22 @@ Types:
       ByteSize: 8
       Pointee: 118 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 137
+      ID: 123
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 35680
+      GoKind: 22
+      Pointee: 105 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 140
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []int.array
+      Pointee: 139 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2535,20 +3519,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 139
+      ID: 142
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 138 GoSliceDataType []string.array
+      Pointee: 141 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 132 GoSliceDataType []uint8.array
+      Pointee: 135 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uintptr.array
+      Pointee: 137 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -2599,12 +3583,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 154
+      ID: 157
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 27488
       GoKind: 22
-      Pointee: 155 StructureType main.bigStruct
+      Pointee: 158 StructureType main.bigStruct
     - __kind: PointerType
       ID: 121
       Name: '*main.condFields'
@@ -2613,10 +3597,17 @@ Types:
       GoKind: 22
       Pointee: 119 StructureType main.condFields
     - __kind: PointerType
-      ID: 165
+      ID: 124
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 27360
+      GoKind: 22
+      Pointee: 122 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 168
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 169 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 110
       Name: '*map<string,int>'
@@ -2628,30 +3619,30 @@ Types:
       ByteSize: 8
       Pointee: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 123
+      ID: 126
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 143 StructureType noalg.map.group[string]int
+      Pointee: 146 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 150
+      ID: 153
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 151 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2730,30 +3721,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 130 GoStringDataType string.str
+      Pointee: 133 GoStringDataType string.str
     - __kind: PointerType
-      ID: 168
+      ID: 171
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 171 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 174 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 113
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 140 StructureType table<string,int>
+      Pointee: 143 StructureType table<string,int>
     - __kind: PointerType
       ID: 118
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 148 StructureType table<string,main.bigStruct>
+      Pointee: 151 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 126
+      ID: 129
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 158 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 161 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 103
       Name: '*uint'
@@ -2797,7 +3788,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 295
+      ID: 350
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2806,24 +3797,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 127 PointerType *****int
+            Type: 130 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 127 PointerType *****int
+            Type: 130 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 351
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2832,14 +3823,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType **int
+            Type: 132 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2865,10 +3856,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2884,7 +3875,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2900,7 +3891,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2926,16 +3917,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 241
+      ID: 244
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2951,10 +3942,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 242
+      ID: 245
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2970,10 +3961,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2989,7 +3980,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3015,13 +4006,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 210
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 212
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 213
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 215
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 216
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3037,7 +4028,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 215
+      ID: 218
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3053,7 +4044,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 220
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3079,16 +4070,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 214
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 216
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 218
+      ID: 217
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 219
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 221
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 222
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3104,7 +4095,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3130,13 +4121,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
+      ID: 223
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3152,7 +4143,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3178,13 +4169,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3200,7 +4191,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 293
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3226,7 +4217,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3242,7 +4233,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3268,71 +4259,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 288
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 289
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 291
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 274
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3348,7 +4339,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3364,7 +4355,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3390,16 +4381,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 279
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 284
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3415,7 +4406,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3441,10 +4432,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3460,7 +4451,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3476,7 +4467,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3484,6 +4475,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 258
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3493,70 +4536,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 255
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 257
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 252
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 254
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 256
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 258
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 259
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 261
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 262
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3572,7 +4563,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3588,7 +4579,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3604,7 +4595,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3620,7 +4611,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3636,7 +4627,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 269
+      ID: 272
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3662,25 +4653,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 262
+      ID: 265
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 264
+      ID: 267
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 268
+      ID: 271
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3696,7 +4687,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3722,13 +4713,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 232
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 233
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 235
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 236
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3744,7 +4735,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
+      ID: 238
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3770,13 +4761,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 234
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 236
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 237
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 239
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 240
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3792,7 +4783,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 239
+      ID: 242
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3818,13 +4809,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 238
+      ID: 241
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 240
+      ID: 243
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 223
+      ID: 226
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3840,7 +4831,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3856,7 +4847,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3882,16 +4873,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
+      ID: 227
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 348
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3903,14 +4894,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 294
+      ID: 349
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 182
+      ID: 185
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3926,10 +4917,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 183
+      ID: 186
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3945,10 +4936,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3964,10 +4955,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 338
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 119 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 109 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 93 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 105 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 294
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 296
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 297
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 122 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 202
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3993,16 +5508,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 184
+      ID: 187
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4018,10 +5533,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 186
+      ID: 189
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4047,16 +5562,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 185
+      ID: 188
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4072,7 +5587,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4088,10 +5603,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4107,13 +5622,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 346
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 292
+      ID: 347
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4122,10 +5637,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 122 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 125 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4145,7 +5660,7 @@ Types:
       HasCount: true
       Element: 90 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 47968
@@ -4271,29 +5786,29 @@ Types:
       HasCount: true
       Element: 83 StructureType runtime.pcvalueCacheEnt
     - __kind: GoSliceDataType
-      ID: 178
+      ID: 181
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 168 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 171 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 149
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 113 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 159
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 118 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 169
+      ID: 172
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 126 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 129 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 105
       Name: '[]int'
@@ -4310,37 +5825,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 136 GoSliceDataType []int.array
+      Data: 139 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 182
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 147
+      ID: 150
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 143 StructureType noalg.map.group[string]int
+      Element: 146 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 151 StructureType noalg.map.group[string]main.bigStruct
+      Element: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 170
+      ID: 173
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -4361,9 +5876,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 138 GoSliceDataType []string.array
+      Data: 141 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 138
+      ID: 141
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4384,9 +5899,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 132 GoSliceDataType []uint8.array
+      Data: 135 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 132
+      ID: 135
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4407,9 +5922,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 134 GoSliceDataType []uintptr.array
+      Data: 137 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4470,61 +5985,61 @@ Types:
       GoRuntimeType: 58208
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 172
+      ID: 175
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 173 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 176 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 179 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 182 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 141
+      ID: 144
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 142 PointerType *noalg.map.group[string]int
+          Type: 145 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 143 StructureType noalg.map.group[string]int
-      GroupSliceType: 147 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 146 StructureType noalg.map.group[string]int
+      GroupSliceType: 150 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 149
+      ID: 152
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 150 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 153 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 151 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 157 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 154 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 160 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 159
+      ID: 162
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 160 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 163 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 170 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 173 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4655,14 +6170,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 177
+      ID: 180
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 71296
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 155
+      ID: 158
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 123168
@@ -4691,7 +6206,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 180 ArrayType [128]uint8
+          Type: 183 ArrayType [128]uint8
     - __kind: StructureType
       ID: 119
       Name: main.condFields
@@ -4738,8 +6253,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 120 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 122
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 117536
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 105 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 109 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 93 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 123 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 120 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 166
+      ID: 169
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4752,7 +6292,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 167 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 170 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4768,8 +6308,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 178 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 174 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 181 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 177 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 111
       Name: map<string,int>
@@ -4800,8 +6340,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 146 GoSliceDataType []*table<string,int>.array
-      GroupType: 143 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 149 GoSliceDataType []*table<string,int>.array
+      GroupType: 146 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 116
       Name: map<string,main.bigStruct>
@@ -4832,10 +6372,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 156 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 151 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 159 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 154 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 124
+      ID: 127
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4848,7 +6388,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 125 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 128 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4864,15 +6404,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 169 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 161 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 172 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 164 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 164
+      ID: 167
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 69280
       GoKind: 21
-      HeaderType: 166 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 169 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 109
       Name: map[string]int
@@ -4888,50 +6428,50 @@ Types:
       GoKind: 21
       HeaderType: 116 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 122
+      ID: 125
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 69664
       GoKind: 21
-      HeaderType: 124 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 127 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 175
+      ID: 178
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 47872
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 176 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 179 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 152
+      ID: 155
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 48064
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 153 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 156 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 144
+      ID: 147
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 47488
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 145 StructureType noalg.struct { key string; elem int }
+      Element: 148 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 162
+      ID: 165
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 48256
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 163 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 166 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 174
+      ID: 177
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 77312
@@ -4942,9 +6482,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 175 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 178 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 143
+      ID: 146
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 77056
@@ -4955,9 +6495,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 144 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 147 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 151
+      ID: 154
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 77568
@@ -4968,9 +6508,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 152 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 155 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 78080
@@ -4981,9 +6521,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 162 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 165 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 176
+      ID: 179
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 77184
@@ -4994,9 +6534,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 177 StructureType main.aStructNotUsedAsAnArgument
+          Type: 180 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 77440
@@ -5007,9 +6547,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 154 PointerType *main.bigStruct
+          Type: 157 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 76928
@@ -5022,7 +6562,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 77952
@@ -5033,7 +6573,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 164 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 167 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5797,18 +7337,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 131 PointerType *string.str
+          Type: 134 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 130 GoStringDataType string.str
+      Data: 133 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 130
+      ID: 133
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 171
+      ID: 174
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5830,9 +7370,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 172 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 175 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 140
+      ID: 143
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -5854,9 +7394,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 141 GoSwissMapGroupsType groupReference<string,int>
+          Type: 144 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -5878,9 +7418,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 149 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 152 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5902,7 +7442,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 159 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 162 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -5945,7 +7485,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43648
       GoKind: 26
-MaxTypeID: 296
+MaxTypeID: 351
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6176,6 +7716,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.PointerChainArg]
+          Type: 366 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5314", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 367 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb534c", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.inlined]
+          Type: 364 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb5130"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.inlined]Return
+          Type: 365 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6070", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenErrInt]
+          Type: 354 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb782c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenErrInt]Return
+          Type: 355 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenErrStruct]
+          Type: 358 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb792c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenErrStruct]Return
+          Type: 359 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenErrInt]
+          Type: 356 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb782c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenErrInt]Return
+          Type: 357 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenErrStruct]
+          Type: 360 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb792c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenErrStruct]Return
+          Type: 361 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenMap]
+          Type: 320 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenMap]Return
+          Type: 321 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenMap]
+          Type: 322 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenMap]Return
+          Type: 323 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenPtrString]
+          Type: 324 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenPtrString]Return
+          Type: 325 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb7554", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenPtrString]
+          Type: 326 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenPtrString]Return
+          Type: 327 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb7554", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenPtrStructFields]
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenPtrStructFields]
+          Type: 348 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 349 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenPtrStructFields]
+          Type: 350 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 353 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenSlice]
+          Type: 310 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenSlice]Return
+          Type: 311 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenSlice]
+          Type: 312 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenSlice]Return
+          Type: 313 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenStructFields]
+          Type: 328 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenStructFields]Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenStructFields]
+          Type: 330 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenStructFields]Return
+          Type: 331 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenStructFields]
+          Type: 332 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenStructFields]Return
+          Type: 333 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenStructFields]
+          Type: 334 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenStructFields]Return
+          Type: 335 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenStructFields]
+          Type: 336 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenStructFields]Return
+          Type: 337 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenStructFields]
+          Type: 338 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb759c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7a40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 363 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7bc0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3788,7 +4093,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3814,7 +4119,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4882,7 +5187,7 @@ Types:
       ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4898,7 +5203,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 185
@@ -4958,7 +5263,7 @@ Types:
       ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4984,16 +5289,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5019,19 +5324,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 308
+      ID: 314
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 316
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 322
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5057,13 +5429,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 309
+      ID: 315
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 317
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 312
+      ID: 319
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 324
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5082,7 +5463,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5108,13 +5489,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 313
+      ID: 325
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 315
+      ID: 327
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5140,10 +5521,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5162,7 +5562,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5181,19 +5581,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 349
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 304
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5209,7 +5657,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 312
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5239,6 +5687,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 307
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 313
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 294
@@ -5346,7 +5803,7 @@ Types:
       ID: 303
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 328
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5372,10 +5829,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 320
+      ID: 332
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5394,7 +5867,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 334
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5413,7 +5886,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 336
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5429,7 +5902,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 338
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5445,7 +5918,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 340
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5461,25 +5934,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 317
-      Name: Probe[main.lenStructFields]Return
+      ID: 342
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 319
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 321
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 323
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 325
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.lenStructFields]Return
+      ID: 344
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 345
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 202
@@ -5625,10 +6136,10 @@ Types:
       ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7485,7 +7996,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43648
       GoKind: 26
-MaxTypeID: 351
+MaxTypeID: 367
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 366 EventRootType Probe[main.PointerChainArg]
+          Type: 382 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb5314", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 367 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 383 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb534c", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 212 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb6348", Frameless: false}]
           Condition:
-            Type: 94 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 216 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 218 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb63e8", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 222 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb6488", Frameless: false}]
           Condition:
-            Type: 13 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 208 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb6298", Frameless: false}]
           Condition:
-            Type: 16 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 292 EventRootType Probe[main.condLine]Line
+          Type: 296 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 293 EventRootType Probe[main.condLine]Line
+          Type: 297 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb6eb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condNilPtrStruct]
+          Type: 284 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condNilPtrStruct]
+          Type: 286 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb6ca8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 287 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb6d1c", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condOnly]
+          Type: 292 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condOnly]Return
+          Type: 293 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condOnly]
+          Type: 294 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb6e08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condOnly]Return
+          Type: 295 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb6e68", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condPtrStructArg]
+          Type: 278 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condPtrStructArg]
+          Type: 280 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 281 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condPtrStructArg]
+          Type: 282 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb6b8c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 283 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb6c64", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condReturnAndLocal]
+          Type: 288 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condReturnAndLocal]
+          Type: 290 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb6d68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 291 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb6dc8", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 254 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 256 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 258 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 259 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 260 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 261 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condString]
+          Type: 262 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condString]Return
+          Type: 263 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condString]
+          Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb69c8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condString]Return
+          Type: 265 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb6a2c", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condStructArg]
+          Type: 266 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condStructArg]Return
+          Type: 267 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condStructArg]
+          Type: 268 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condStructArg]Return
+          Type: 269 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condStructArg]
+          Type: 270 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
-            Type: 18 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condStructArg]Return
+          Type: 271 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condStructArg]
+          Type: 274 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condStructArg]Return
+          Type: 275 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb6a7c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb6b48", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 232 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb65d8", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 236 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb6678", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 240 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb6718", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 226 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 228 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb6528", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 364 EventRootType Probe[main.inlined]
+          Type: 380 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb5130"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 365 EventRootType Probe[main.inlined]Return
+          Type: 381 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb6070", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenErrInt]
+          Type: 370 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb782c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenErrInt]Return
+          Type: 371 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.lenErrStruct]
+          Type: 374 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb792c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.lenErrStruct]Return
+          Type: 375 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.lenErrInt]
+          Type: 372 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xb782c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.lenErrInt]Return
+          Type: 373 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xb78e0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.lenErrStruct]
+          Type: 376 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xb792c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 361 EventRootType Probe[main.lenErrStruct]Return
+          Type: 377 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xb79fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenMap]
+          Type: 328 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenMap]Return
+          Type: 329 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb739c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb745c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenMap]
+          Type: 332 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenMap]Return
+          Type: 333 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenMap]
+          Type: 334 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenMap]Return
+          Type: 335 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenMap]
+          Type: 336 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenMap]Return
+          Type: 337 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenMap]
+          Type: 338 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb739c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenMap]Return
+          Type: 339 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb745c", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenPtrString]
+          Type: 340 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          Type: 341 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb7554", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenPtrString]
+          Type: 342 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb74ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenPtrString]Return
+          Type: 343 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb7554", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          Type: 362 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenPtrStructFields]
+          Type: 364 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 365 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenPtrStructFields]
+          Type: 366 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 367 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenPtrStructFields]
+          Type: 368 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xb76ec", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 369 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xb77e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenSlice]
+          Type: 316 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenSlice]Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb728c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenSlice]
+          Type: 320 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenSlice]Return
+          Type: 321 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenSlice]
+          Type: 322 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenSlice]Return
+          Type: 323 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenSlice]
+          Type: 324 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenSlice]Return
+          Type: 325 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenSlice]
+          Type: 326 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb728c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenSlice]Return
+          Type: 327 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb734c", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 298 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 299 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 300 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 301 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 302 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 303 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 294 EventRootType Probe[main.lenString]
+          Type: 304 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb718c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 295 EventRootType Probe[main.lenString]Return
+          Type: 305 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb718c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb7240", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.lenString]
+          Type: 308 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb718c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.lenString]Return
+          Type: 309 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.lenString]
+          Type: 310 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb718c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 299 EventRootType Probe[main.lenString]Return
+          Type: 311 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.lenString]
+          Type: 312 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb718c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 301 EventRootType Probe[main.lenString]Return
+          Type: 313 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 302 EventRootType Probe[main.lenString]
+          Type: 314 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb718c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 303 EventRootType Probe[main.lenString]Return
+          Type: 315 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb7240", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenStructFields]
+          Type: 346 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          Type: 347 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenStructFields]
+          Type: 348 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          Type: 349 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenStructFields]
+          Type: 350 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          Type: 351 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenStructFields]
+          Type: 352 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          Type: 353 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenStructFields]
+          Type: 356 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          Type: 357 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenStructFields]
+          Type: 358 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          Type: 359 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenStructFields]
+          Type: 360 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb759c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenStructFields]Return
+          Type: 361 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xb76b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 362 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 378 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xb7a40", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 363 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 379 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xb7bc0", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4093,7 +4305,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4119,7 +4331,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4480,7 +4692,7 @@ Types:
       ID: 211
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4496,7 +4708,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4522,7 +4734,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 284
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4538,7 +4750,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 286
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4564,13 +4776,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 281
+      ID: 285
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 283
+      ID: 287
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 288
+      ID: 292
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4596,7 +4808,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4622,45 +4834,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 293
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 278
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 282
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4686,16 +4898,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 277
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 279
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 281
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 283
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 288
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4711,7 +4923,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 286
+      ID: 290
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4737,10 +4949,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 285
+      ID: 289
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 287
+      ID: 291
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4790,6 +5002,48 @@ Types:
     - __kind: EventRootType
       ID: 258
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 260
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 262
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4814,7 +5068,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 260
+      ID: 264
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4852,7 +5106,13 @@ Types:
       ID: 261
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 262
+      ID: 263
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 266
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4860,38 +5120,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -4934,6 +5162,38 @@ Types:
     - __kind: EventRootType
       ID: 272
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 274
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 276
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4958,12 +5218,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 265
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 267
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4974,6 +5228,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 273
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 232
@@ -5187,7 +5447,7 @@ Types:
       ID: 231
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5203,7 +5463,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 185
@@ -5263,7 +5523,7 @@ Types:
       ID: 194
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5289,16 +5549,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5324,16 +5584,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 328
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5349,7 +5609,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 330
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5368,7 +5653,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 334
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5384,7 +5669,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 336
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5403,7 +5688,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 338
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5429,22 +5714,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 329
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 331
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 333
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 335
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 323
+      ID: 337
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 339
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 340
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5463,7 +5751,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 326
+      ID: 342
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5489,13 +5777,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5521,7 +5809,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,7 +5831,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5562,7 +5850,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5581,19 +5869,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 316
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5609,7 +5897,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 306
+      ID: 318
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 320
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5625,7 +5935,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 322
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5641,7 +5951,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 324
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5657,7 +5967,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 326
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5683,22 +5993,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 311
+      ID: 323
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 325
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 327
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 298
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 304
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5714,7 +6093,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 296
+      ID: 306
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5730,7 +6131,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 298
+      ID: 310
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5746,7 +6147,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 312
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5762,7 +6163,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 302
+      ID: 314
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5788,12 +6189,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 299
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5803,7 +6198,25 @@ Types:
       ID: 303
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 305
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 344
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5829,7 +6242,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5848,7 +6261,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5867,7 +6280,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 350
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5886,7 +6299,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5902,7 +6315,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5918,7 +6331,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5934,7 +6347,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5950,7 +6363,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5965,32 +6378,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 331
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 339
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 345
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 357
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 361
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 202
@@ -6136,10 +6549,10 @@ Types:
       ID: 198
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7996,7 +8409,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 43648
       GoKind: 26
-MaxTypeID: 367
+MaxTypeID: 383
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8074,7 +8487,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8104,7 +8517,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8119,7 +8532,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8134,7 +8547,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.PointerChainArg]
+          Type: 355 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7eb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 356 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7ee8", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.bigMapArg]
+          Type: 209 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xb8cb0", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 207 EventRootType Probe[main.bigMapArg]Return
+          Type: 210 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xb8d20", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 250 EventRootType Probe[main.condBool]
+          Type: 253 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 251 EventRootType Probe[main.condBool]Return
+          Type: 254 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 252 EventRootType Probe[main.condBool]
+          Type: 255 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 253 EventRootType Probe[main.condBool]Return
+          Type: 256 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 254 EventRootType Probe[main.condBool]
+          Type: 257 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 255 EventRootType Probe[main.condBool]Return
+          Type: 258 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 246 EventRootType Probe[main.condFloat32]
+          Type: 249 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0xb92c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 247 EventRootType Probe[main.condFloat32]Return
+          Type: 250 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0xb9324", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 248 EventRootType Probe[main.condFloat64]
+          Type: 251 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0xb9368", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 249 EventRootType Probe[main.condFloat64]Return
+          Type: 252 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0xb93c4", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 214 EventRootType Probe[main.condInt16]
+          Type: 217 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
           Condition:
             Type: 96 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 215 EventRootType Probe[main.condInt16]Return
+          Type: 218 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb8ec0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 216 EventRootType Probe[main.condInt16]
+          Type: 219 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 217 EventRootType Probe[main.condInt16]Return
+          Type: 220 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xb8ec0", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 218 EventRootType Probe[main.condInt32]
+          Type: 221 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 219 EventRootType Probe[main.condInt32]Return
+          Type: 222 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 220 EventRootType Probe[main.condInt32]
+          Type: 223 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 221 EventRootType Probe[main.condInt32]Return
+          Type: 224 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 222 EventRootType Probe[main.condInt32]
+          Type: 225 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 223 EventRootType Probe[main.condInt32]Return
+          Type: 226 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 224 EventRootType Probe[main.condInt64]
+          Type: 227 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb8fa8", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 225 EventRootType Probe[main.condInt64]Return
+          Type: 228 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb9000", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 226 EventRootType Probe[main.condInt64]
+          Type: 229 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb8fa8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 227 EventRootType Probe[main.condInt64]Return
+          Type: 230 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xb9000", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 210 EventRootType Probe[main.condInt8]
+          Type: 213 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb8dc8", Frameless: false}]
           Condition:
             Type: 17 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 211 EventRootType Probe[main.condInt8]Return
+          Type: 214 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 212 EventRootType Probe[main.condInt8]
+          Type: 215 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb8dc8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 213 EventRootType Probe[main.condInt8]Return
+          Type: 216 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 294 EventRootType Probe[main.condLine]Line
+          Type: 297 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 295 EventRootType Probe[main.condLine]Line
+          Type: 298 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condNilPtrStruct]
+          Type: 285 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 286 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condNilPtrStruct]
+          Type: 287 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condOnly]
+          Type: 293 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condOnly]Return
+          Type: 294 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 292 EventRootType Probe[main.condOnly]
+          Type: 295 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 293 EventRootType Probe[main.condOnly]Return
+          Type: 296 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condPtrStructArg]
+          Type: 279 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 280 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condPtrStructArg]
+          Type: 281 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condPtrStructArg]
+          Type: 283 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condReturnAndLocal]
+          Type: 289 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 290 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condReturnAndLocal]
+          Type: 291 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 256 EventRootType Probe[main.condString]
+          Type: 259 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 257 EventRootType Probe[main.condString]Return
+          Type: 260 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 258 EventRootType Probe[main.condString]
+          Type: 261 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 259 EventRootType Probe[main.condString]Return
+          Type: 262 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 260 EventRootType Probe[main.condString]
+          Type: 263 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 261 EventRootType Probe[main.condString]Return
+          Type: 264 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 262 EventRootType Probe[main.condString]
+          Type: 265 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 263 EventRootType Probe[main.condString]Return
+          Type: 266 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 264 EventRootType Probe[main.condStructArg]
+          Type: 267 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 265 EventRootType Probe[main.condStructArg]Return
+          Type: 268 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 266 EventRootType Probe[main.condStructArg]
+          Type: 269 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 267 EventRootType Probe[main.condStructArg]Return
+          Type: 270 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condStructArg]
+          Type: 271 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 16 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condStructArg]Return
+          Type: 272 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condStructArg]
+          Type: 273 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condStructArg]Return
+          Type: 274 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 275 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 276 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condStructArg]
+          Type: 277 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condStructArg]Return
+          Type: 278 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 234 EventRootType Probe[main.condUint16]
+          Type: 237 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb90e8", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 235 EventRootType Probe[main.condUint16]Return
+          Type: 238 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb9140", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 236 EventRootType Probe[main.condUint16]
+          Type: 239 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb90e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 237 EventRootType Probe[main.condUint16]Return
+          Type: 240 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xb9140", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 238 EventRootType Probe[main.condUint32]
+          Type: 241 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb9188", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 239 EventRootType Probe[main.condUint32]Return
+          Type: 242 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb91e0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 240 EventRootType Probe[main.condUint32]
+          Type: 243 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb9188", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 241 EventRootType Probe[main.condUint32]Return
+          Type: 244 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xb91e0", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 242 EventRootType Probe[main.condUint64]
+          Type: 245 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb9228", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 243 EventRootType Probe[main.condUint64]Return
+          Type: 246 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb9280", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 244 EventRootType Probe[main.condUint64]
+          Type: 247 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb9228", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 245 EventRootType Probe[main.condUint64]Return
+          Type: 248 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xb9280", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 228 EventRootType Probe[main.condUint8]
+          Type: 231 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 229 EventRootType Probe[main.condUint8]Return
+          Type: 232 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 230 EventRootType Probe[main.condUint8]
+          Type: 233 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 231 EventRootType Probe[main.condUint8]Return
+          Type: 234 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 232 EventRootType Probe[main.condUint8]
+          Type: 235 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 233 EventRootType Probe[main.condUint8]Return
+          Type: 236 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.inlined]
+          Type: 353 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7cd0"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 299 EventRootType Probe[main.inlined]Return
+          Type: 354 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb8bac", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 187 EventRootType Probe[main.intArg]
+          Type: 190 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xb88a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 188 EventRootType Probe[main.intArg]Return
+          Type: 191 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xb88dc", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 197 EventRootType Probe[main.intArrayArg]
+          Type: 200 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 198 EventRootType Probe[main.intArrayArg]Return
+          Type: 201 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 203 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 206 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xb8b50", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 195 EventRootType Probe[main.intSliceArg]
+          Type: 198 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xb8988", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 196 EventRootType Probe[main.intSliceArg]Return
+          Type: 199 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xb89c0", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 343 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 344 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xba244", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 347 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xba28c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 348 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xba348", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 345 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 346 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xba244", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 349 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xba28c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 350 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xba348", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 315 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 316 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 317 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 318 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xba168", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 337 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 338 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xba168", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 339 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 340 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xba168", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 341 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xba09c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 342 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xba168", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 299 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 300 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 301 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 302 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 325 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 327 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 329 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 330 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 331 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 332 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 333 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 189 EventRootType Probe[main.stringArg]
+          Type: 192 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 190 EventRootType Probe[main.stringArg]Return
+          Type: 193 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 191 EventRootType Probe[main.stringArg]
+          Type: 194 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 192 EventRootType Probe[main.stringArg]Return
+          Type: 195 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.mapArg]
+          Type: 207 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xb8c38", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.mapArg]Return
+          Type: 208 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xb8c64", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.noArgs]
+          Type: 211 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xb8d58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 209 EventRootType Probe[main.noArgs]Return
+          Type: 212 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xb8d8c", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 193 EventRootType Probe[main.stringArg]
+          Type: 196 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 194 EventRootType Probe[main.stringArg]Return
+          Type: 197 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 201 EventRootType Probe[main.stringArrayArg]
+          Type: 204 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 202 EventRootType Probe[main.stringArrayArg]Return
+          Type: 205 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xb8b38", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 199 EventRootType Probe[main.stringSliceArg]
+          Type: 202 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xb8a78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 200 EventRootType Probe[main.stringSliceArg]Return
+          Type: 203 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xb8ab0", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 351 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xba390", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 352 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xba508", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2418,12 +3085,322 @@ Subprograms:
                   Op: {CfaOffset: 96}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0xb9bc0..0xb9ca0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9bc0..0xb9c10
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb9c10..0xb9c14
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xb9c14..0xb9ca0
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9bc0..0xb9c08
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xb9c08..0xb9c18
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xb9c18..0xb9ca0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0xb9ca0..0xb9d90]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 107 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xb9ca0..0xb9cfc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9cfc..0xb9d00
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9d00..0xb9d04
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9d04..0xb9d90
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9ca0..0xb9cf0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xb9cf0..0xb9cf4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xb9cf4..0xb9d90
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0xb9d90..0xb9e80]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 111 GoMapType map[string]int
+          Locations:
+            - Range: 0xb9d90..0xb9ddc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb9ddc..0xb9e80
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9d90..0xb9de0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9de0..0xb9de4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9de4..0xb9e80
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0xb9e80..0xb9f50]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 95 PointerType *string
+          Locations:
+            - Range: 0xb9e80..0xb9ecc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xb9ecc..0xb9f50
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9e80..0xb9ed0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xb9ed0..0xb9ed4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xb9ed4..0xb9f50
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xb9f50..0xba080]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 124 StructureType main.lenFields
+          Locations:
+            - Range: 0xb9f50..0xba080
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xb9f50..0xb9fcc
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xb9fcc..0xb9fd0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xb9fd0..0xba080
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xba080..0xba190]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 PointerType *main.lenFields
+          Locations:
+            - Range: 0xba080..0xba0cc
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba0cc..0xba190
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba080..0xba0d0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xba0d0..0xba0d4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xba0d4..0xba190
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xba190..0xba270]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xba190..0xba1e4
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xba1e4..0xba270
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba190..0xba1e8
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xba1e8..0xba1ec
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xba1ec..0xba270
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0xba270..0xba370]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 121 StructureType main.condFields
+          Locations:
+            - Range: 0xba270..0xba370
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xba270..0xba2e0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xba2e0..0xba2e4
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xba2e4..0xba370
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0xba370..0xba520]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0xba370..0xba508
               Pieces: []
@@ -2432,7 +3409,7 @@ Subprograms:
             - Range: 0xba509..0xba520
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0xb8b60..0xb8bd0]
       InlinePCRanges:
@@ -2447,7 +3424,7 @@ Subprograms:
             - Range: 0xb8b60..0xb8b80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2455,12 +3432,12 @@ Subprograms:
           RootRanges: [0xb7b40..0xb8890]
       Variables:
         - Name: ptr
-          Type: 129 PointerType *****int
+          Type: 132 PointerType *****int
           Locations:
             - Range: 0xb7e88..0xb7ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2468,35 +3445,35 @@ Subprograms:
           RootRanges: [0xb7b40..0xb8890]
       Variables:
         - Name: ptr
-          Type: 131 PointerType **int
+          Type: 134 PointerType **int
           Locations:
             - Range: 0xb7ee8..0xb7f18
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 129
+      ID: 132
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 36992
       GoKind: 22
-      Pointee: 130 PointerType ****int
+      Pointee: 133 PointerType ****int
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 36928
       GoKind: 22
-      Pointee: 186 PointerType ***int
+      Pointee: 189 PointerType ***int
     - __kind: PointerType
-      ID: 186
+      ID: 189
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 36864
       GoKind: 22
-      Pointee: 131 PointerType **int
+      Pointee: 134 PointerType **int
     - __kind: PointerType
-      ID: 131
+      ID: 134
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 36800
@@ -2509,10 +3486,10 @@ Types:
       GoKind: 22
       Pointee: 64 PointerType *runtime.p
     - __kind: PointerType
-      ID: 172
+      ID: 175
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 173 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 176 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 114
       Name: '**table<string,int>'
@@ -2524,20 +3501,27 @@ Types:
       ByteSize: 8
       Pointee: 120 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 127
+      ID: 130
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 128 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 131 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []*runtime.p.array
+      Pointee: 142 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 142
+      ID: 125
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 36736
+      GoKind: 22
+      Pointee: 107 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 145
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []int.array
+      Pointee: 144 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 39
       Name: '*[]runtime.ancestorInfo'
@@ -2546,20 +3530,20 @@ Types:
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 144
+      ID: 147
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 143 GoSliceDataType []string.array
+      Pointee: 146 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 134 GoSliceDataType []uint8.array
+      Pointee: 137 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 137
+      ID: 140
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 136 GoSliceDataType []uintptr.array
+      Pointee: 139 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 11
       Name: '*bool'
@@ -2610,12 +3594,12 @@ Types:
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
-      ID: 159
+      ID: 162
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 28352
       GoKind: 22
-      Pointee: 160 StructureType main.bigStruct
+      Pointee: 163 StructureType main.bigStruct
     - __kind: PointerType
       ID: 123
       Name: '*main.condFields'
@@ -2624,10 +3608,17 @@ Types:
       GoKind: 22
       Pointee: 121 StructureType main.condFields
     - __kind: PointerType
-      ID: 170
+      ID: 126
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 28224
+      GoKind: 22
+      Pointee: 124 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 173
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 174 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 112
       Name: '*map<string,int>'
@@ -2639,30 +3630,30 @@ Types:
       ByteSize: 8
       Pointee: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 125
+      ID: 128
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 147
+      ID: 150
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 148 StructureType noalg.map.group[string]int
+      Pointee: 151 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 155
+      ID: 158
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 156 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 165
+      ID: 168
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 26
       Name: '*runtime._defer'
@@ -2711,7 +3702,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 69408
       GoKind: 22
-      Pointee: 138 UnresolvedPointeeType runtime.p
+      Pointee: 141 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
@@ -2748,30 +3739,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 132 GoStringDataType string.str
+      Pointee: 135 GoStringDataType string.str
     - __kind: PointerType
-      ID: 173
+      ID: 176
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 176 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 179 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 115
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 145 StructureType table<string,int>
+      Pointee: 148 StructureType table<string,int>
     - __kind: PointerType
       ID: 120
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 153 StructureType table<string,main.bigStruct>
+      Pointee: 156 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 128
+      ID: 131
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 163 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 166 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 105
       Name: '*uint'
@@ -2815,7 +3806,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 300
+      ID: 355
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2824,24 +3815,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 129 PointerType *****int
+            Type: 132 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 301
+      ID: 356
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2850,14 +3841,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 131 PointerType **int
+            Type: 134 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2883,10 +3874,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2902,7 +3893,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2918,7 +3909,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 257
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -2944,16 +3935,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 246
+      ID: 249
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2969,10 +3960,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 247
+      ID: 250
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2988,10 +3979,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3007,7 +3998,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 216
+      ID: 219
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3033,13 +4024,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 215
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 217
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 218
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 220
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 221
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3055,7 +4046,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
+      ID: 223
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3071,7 +4062,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 222
+      ID: 225
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3097,16 +4088,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 219
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 221
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 223
+      ID: 222
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 224
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 226
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 227
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3122,7 +4113,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 226
+      ID: 229
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3148,13 +4139,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3170,7 +4161,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3196,13 +4187,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 213
+      ID: 216
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 297
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3218,7 +4209,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 298
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3244,7 +4235,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3260,7 +4251,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3286,71 +4277,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 285
+      ID: 288
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 290
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 292
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 291
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 293
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 295
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 294
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 296
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 279
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3366,7 +4357,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3382,7 +4373,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3408,16 +4399,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 284
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 286
+      ID: 289
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3433,7 +4424,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 288
+      ID: 291
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3459,10 +4450,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 287
+      ID: 290
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3478,7 +4469,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3494,7 +4485,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3502,6 +4493,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 263
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3511,70 +4554,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 260
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 262
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 257
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 259
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 261
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 263
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 264
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 266
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 267
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3590,7 +4581,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 266
+      ID: 269
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3606,7 +4597,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 268
+      ID: 271
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3622,7 +4613,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3638,7 +4629,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3654,7 +4645,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3680,25 +4671,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 268
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 270
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 269
+      ID: 272
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 271
+      ID: 274
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3714,7 +4705,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3740,13 +4731,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 237
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 238
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 240
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 241
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3762,7 +4753,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 240
+      ID: 243
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3788,13 +4779,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 239
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 241
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 242
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 244
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 245
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3810,7 +4801,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
+      ID: 247
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3836,13 +4827,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 243
+      ID: 246
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 228
+      ID: 231
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3858,7 +4849,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3874,7 +4865,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3900,16 +4891,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 229
+      ID: 232
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 353
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3921,14 +4912,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 299
+      ID: 354
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 187
+      ID: 190
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3944,10 +4935,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 188
+      ID: 191
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3963,10 +4954,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3982,10 +4973,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 343
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 121 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 111 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 95 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 107 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 299
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 301
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 302
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 124 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 207
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4011,16 +5526,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 209
+      ID: 212
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 189
+      ID: 192
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4036,10 +5551,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 191
+      ID: 194
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4065,16 +5580,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 190
+      ID: 193
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4090,7 +5605,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4106,10 +5621,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 202
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4125,13 +5640,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 351
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 297
+      ID: 352
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4140,10 +5655,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 127 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4156,7 +5671,7 @@ Types:
       HasCount: true
       Element: 93 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 185
+      ID: 188
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 49408
@@ -4297,37 +5812,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []*runtime.p.array
+      Data: 142 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 142
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 64 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 183
+      ID: 186
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 173 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 176 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 151
+      ID: 154
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 115 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 161
+      ID: 164
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 120 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 174
+      ID: 177
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 128 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 131 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 107
       Name: '[]int'
@@ -4344,37 +5859,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 141 GoSliceDataType []int.array
+      Data: 144 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 144
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 184
+      ID: 187
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 152
+      ID: 155
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 148 StructureType noalg.map.group[string]int
+      Element: 151 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 162
+      ID: 165
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 156 StructureType noalg.map.group[string]main.bigStruct
+      Element: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 175
+      ID: 178
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 40
       Name: '[]runtime.ancestorInfo'
@@ -4395,9 +5910,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 143 GoSliceDataType []string.array
+      Data: 146 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 143
+      ID: 146
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4418,9 +5933,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 134 GoSliceDataType []uint8.array
+      Data: 137 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 134
+      ID: 137
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4441,9 +5956,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 136 GoSliceDataType []uintptr.array
+      Data: 139 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 136
+      ID: 139
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4504,61 +6019,61 @@ Types:
       GoRuntimeType: 60128
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 177
+      ID: 180
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 178 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 181 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 184 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 187 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 146
+      ID: 149
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 147 PointerType *noalg.map.group[string]int
+          Type: 150 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 148 StructureType noalg.map.group[string]int
-      GroupSliceType: 152 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 151 StructureType noalg.map.group[string]int
+      GroupSliceType: 155 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 154
+      ID: 157
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 155 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 158 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 156 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 162 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 159 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 165 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 164
+      ID: 167
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 165 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 168 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 175 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 178 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4689,14 +6204,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 182
+      ID: 185
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 73888
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 160
+      ID: 163
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 128160
@@ -4725,7 +6240,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 185 ArrayType [128]uint8
+          Type: 188 ArrayType [128]uint8
     - __kind: StructureType
       ID: 121
       Name: main.condFields
@@ -4772,8 +6287,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 122 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 124
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 122304
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 107 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 111 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 95 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 125 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 122 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 171
+      ID: 174
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4786,7 +6326,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 172 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 175 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4805,8 +6345,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 183 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 179 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 186 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 182 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 113
       Name: map<string,int>
@@ -4840,8 +6380,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 151 GoSliceDataType []*table<string,int>.array
-      GroupType: 148 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 154 GoSliceDataType []*table<string,int>.array
+      GroupType: 151 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 118
       Name: map<string,main.bigStruct>
@@ -4875,10 +6415,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 161 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 156 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 164 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 159 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 126
+      ID: 129
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4891,7 +6431,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 127 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 130 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4910,15 +6450,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 174 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 166 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 177 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 169 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 169
+      ID: 172
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 72096
       GoKind: 21
-      HeaderType: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 174 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
@@ -4934,50 +6474,50 @@ Types:
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 124
+      ID: 127
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 72480
       GoKind: 21
-      HeaderType: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 129 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 180
+      ID: 183
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 49312
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 181 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 184 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 157
+      ID: 160
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 49504
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 158 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 161 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 149
+      ID: 152
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 48928
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 150 StructureType noalg.struct { key string; elem int }
+      Element: 153 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 167
+      ID: 170
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 49696
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 168 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 171 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 179
+      ID: 182
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 79904
@@ -4988,9 +6528,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 180 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 183 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 148
+      ID: 151
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 79648
@@ -5001,9 +6541,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 149 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 152 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 156
+      ID: 159
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 80160
@@ -5014,9 +6554,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 157 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 160 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 166
+      ID: 169
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 80672
@@ -5027,9 +6567,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 167 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 170 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 181
+      ID: 184
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 79776
@@ -5040,9 +6580,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 182 StructureType main.aStructNotUsedAsAnArgument
+          Type: 185 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 80032
@@ -5053,9 +6593,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 159 PointerType *main.bigStruct
+          Type: 162 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 79520
@@ -5068,7 +6608,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 168
+      ID: 171
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 80544
@@ -5079,7 +6619,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 169 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 172 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 27
       Name: runtime._defer
@@ -5725,7 +7265,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 138
+      ID: 141
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -5850,18 +7390,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 133 PointerType *string.str
+          Type: 136 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 132 GoStringDataType string.str
+      Data: 135 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 132
+      ID: 135
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 176
+      ID: 179
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5883,9 +7423,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 177 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 180 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 145
+      ID: 148
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -5907,9 +7447,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 146 GoSwissMapGroupsType groupReference<string,int>
+          Type: 149 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -5931,9 +7471,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 154 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 157 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5955,7 +7495,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 164 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 167 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 10
       Name: uint
@@ -5998,7 +7538,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45024
       GoKind: 26
-MaxTypeID: 301
+MaxTypeID: 356
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6229,6 +7769,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 300 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xb7ea8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7eb0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'ptr: {ptr}'
@@ -34,7 +34,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 301 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xb7edc", Frameless: false}]
+          InjectionPoints: [{PC: "0xb7ee8", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xb8810", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8cb0", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 207 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0xb8880", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8d20", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 250 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 251 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb8fc8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 252 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 253 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb8fc8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 254 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xb8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9408", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 255 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xb8fc8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9468", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 246 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
+          InjectionPoints: [{PC: "0xb92c8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 247 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0xb8e84", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9324", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 248 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0xb8ec8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9368", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 249 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0xb8f24", Frameless: false}]
+          InjectionPoints: [{PC: "0xb93c4", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 214 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb89c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
           Condition:
             Type: 96 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 215 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb8a20", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8ec0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 216 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xb89c8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 217 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xb8a20", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8ec0", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 218 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb8a68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 219 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb8ac0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 220 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb8a68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 221 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb8ac0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 222 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xb8a68", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 223 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xb8ac0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8f60", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 224 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb8b08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8fa8", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 225 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb8b60", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9000", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 226 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xb8b08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8fa8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 227 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xb8b60", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9000", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 210 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb8928", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8dc8", Frameless: false}]
           Condition:
             Type: 17 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 211 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb8988", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 212 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xb8928", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8dc8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 213 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xb8988", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8e28", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 294 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb9498", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 295 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xb9498", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 282 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb92a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 283 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb9310", Frameless: false}]
+          InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 284 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xb92a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 285 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xb9310", Frameless: false}]
+          InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 290 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 291 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb9440", Frameless: false}]
+          InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 292 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xb93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 293 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xb9440", Frameless: false}]
+          InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 276 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb919c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 277 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb925c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 278 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb919c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 279 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb925c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 280 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xb919c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 281 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xb925c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 286 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb9358", Frameless: false}]
+          InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 287 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb93b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 288 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xb9358", Frameless: false}]
+          InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 289 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xb93b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 256 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb9008", Frameless: false}]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 257 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb9064", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 258 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb9008", Frameless: false}]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 259 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb9064", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 260 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb9008", Frameless: false}]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 261 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb9064", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 262 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xb9008", Frameless: false}]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 263 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xb9064", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 264 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 265 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 266 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 267 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 268 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 16 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 269 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 270 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 271 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 272 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 273 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 274 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xb90ac", Frameless: false}]
+          InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 275 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xb9160", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 234 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb8c48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb90e8", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 235 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb8ca0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9140", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 236 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xb8c48", Frameless: false}]
+          InjectionPoints: [{PC: "0xb90e8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 237 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xb8ca0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9140", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 238 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb8ce8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9188", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 239 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb8d40", Frameless: false}]
+          InjectionPoints: [{PC: "0xb91e0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 240 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xb8ce8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9188", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 241 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xb8d40", Frameless: false}]
+          InjectionPoints: [{PC: "0xb91e0", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 242 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb8d88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9228", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 243 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb8de0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9280", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 244 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xb8d88", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9228", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 245 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xb8de0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9280", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 228 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb8ba8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 229 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb8c08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 230 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb8ba8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 231 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb8c08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 232 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xb8ba8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 233 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xb8c08", Frameless: false}]
+          InjectionPoints: [{PC: "0xb90a8", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0xb7cd0"
               Frameless: false
-            - PC: "0xb86d8"
+            - PC: "0xb8b78"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 299 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0xb870c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8bac", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 187 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xb8408", Frameless: false}]
+          InjectionPoints: [{PC: "0xb88a8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 188 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0xb843c", Frameless: false}]
+          InjectionPoints: [{PC: "0xb88dc", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 197 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xb8568", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8a08", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 198 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0xb85a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8a48", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 203 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xb86b0", Frameless: true}]
+          InjectionPoints: [{PC: "0xb8b50", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 195 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xb84e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8988", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 196 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0xb8520", Frameless: false}]
+          InjectionPoints: [{PC: "0xb89c0", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 189 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb8478", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 190 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb84b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 191 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb8478", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 192 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb84b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xb8798", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8c38", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0xb87c4", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8c64", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xb88b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8d58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 209 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0xb88ec", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8d8c", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 193 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xb8478", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8918", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 194 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xb84b0", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8950", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 201 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xb8658", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8af8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 202 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0xb8698", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8b38", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 199 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xb85d8", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8a78", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 200 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xb8610", Frameless: false}]
+          InjectionPoints: [{PC: "0xb8ab0", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 296 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xb9730", Frameless: false}]
+          InjectionPoints: [{PC: "0xba390", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 297 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0xb98a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xba508", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xb83f0..0xb8460]
+      OutOfLinePCRanges: [0xb8890..0xb8900]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb83f0..0xb8410
+            - Range: 0xb8890..0xb88b0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xb8460..0xb84d0]
+      OutOfLinePCRanges: [0xb8900..0xb8970]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8460..0xb8484
+            - Range: 0xb8900..0xb8924
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xb84d0..0xb8550]
+      OutOfLinePCRanges: [0xb8970..0xb89f0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb84d0..0xb84f4
+            - Range: 0xb8970..0xb8994
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xb8550..0xb85c0]
+      OutOfLinePCRanges: [0xb89f0..0xb8a60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 108 ArrayType [3]int
           Locations:
-            - Range: 0xb8550..0xb85c0
+            - Range: 0xb89f0..0xb8a60
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xb85c0..0xb8640]
+      OutOfLinePCRanges: [0xb8a60..0xb8ae0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 109 GoSliceHeaderType []string
           Locations:
-            - Range: 0xb85c0..0xb85e4
+            - Range: 0xb8a60..0xb8a84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xb8640..0xb86b0]
+      OutOfLinePCRanges: [0xb8ae0..0xb8b50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xb8640..0xb86b0
+            - Range: 0xb8ae0..0xb8b50
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xb86b0..0xb86c0]
+      OutOfLinePCRanges: [0xb8b50..0xb8b60]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 110 ArrayType [3]string
           Locations:
-            - Range: 0xb86b0..0xb86c0
+            - Range: 0xb8b50..0xb8b60
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xb8780..0xb87f0]
+      OutOfLinePCRanges: [0xb8c20..0xb8c90]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xb8780..0xb87b4
+            - Range: 0xb8c20..0xb8c54
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xb87f0..0xb88a0]
+      OutOfLinePCRanges: [0xb8c90..0xb8d40]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xb87f0..0xb8828
+            - Range: 0xb8c90..0xb8cc8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb8828..0xb88a0
+            - Range: 0xb8cc8..0xb8d40
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xb88a0..0xb8910]
+      OutOfLinePCRanges: [0xb8d40..0xb8db0]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xb8910..0xb89b0]
+      OutOfLinePCRanges: [0xb8db0..0xb8e50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType int8
           Locations:
-            - Range: 0xb8910..0xb8954
+            - Range: 0xb8db0..0xb8df4
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8910..0xb8958
+            - Range: 0xb8db0..0xb8df8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8958..0xb895c
+            - Range: 0xb8df8..0xb8dfc
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,25 +1827,25 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xb89b0..0xb8a50]
+      OutOfLinePCRanges: [0xb8e50..0xb8ef0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 96 BaseType int16
           Locations:
-            - Range: 0xb89b0..0xb89dc
+            - Range: 0xb8e50..0xb8e7c
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb89b0..0xb89dc
+            - Range: 0xb8e50..0xb8e7c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb89dc..0xb8a50
+            - Range: 0xb8e7c..0xb8ef0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1854,25 +1854,25 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xb8a50..0xb8af0]
+      OutOfLinePCRanges: [0xb8ef0..0xb8f90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xb8a50..0xb8a7c
+            - Range: 0xb8ef0..0xb8f1c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8a50..0xb8a7c
+            - Range: 0xb8ef0..0xb8f1c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8a7c..0xb8af0
+            - Range: 0xb8f1c..0xb8f90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1881,25 +1881,25 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xb8af0..0xb8b90]
+      OutOfLinePCRanges: [0xb8f90..0xb9030]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xb8af0..0xb8b1c
+            - Range: 0xb8f90..0xb8fbc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8af0..0xb8b1c
+            - Range: 0xb8f90..0xb8fbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8b1c..0xb8b90
+            - Range: 0xb8fbc..0xb9030
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1908,25 +1908,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xb8b90..0xb8c30]
+      OutOfLinePCRanges: [0xb9030..0xb90d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xb8b90..0xb8bd4
+            - Range: 0xb9030..0xb9074
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8b90..0xb8bd8
+            - Range: 0xb9030..0xb9078
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8bd8..0xb8bdc
+            - Range: 0xb9078..0xb907c
               Pieces:
                 - Size: 8
                   Op: null
@@ -1935,25 +1935,25 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xb8c30..0xb8cd0]
+      OutOfLinePCRanges: [0xb90d0..0xb9170]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xb8c30..0xb8c5c
+            - Range: 0xb90d0..0xb90fc
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8c30..0xb8c5c
+            - Range: 0xb90d0..0xb90fc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8c5c..0xb8cd0
+            - Range: 0xb90fc..0xb9170
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1962,25 +1962,25 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xb8cd0..0xb8d70]
+      OutOfLinePCRanges: [0xb9170..0xb9210]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xb8cd0..0xb8cfc
+            - Range: 0xb9170..0xb919c
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8cd0..0xb8cfc
+            - Range: 0xb9170..0xb919c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8cfc..0xb8d70
+            - Range: 0xb919c..0xb9210
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1989,25 +1989,25 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xb8d70..0xb8e10]
+      OutOfLinePCRanges: [0xb9210..0xb92b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xb8d70..0xb8d9c
+            - Range: 0xb9210..0xb923c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8d70..0xb8d9c
+            - Range: 0xb9210..0xb923c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8d9c..0xb8e10
+            - Range: 0xb923c..0xb92b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2016,31 +2016,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xb8e10..0xb8eb0]
+      OutOfLinePCRanges: [0xb92b0..0xb9350]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 18 BaseType float32
           Locations:
-            - Range: 0xb8e10..0xb8e40
+            - Range: 0xb92b0..0xb92e0
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8e10..0xb8e3c
+            - Range: 0xb92b0..0xb92dc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8e3c..0xb8e40
+            - Range: 0xb92dc..0xb92e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8e40..0xb8eb0
+            - Range: 0xb92e0..0xb9350
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2049,31 +2049,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xb8eb0..0xb8f50]
+      OutOfLinePCRanges: [0xb9350..0xb93f0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 16 BaseType float64
           Locations:
-            - Range: 0xb8eb0..0xb8ee0
+            - Range: 0xb9350..0xb9380
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8eb0..0xb8edc
+            - Range: 0xb9350..0xb937c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb8edc..0xb8ee0
+            - Range: 0xb937c..0xb9380
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xb8ee0..0xb8f50
+            - Range: 0xb9380..0xb93f0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2082,25 +2082,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xb8f50..0xb8ff0]
+      OutOfLinePCRanges: [0xb93f0..0xb9490]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xb8f50..0xb8f94
+            - Range: 0xb93f0..0xb9434
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8f50..0xb8f98
+            - Range: 0xb93f0..0xb9438
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb8f98..0xb8f9c
+            - Range: 0xb9438..0xb943c
               Pieces:
                 - Size: 8
                   Op: null
@@ -2109,13 +2109,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xb8ff0..0xb9090]
+      OutOfLinePCRanges: [0xb9490..0xb9530]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8ff0..0xb9020
+            - Range: 0xb9490..0xb94c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2125,13 +2125,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb8ff0..0xb9020
+            - Range: 0xb9490..0xb94c0
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xb9020..0xb9090
+            - Range: 0xb94c0..0xb9530
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2140,31 +2140,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xb9090..0xb9180]
+      OutOfLinePCRanges: [0xb9530..0xb9620]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0xb9090..0xb9180
+            - Range: 0xb9530..0xb9620
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9090..0xb90d0
+            - Range: 0xb9530..0xb9570
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb90d0..0xb90d4
+            - Range: 0xb9570..0xb9574
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb90d4..0xb9180
+            - Range: 0xb9574..0xb9620
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2173,27 +2173,27 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xb9180..0xb9290]
+      OutOfLinePCRanges: [0xb9620..0xb9730]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0xb9180..0xb91c4
+            - Range: 0xb9620..0xb9664
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb91c4..0xb9290
+            - Range: 0xb9664..0xb9730
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9180..0xb91c8
+            - Range: 0xb9620..0xb9668
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb91c8..0xb9290
+            - Range: 0xb9668..0xb9730
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2202,25 +2202,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xb9290..0xb9340]
+      OutOfLinePCRanges: [0xb9730..0xb97e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 123 PointerType *main.condFields
           Locations:
-            - Range: 0xb9290..0xb92dc
+            - Range: 0xb9730..0xb977c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9290..0xb92e0
+            - Range: 0xb9730..0xb9780
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb92e0..0xb92e4
+            - Range: 0xb9780..0xb9784
               Pieces:
                 - Size: 8
                   Op: null
@@ -2229,60 +2229,60 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xb9340..0xb93d0]
+      OutOfLinePCRanges: [0xb97e0..0xb9870]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9340..0xb935c
+            - Range: 0xb97e0..0xb97fc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9340..0xb9370
+            - Range: 0xb97e0..0xb9810
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9340..0xb93b0
+            - Range: 0xb97e0..0xb9850
               Pieces: []
-            - Range: 0xb93b0..0xb93b1
+            - Range: 0xb9850..0xb9851
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb93b1..0xb93d0
+            - Range: 0xb9851..0xb9870
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb935c..0xb9380
+            - Range: 0xb97fc..0xb9820
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9380..0xb93d0
+            - Range: 0xb9820..0xb9870
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xb93d0..0xb9470]
+      OutOfLinePCRanges: [0xb9870..0xb9910]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb93d0..0xb93fc
+            - Range: 0xb9870..0xb989c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb93d0..0xb93fc
+            - Range: 0xb9870..0xb989c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb93fc..0xb9470
+            - Range: 0xb989c..0xb9910
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2291,27 +2291,27 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xb9470..0xb9530]
+      OutOfLinePCRanges: [0xb9910..0xb99d0]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9470..0xb9498
+            - Range: 0xb9910..0xb9938
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb9498..0xb9530
+            - Range: 0xb9938..0xb99d0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9470..0xb94a8
+            - Range: 0xb9910..0xb9948
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb94a8..0xb9530
+            - Range: 0xb9948..0xb99d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2321,18 +2321,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb9498..0xb94a8
+            - Range: 0xb9938..0xb9948
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xb9530..0xb95e0]
+      OutOfLinePCRanges: [0xb99d0..0xb9a80]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 107 GoSliceHeaderType []int
           Locations:
-            - Range: 0xb9530..0xb9560
+            - Range: 0xb99d0..0xb9a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2344,13 +2344,13 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9530..0xb9560
+            - Range: 0xb99d0..0xb9a00
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xb9560..0xb95e0
+            - Range: 0xb9a00..0xb9a80
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -2359,25 +2359,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xb95e0..0xb9670]
+      OutOfLinePCRanges: [0xb9a80..0xb9b10]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 111 GoMapType map[string]int
           Locations:
-            - Range: 0xb95e0..0xb9614
+            - Range: 0xb9a80..0xb9ab4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb95e0..0xb9618
+            - Range: 0xb9a80..0xb9ab8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xb9618..0xb961c
+            - Range: 0xb9ab8..0xb9abc
               Pieces:
                 - Size: 8
                   Op: null
@@ -2386,31 +2386,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xb9670..0xb9710]
+      OutOfLinePCRanges: [0xb9b10..0xb9bb0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 121 StructureType main.condFields
           Locations:
-            - Range: 0xb9670..0xb9710
+            - Range: 0xb9b10..0xb9bb0
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xb9670..0xb96a0
+            - Range: 0xb9b10..0xb9b40
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xb96a0..0xb96a4
+            - Range: 0xb9b40..0xb9b44
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xb96a4..0xb9710
+            - Range: 0xb9b44..0xb9bb0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2419,58 +2419,58 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xb9710..0xb98c0]
+      OutOfLinePCRanges: [0xba370..0xba520]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 124 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xb9710..0xb98a8
+            - Range: 0xba370..0xba508
               Pieces: []
-            - Range: 0xb98a8..0xb98a9
+            - Range: 0xba508..0xba509
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xb98a9..0xb98c0
+            - Range: 0xba509..0xba520
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0xb86c0..0xb8730]
+      OutOfLinePCRanges: [0xb8b60..0xb8bd0]
       InlinePCRanges:
-        - Ranges: [0xb7cd0..0xb7d04]
-          RootRanges: [0xb7b40..0xb83f0]
+        - Ranges: [0xb7cd0..0xb7d08]
+          RootRanges: [0xb7b40..0xb8890]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xb7cd0..0xb7d04
+            - Range: 0xb7cd0..0xb7d08
               Pieces: []
-            - Range: 0xb86c0..0xb86e0
+            - Range: 0xb8b60..0xb8b80
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb7ea8..0xb7ed4]
-          RootRanges: [0xb7b40..0xb83f0]
+        - Ranges: [0xb7eb0..0xb7ee0]
+          RootRanges: [0xb7b40..0xb8890]
       Variables:
         - Name: ptr
           Type: 129 PointerType *****int
           Locations:
-            - Range: 0xb7e80..0xb7ec4
+            - Range: 0xb7e88..0xb7ed0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 35
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xb7edc..0xb7f08]
-          RootRanges: [0xb7b40..0xb83f0]
+        - Ranges: [0xb7ee8..0xb7f18]
+          RootRanges: [0xb7b40..0xb8890]
       Variables:
         - Name: ptr
           Type: 131 PointerType **int
           Locations:
-            - Range: 0xb7edc..0xb7f08
+            - Range: 0xb7ee8..0xb7f18
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
@@ -2478,28 +2478,28 @@ Types:
       ID: 129
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 36768
+      GoRuntimeType: 36992
       GoKind: 22
       Pointee: 130 PointerType ****int
     - __kind: PointerType
       ID: 130
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 36704
+      GoRuntimeType: 36928
       GoKind: 22
       Pointee: 186 PointerType ***int
     - __kind: PointerType
       ID: 186
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 36640
+      GoRuntimeType: 36864
       GoKind: 22
       Pointee: 131 PointerType **int
     - __kind: PointerType
       ID: 131
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 36576
+      GoRuntimeType: 36800
       GoKind: 22
       Pointee: 100 PointerType *int
     - __kind: PointerType
@@ -2542,7 +2542,7 @@ Types:
       ID: 39
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 41568
+      GoRuntimeType: 41728
       GoKind: 22
       Pointee: 40 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2564,63 +2564,63 @@ Types:
       ID: 11
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 30880
+      GoRuntimeType: 30976
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 103
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 29792
+      GoRuntimeType: 29888
       GoKind: 22
       Pointee: 14 GoInterfaceType error
     - __kind: PointerType
       ID: 104
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 30752
+      GoRuntimeType: 30848
       GoKind: 22
       Pointee: 18 BaseType float32
     - __kind: PointerType
       ID: 99
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 30816
+      GoRuntimeType: 30912
       GoKind: 22
       Pointee: 16 BaseType float64
     - __kind: PointerType
       ID: 100
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 30432
+      GoRuntimeType: 30528
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 20
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 30176
+      GoRuntimeType: 30272
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 102
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 30304
+      GoRuntimeType: 30400
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 159
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 28256
+      GoRuntimeType: 28352
       GoKind: 22
       Pointee: 160 StructureType main.bigStruct
     - __kind: PointerType
       ID: 123
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 28128
+      GoRuntimeType: 28160
       GoKind: 22
       Pointee: 121 StructureType main.condFields
     - __kind: PointerType
@@ -2667,84 +2667,84 @@ Types:
       ID: 26
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 31072
+      GoRuntimeType: 31168
       GoKind: 22
       Pointee: 27 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 24
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 84704
+      GoRuntimeType: 84864
       GoKind: 22
       Pointee: 25 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 65
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 31712
+      GoRuntimeType: 31808
       GoKind: 22
       Pointee: 66 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 47
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 31776
+      GoRuntimeType: 31872
       GoKind: 22
       Pointee: 48 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 55
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 62144
+      GoRuntimeType: 62304
       GoKind: 22
       Pointee: 22 StructureType runtime.g
     - __kind: PointerType
       ID: 28
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 85344
+      GoRuntimeType: 85504
       GoKind: 22
       Pointee: 29 StructureType runtime.m
     - __kind: PointerType
       ID: 64
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 69248
+      GoRuntimeType: 69408
       GoKind: 22
       Pointee: 138 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 41
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 32416
+      GoRuntimeType: 32512
       GoKind: 22
       Pointee: 42 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 49
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 97632
+      GoRuntimeType: 97792
       GoKind: 22
       Pointee: 50 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 44
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 129216
+      GoRuntimeType: 129632
       GoKind: 22
       Pointee: 45 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 79
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 103648
+      GoRuntimeType: 103808
       GoKind: 22
       Pointee: 80 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 95
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 29856
+      GoRuntimeType: 29952
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2776,42 +2776,42 @@ Types:
       ID: 105
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 30496
+      GoRuntimeType: 30592
       GoKind: 22
       Pointee: 10 BaseType uint
     - __kind: PointerType
       ID: 106
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 30112
+      GoRuntimeType: 30208
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 21
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 30240
+      GoRuntimeType: 30336
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 101
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 30368
+      GoRuntimeType: 30464
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 19
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 30560
+      GoRuntimeType: 30656
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3220,7 +3220,7 @@ Types:
     - __kind: EventRootType
       ID: 295
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3243,16 +3243,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 282
       Name: Probe[main.condNilPtrStruct]
@@ -4160,7 +4150,7 @@ Types:
       ID: 92
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 55296
+      GoRuntimeType: 55456
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4169,7 +4159,7 @@ Types:
       ID: 185
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 49248
+      GoRuntimeType: 49408
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4178,7 +4168,7 @@ Types:
       ID: 78
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 54912
+      GoRuntimeType: 55072
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4187,7 +4177,7 @@ Types:
       ID: 77
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 55008
+      GoRuntimeType: 55168
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4196,7 +4186,7 @@ Types:
       ID: 84
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 55200
+      GoRuntimeType: 55360
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4205,7 +4195,7 @@ Types:
       ID: 54
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 50976
+      GoRuntimeType: 51136
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4214,7 +4204,7 @@ Types:
       ID: 90
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 57600
+      GoRuntimeType: 57760
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4223,7 +4213,7 @@ Types:
       ID: 68
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 54720
+      GoRuntimeType: 54880
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4232,7 +4222,7 @@ Types:
       ID: 108
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 48864
+      GoRuntimeType: 49120
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4241,7 +4231,7 @@ Types:
       ID: 122
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 48672
+      GoRuntimeType: 48832
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4250,7 +4240,7 @@ Types:
       ID: 53
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 54144
+      GoRuntimeType: 54304
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4259,7 +4249,7 @@ Types:
       ID: 110
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 48960
+      GoRuntimeType: 49216
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4268,7 +4258,7 @@ Types:
       ID: 91
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 56736
+      GoRuntimeType: 56896
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4277,7 +4267,7 @@ Types:
       ID: 58
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 53472
+      GoRuntimeType: 53632
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4286,7 +4276,7 @@ Types:
       ID: 85
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 55104
+      GoRuntimeType: 55264
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4295,7 +4285,7 @@ Types:
       ID: 62
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 41120
+      GoRuntimeType: 41280
       GoKind: 23
       RawFields:
         - Name: array
@@ -4342,7 +4332,7 @@ Types:
       ID: 107
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 39520
+      GoRuntimeType: 39680
       GoKind: 23
       RawFields:
         - Name: array
@@ -4393,7 +4383,7 @@ Types:
       ID: 109
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 39776
+      GoRuntimeType: 39936
       GoKind: 23
       RawFields:
         - Name: array
@@ -4416,7 +4406,7 @@ Types:
       ID: 38
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 39136
+      GoRuntimeType: 39296
       GoKind: 23
       RawFields:
         - Name: array
@@ -4439,7 +4429,7 @@ Types:
       ID: 43
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 39648
+      GoRuntimeType: 39808
       GoKind: 23
       RawFields:
         - Name: array
@@ -4462,25 +4452,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 44800
+      GoRuntimeType: 44960
       GoKind: 1
     - __kind: BaseType
       ID: 98
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 44608
+      GoRuntimeType: 44768
       GoKind: 16
     - __kind: BaseType
       ID: 97
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 44544
+      GoRuntimeType: 44704
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 14
       Name: error
       ByteSize: 16
-      GoRuntimeType: 67584
+      GoRuntimeType: 67744
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4493,25 +4483,25 @@ Types:
       ID: 18
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 44672
+      GoRuntimeType: 44832
       GoKind: 13
     - __kind: BaseType
       ID: 16
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 44736
+      GoRuntimeType: 44896
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 59
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 37216
+      GoRuntimeType: 37376
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 73
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 59968
+      GoRuntimeType: 60128
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 177
@@ -4573,37 +4563,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 44352
+      GoRuntimeType: 44512
       GoKind: 2
     - __kind: BaseType
       ID: 96
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 43968
+      GoRuntimeType: 44128
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 44096
+      GoRuntimeType: 44256
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 44224
+      GoRuntimeType: 44384
       GoKind: 6
     - __kind: BaseType
       ID: 17
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 43840
+      GoRuntimeType: 44000
       GoKind: 3
     - __kind: StructureType
       ID: 89
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 120256
+      GoRuntimeType: 120416
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4625,7 +4615,7 @@ Types:
       ID: 35
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 78080
+      GoRuntimeType: 78240
       GoKind: 25
       RawFields:
         - Name: u
@@ -4635,7 +4625,7 @@ Types:
       ID: 71
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 106720
+      GoRuntimeType: 106880
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4651,7 +4641,7 @@ Types:
       ID: 32
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 95904
+      GoRuntimeType: 96064
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4664,7 +4654,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 95744
+      GoRuntimeType: 95904
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4677,7 +4667,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Uintptr
       ByteSize: 8
-      GoRuntimeType: 96064
+      GoRuntimeType: 96224
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4689,27 +4679,27 @@ Types:
     - __kind: StructureType
       ID: 72
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 65888
+      GoRuntimeType: 66048
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 33
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 65792
+      GoRuntimeType: 65952
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 182
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 73728
+      GoRuntimeType: 73888
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 160
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 127744
+      GoRuntimeType: 128160
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4740,7 +4730,7 @@ Types:
       ID: 121
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 135360
+      GoRuntimeType: 135776
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4926,35 +4916,35 @@ Types:
       ID: 169
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 71808
+      GoRuntimeType: 72096
       GoKind: 21
       HeaderType: 171 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 111
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 71936
+      GoRuntimeType: 71968
       GoKind: 21
       HeaderType: 113 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 116
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 72064
+      GoRuntimeType: 72224
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 124
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 72320
+      GoRuntimeType: 72480
       GoKind: 21
       HeaderType: 126 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 180
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 49056
+      GoRuntimeType: 49312
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4963,7 +4953,7 @@ Types:
       ID: 157
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 49344
+      GoRuntimeType: 49504
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4972,7 +4962,7 @@ Types:
       ID: 149
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 49152
+      GoRuntimeType: 48928
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4981,7 +4971,7 @@ Types:
       ID: 167
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 49536
+      GoRuntimeType: 49696
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4990,7 +4980,7 @@ Types:
       ID: 179
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 79488
+      GoRuntimeType: 79904
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5003,7 +4993,7 @@ Types:
       ID: 148
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 79744
+      GoRuntimeType: 79648
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5016,7 +5006,7 @@ Types:
       ID: 156
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 80000
+      GoRuntimeType: 80160
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5029,7 +5019,7 @@ Types:
       ID: 166
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 80512
+      GoRuntimeType: 80672
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5042,7 +5032,7 @@ Types:
       ID: 181
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 79360
+      GoRuntimeType: 79776
       GoKind: 25
       RawFields:
         - Name: key
@@ -5055,7 +5045,7 @@ Types:
       ID: 158
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 79872
+      GoRuntimeType: 80032
       GoKind: 25
       RawFields:
         - Name: key
@@ -5068,7 +5058,7 @@ Types:
       ID: 150
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 79616
+      GoRuntimeType: 79520
       GoKind: 25
       RawFields:
         - Name: key
@@ -5081,7 +5071,7 @@ Types:
       ID: 168
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 80384
+      GoRuntimeType: 80544
       GoKind: 25
       RawFields:
         - Name: key
@@ -5109,14 +5099,14 @@ Types:
     - __kind: StructureType
       ID: 87
       Name: runtime.dlogPerM
-      GoRuntimeType: 65024
+      GoRuntimeType: 65184
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 22
       Name: runtime.g
       ByteSize: 440
-      GoRuntimeType: 150432
+      GoRuntimeType: 150848
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5306,7 +5296,7 @@ Types:
       ID: 51
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 76544
+      GoRuntimeType: 76704
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5316,7 +5306,7 @@ Types:
       ID: 30
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 123424
+      GoRuntimeType: 123840
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5341,7 +5331,7 @@ Types:
       ID: 46
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 93024
+      GoRuntimeType: 93184
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5354,7 +5344,7 @@ Types:
       ID: 56
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 112096
+      GoRuntimeType: 112256
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5373,13 +5363,13 @@ Types:
       ID: 31
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 58432
+      GoRuntimeType: 58592
       GoKind: 12
     - __kind: StructureType
       ID: 93
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 92864
+      GoRuntimeType: 93024
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5392,7 +5382,7 @@ Types:
       ID: 81
       Name: runtime.libcall
       ByteSize: 48
-      GoRuntimeType: 124192
+      GoRuntimeType: 124608
       GoKind: 25
       RawFields:
         - Name: fn
@@ -5417,13 +5407,13 @@ Types:
       ID: 94
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 58336
+      GoRuntimeType: 58496
       GoKind: 2
     - __kind: StructureType
       ID: 29
       Name: runtime.m
       ByteSize: 1816
-      GoRuntimeType: 153728
+      GoRuntimeType: 154144
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5643,7 +5633,7 @@ Types:
       ID: 70
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 123936
+      GoRuntimeType: 124352
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5668,7 +5658,7 @@ Types:
       ID: 88
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 119136
+      GoRuntimeType: 119296
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5690,7 +5680,7 @@ Types:
       ID: 75
       Name: runtime.mTraceState
       ByteSize: 56
-      GoRuntimeType: 118912
+      GoRuntimeType: 119072
       GoKind: 25
       RawFields:
         - Name: seqlock
@@ -5712,7 +5702,7 @@ Types:
       ID: 69
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 92544
+      GoRuntimeType: 92704
       GoKind: 25
       RawFields:
         - Name: next
@@ -5725,13 +5715,13 @@ Types:
       ID: 37
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 58048
+      GoRuntimeType: 58208
       GoKind: 12
     - __kind: StructureType
       ID: 67
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 76288
+      GoRuntimeType: 76448
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -5742,7 +5732,7 @@ Types:
       ID: 83
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 92704
+      GoRuntimeType: 92864
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5755,7 +5745,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 113056
+      GoRuntimeType: 113216
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5774,13 +5764,13 @@ Types:
       ID: 60
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 58240
+      GoRuntimeType: 58400
       GoKind: 12
     - __kind: ArrayType
       ID: 57
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 61664
+      GoRuntimeType: 61824
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5789,7 +5779,7 @@ Types:
       ID: 23
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 90784
+      GoRuntimeType: 90944
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5810,7 +5800,7 @@ Types:
       ID: 61
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 45056
+      GoRuntimeType: 45216
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 45
@@ -5820,7 +5810,7 @@ Types:
       ID: 74
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 45120
+      GoRuntimeType: 45280
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 80
@@ -5830,7 +5820,7 @@ Types:
       ID: 52
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 91744
+      GoRuntimeType: 91904
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5843,19 +5833,19 @@ Types:
       ID: 34
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 79104
+      GoRuntimeType: 79264
       GoKind: 8
     - __kind: StructureType
       ID: 82
       Name: runtime.winlibcall
-      GoRuntimeType: 64928
+      GoRuntimeType: 65088
       GoKind: 25
       RawFields: []
     - __kind: GoStringHeaderType
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 43776
+      GoRuntimeType: 43936
       GoKind: 24
       RawFields:
         - Name: str
@@ -5970,43 +5960,43 @@ Types:
       ID: 10
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 44416
+      GoRuntimeType: 44576
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 44032
+      GoRuntimeType: 44192
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 44160
+      GoRuntimeType: 44320
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 44288
+      GoRuntimeType: 44448
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 43904
+      GoRuntimeType: 44064
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 44480
+      GoRuntimeType: 44640
       GoKind: 12
     - __kind: VoidPointerType
       ID: 15
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 44864
+      GoRuntimeType: 45024
       GoKind: 26
 MaxTypeID: 301
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 371 EventRootType Probe[main.PointerChainArg]
+          Type: 387 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7eb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 372 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 388 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7ee8", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 217 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xb8e68", Frameless: false}]
           Condition:
-            Type: 96 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 221 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 223 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xb8f08", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 227 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xb8fa8", Frameless: false}]
           Condition:
-            Type: 13 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 213 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xb8dc8", Frameless: false}]
           Condition:
-            Type: 17 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 297 EventRootType Probe[main.condLine]Line
+          Type: 301 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 298 EventRootType Probe[main.condLine]Line
+          Type: 302 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xb9934", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condNilPtrStruct]
+          Type: 289 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condNilPtrStruct]
+          Type: 291 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xb9748", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 292 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xb97b0", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.condOnly]
+          Type: 297 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 294 EventRootType Probe[main.condOnly]Return
+          Type: 298 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.condOnly]
+          Type: 299 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xb9888", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 296 EventRootType Probe[main.condOnly]Return
+          Type: 300 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xb98e0", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condPtrStructArg]
+          Type: 283 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condPtrStructArg]
+          Type: 285 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 286 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condPtrStructArg]
+          Type: 287 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xb963c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 288 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xb96fc", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.condReturnAndLocal]
+          Type: 293 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 290 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.condReturnAndLocal]
+          Type: 295 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xb97f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 296 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xb9850", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 259 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 261 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 263 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 264 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 265 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 266 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xb9504", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condString]
+          Type: 267 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condString]Return
+          Type: 268 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condString]
+          Type: 269 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xb94a8", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condString]Return
+          Type: 270 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xb9504", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condStructArg]
+          Type: 271 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condStructArg]Return
+          Type: 272 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 273 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 274 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condStructArg]
+          Type: 275 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
-            Type: 16 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condStructArg]Return
+          Type: 276 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condStructArg]
+          Type: 277 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condStructArg]Return
+          Type: 278 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condStructArg]
+          Type: 279 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condStructArg]Return
+          Type: 280 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condStructArg]
+          Type: 281 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xb954c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condStructArg]Return
+          Type: 282 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xb9600", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 237 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xb90e8", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 241 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xb9188", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 245 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xb9228", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 231 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 233 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xb9048", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 369 EventRootType Probe[main.inlined]
+          Type: 385 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7cd0"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 370 EventRootType Probe[main.inlined]Return
+          Type: 386 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb8bac", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 359 EventRootType Probe[main.lenErrInt]
+          Type: 375 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 360 EventRootType Probe[main.lenErrInt]Return
+          Type: 376 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xba244", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 363 EventRootType Probe[main.lenErrStruct]
+          Type: 379 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xba28c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 364 EventRootType Probe[main.lenErrStruct]Return
+          Type: 380 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xba348", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 361 EventRootType Probe[main.lenErrInt]
+          Type: 377 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 362 EventRootType Probe[main.lenErrInt]Return
+          Type: 378 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xba244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 365 EventRootType Probe[main.lenErrStruct]
+          Type: 381 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xba28c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 366 EventRootType Probe[main.lenErrStruct]Return
+          Type: 382 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xba348", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenMap]
+          Type: 333 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenMap]Return
+          Type: 334 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 335 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 336 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenMap]
+          Type: 337 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenMap]Return
+          Type: 338 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenMap]
+          Type: 339 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenMap]Return
+          Type: 340 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenMap]
+          Type: 341 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenMap]Return
+          Type: 342 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenMap]
+          Type: 343 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenMap]Return
+          Type: 344 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenPtrString]
+          Type: 345 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenPtrString]Return
+          Type: 346 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenPtrString]
+          Type: 347 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenPtrString]Return
+          Type: 348 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.lenPtrStructFields]
+          Type: 367 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 368 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 353 EventRootType Probe[main.lenPtrStructFields]
+          Type: 369 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 354 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 370 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 355 EventRootType Probe[main.lenPtrStructFields]
+          Type: 371 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 356 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 372 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 357 EventRootType Probe[main.lenPtrStructFields]
+          Type: 373 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 358 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 374 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenSlice]
+          Type: 321 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenSlice]Return
+          Type: 322 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenSlice]
+          Type: 325 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenSlice]Return
+          Type: 326 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenSlice]
+          Type: 327 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenSlice]Return
+          Type: 328 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenSlice]
+          Type: 329 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenSlice]Return
+          Type: 330 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenSlice]
+          Type: 331 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenSlice]Return
+          Type: 332 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 303 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 304 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 305 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 306 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 307 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 308 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 299 EventRootType Probe[main.lenString]
+          Type: 309 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 300 EventRootType Probe[main.lenString]Return
+          Type: 310 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.lenString]
+          Type: 313 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.lenString]Return
+          Type: 314 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.lenString]
+          Type: 315 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 304 EventRootType Probe[main.lenString]Return
+          Type: 316 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.lenString]
+          Type: 317 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 306 EventRootType Probe[main.lenString]Return
+          Type: 318 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 307 EventRootType Probe[main.lenString]
+          Type: 319 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xb9bdc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 308 EventRootType Probe[main.lenString]Return
+          Type: 320 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xb9c70", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenStructFields]
+          Type: 349 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          Type: 350 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenStructFields]
+          Type: 351 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenStructFields]Return
+          Type: 352 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenStructFields]
+          Type: 353 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenStructFields]Return
+          Type: 354 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenStructFields]
+          Type: 355 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenStructFields]Return
+          Type: 356 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenStructFields]
+          Type: 357 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenStructFields]Return
+          Type: 358 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenStructFields]
+          Type: 359 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenStructFields]Return
+          Type: 360 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.lenStructFields]
+          Type: 361 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 346 EventRootType Probe[main.lenStructFields]Return
+          Type: 362 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.lenStructFields]
+          Type: 363 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 348 EventRootType Probe[main.lenStructFields]Return
+          Type: 364 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.lenStructFields]
+          Type: 365 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 350 EventRootType Probe[main.lenStructFields]Return
+          Type: 366 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 367 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 383 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xba390", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 368 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 384 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xba508", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4111,7 +4323,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 371
+      ID: 387
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4137,7 +4349,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 372
+      ID: 388
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4498,7 +4710,7 @@ Types:
       ID: 216
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 301
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4514,7 +4726,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 298
+      ID: 302
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4540,7 +4752,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
+      ID: 289
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4556,7 +4768,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 291
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4582,13 +4794,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 286
+      ID: 290
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 288
+      ID: 292
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4614,7 +4826,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 295
+      ID: 299
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4640,45 +4852,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 294
+      ID: 298
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 296
+      ID: 300
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 279
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 281
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 283
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4704,16 +4916,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 280
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 282
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 284
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 289
+      ID: 286
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 288
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 293
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4729,7 +4941,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4755,10 +4967,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4808,6 +5020,48 @@ Types:
     - __kind: EventRootType
       ID: 263
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 265
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 267
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4832,7 +5086,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 265
+      ID: 269
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4870,7 +5124,13 @@ Types:
       ID: 266
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 267
+      ID: 268
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 271
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4878,38 +5138,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 269
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 271
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -4952,6 +5180,38 @@ Types:
     - __kind: EventRootType
       ID: 277
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 279
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 281
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -4976,12 +5236,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 268
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 270
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 272
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -4992,6 +5246,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 278
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 280
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 282
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 237
@@ -5205,7 +5465,7 @@ Types:
       ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 369
+      ID: 385
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5221,7 +5481,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 370
+      ID: 386
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 190
@@ -5281,7 +5541,7 @@ Types:
       ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5307,16 +5567,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5342,16 +5602,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 333
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5367,7 +5627,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 321
+      ID: 335
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 337
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5386,7 +5671,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 323
+      ID: 339
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5402,7 +5687,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 341
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5421,7 +5706,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 343
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5447,22 +5732,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 334
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 322
+      ID: 336
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 338
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 326
+      ID: 340
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 328
+      ID: 342
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 344
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 345
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5481,7 +5769,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 347
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5507,13 +5795,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5539,7 +5827,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5561,7 +5849,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5580,7 +5868,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5599,19 +5887,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 309
+      ID: 321
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5627,7 +5915,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 311
+      ID: 323
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 325
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5643,7 +5953,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 313
+      ID: 327
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5659,7 +5969,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 329
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5675,7 +5985,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 317
+      ID: 331
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5701,22 +6011,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 322
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 312
+      ID: 324
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 328
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 332
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 303
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 309
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5732,7 +6111,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 301
+      ID: 311
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 313
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5748,7 +6149,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 303
+      ID: 315
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5764,7 +6165,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
+      ID: 317
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5780,7 +6181,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 307
+      ID: 319
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5806,12 +6207,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 302
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 304
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5821,7 +6216,25 @@ Types:
       ID: 308
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 310
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 349
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5847,7 +6260,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5866,7 +6279,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5885,7 +6298,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5904,7 +6317,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5920,7 +6333,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5936,7 +6349,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5952,7 +6365,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5968,7 +6381,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5983,32 +6396,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 334
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 336
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 338
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 340
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 342
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 344
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 346
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 348
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 350
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 352
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 354
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 356
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 358
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 360
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 362
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 364
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 366
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 207
@@ -6154,10 +6567,10 @@ Types:
       ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 368
+      ID: 384
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8049,7 +8462,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45024
       GoKind: 26
-MaxTypeID: 372
+MaxTypeID: 388
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8127,7 +8540,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8157,7 +8570,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8172,7 +8585,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8187,7 +8600,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 355 EventRootType Probe[main.PointerChainArg]
+          Type: 371 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xb7eb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 372 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xb7ee8", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 353 EventRootType Probe[main.inlined]
+          Type: 369 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xb7cd0"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 354 EventRootType Probe[main.inlined]Return
+          Type: 370 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xb8bac", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 343 EventRootType Probe[main.lenErrInt]
+          Type: 359 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 344 EventRootType Probe[main.lenErrInt]Return
+          Type: 360 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xba244", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 347 EventRootType Probe[main.lenErrStruct]
+          Type: 363 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xba28c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 348 EventRootType Probe[main.lenErrStruct]Return
+          Type: 364 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xba348", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 345 EventRootType Probe[main.lenErrInt]
+          Type: 361 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xba1ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 346 EventRootType Probe[main.lenErrInt]Return
+          Type: 362 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xba244", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 349 EventRootType Probe[main.lenErrStruct]
+          Type: 365 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xba28c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 350 EventRootType Probe[main.lenErrStruct]Return
+          Type: 366 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xba348", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 319 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 320 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 321 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 322 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 323 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 324 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 313 EventRootType Probe[main.lenMap]
+          Type: 325 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 314 EventRootType Probe[main.lenMap]Return
+          Type: 326 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 315 EventRootType Probe[main.lenMap]
+          Type: 327 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xb9dac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 316 EventRootType Probe[main.lenMap]Return
+          Type: 328 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xb9e50", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 317 EventRootType Probe[main.lenPtrString]
+          Type: 329 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 318 EventRootType Probe[main.lenPtrString]Return
+          Type: 330 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 319 EventRootType Probe[main.lenPtrString]
+          Type: 331 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xb9e9c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 320 EventRootType Probe[main.lenPtrString]Return
+          Type: 332 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xb9f28", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 335 EventRootType Probe[main.lenPtrStructFields]
+          Type: 351 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 336 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 352 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 337 EventRootType Probe[main.lenPtrStructFields]
+          Type: 353 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 338 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 354 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 339 EventRootType Probe[main.lenPtrStructFields]
+          Type: 355 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 340 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 356 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 341 EventRootType Probe[main.lenPtrStructFields]
+          Type: 357 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xba09c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 342 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 358 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xba168", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 309 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 310 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 311 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 312 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 313 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 314 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 309 EventRootType Probe[main.lenSlice]
+          Type: 315 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 310 EventRootType Probe[main.lenSlice]Return
+          Type: 316 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 311 EventRootType Probe[main.lenSlice]
+          Type: 317 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xb9cbc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 312 EventRootType Probe[main.lenSlice]Return
+          Type: 318 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xb9d5c", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 321 EventRootType Probe[main.lenStructFields]
+          Type: 333 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 322 EventRootType Probe[main.lenStructFields]Return
+          Type: 334 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 323 EventRootType Probe[main.lenStructFields]
+          Type: 335 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 324 EventRootType Probe[main.lenStructFields]Return
+          Type: 336 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 325 EventRootType Probe[main.lenStructFields]
+          Type: 337 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 326 EventRootType Probe[main.lenStructFields]Return
+          Type: 338 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 327 EventRootType Probe[main.lenStructFields]
+          Type: 339 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 328 EventRootType Probe[main.lenStructFields]Return
+          Type: 340 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 329 EventRootType Probe[main.lenStructFields]
+          Type: 341 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 330 EventRootType Probe[main.lenStructFields]Return
+          Type: 342 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 331 EventRootType Probe[main.lenStructFields]
+          Type: 343 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 332 EventRootType Probe[main.lenStructFields]Return
+          Type: 344 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 345 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 346 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 347 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 348 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xba05c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 333 EventRootType Probe[main.lenStructFields]
+          Type: 349 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xb9f6c", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 334 EventRootType Probe[main.lenStructFields]Return
+          Type: 350 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xba05c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 351 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 367 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xba390", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 352 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 368 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xba508", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3806,7 +4111,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3832,7 +4137,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4900,7 +5205,7 @@ Types:
       ID: 236
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4916,7 +5221,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 190
@@ -4976,7 +5281,7 @@ Types:
       ID: 199
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5002,16 +5307,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5037,19 +5342,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 313
+      ID: 319
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 321
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 327
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5075,13 +5447,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 314
+      ID: 320
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 316
+      ID: 322
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 324
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 329
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5100,7 +5481,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 319
+      ID: 331
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5126,13 +5507,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 318
+      ID: 330
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 320
+      ID: 332
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5158,10 +5539,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 339
+      ID: 355
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5180,7 +5580,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5199,19 +5599,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 354
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 309
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5227,7 +5675,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 311
+      ID: 317
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5257,6 +5705,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 312
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 318
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 299
@@ -5364,7 +5821,7 @@ Types:
       ID: 308
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 333
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5390,10 +5847,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 325
+      ID: 337
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5412,7 +5885,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 327
+      ID: 339
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5431,7 +5904,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 329
+      ID: 341
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5447,7 +5920,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 331
+      ID: 343
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5463,7 +5936,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 333
+      ID: 345
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5479,25 +5952,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 322
-      Name: Probe[main.lenStructFields]Return
+      ID: 347
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 324
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 326
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 328
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 330
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 332
-      Name: Probe[main.lenStructFields]Return
+      ID: 349
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 334
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 348
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 350
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 207
@@ -5643,10 +6154,10 @@ Types:
       ID: 203
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7538,7 +8049,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 45024
       GoKind: 26
-MaxTypeID: 356
+MaxTypeID: 372
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 376 EventRootType Probe[main.PointerChainArg]
+          Type: 392 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xc826c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 377 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 393 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xc82a4", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -210,7 +210,7 @@ Probes:
           Type: 222 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xc91b8", Frameless: false}]
           Condition:
-            Type: 102 BaseType int16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 12, index: 0, name: x}
@@ -268,7 +268,7 @@ Probes:
           Type: 226 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -311,7 +311,7 @@ Probes:
           Type: 228 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 13, index: 0, name: x}
@@ -361,7 +361,7 @@ Probes:
           Type: 232 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
           Condition:
-            Type: 13 BaseType int64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 14, index: 0, name: x}
@@ -419,7 +419,7 @@ Probes:
           Type: 218 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xc9108", Frameless: false}]
           Condition:
-            Type: 19 BaseType int8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 11, index: 0, name: x}
@@ -483,10 +483,10 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 302 EventRootType Probe[main.condLine]Line
+          Type: 306 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 28, index: 0, name: n}
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 303 EventRootType Probe[main.condLine]Line
+          Type: 307 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,10 +533,10 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 290 EventRootType Probe[main.condNilPtrStruct]
+          Type: 294 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 25, index: 0, name: x}
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 291 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 295 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 292 EventRootType Probe[main.condNilPtrStruct]
+          Type: 296 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 293 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 297 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,10 +594,10 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 298 EventRootType Probe[main.condOnly]
+          Type: 302 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 27, index: 0, name: x}
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 299 EventRootType Probe[main.condOnly]Return
+          Type: 303 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 300 EventRootType Probe[main.condOnly]
+          Type: 304 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 301 EventRootType Probe[main.condOnly]Return
+          Type: 305 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,10 +646,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 284 EventRootType Probe[main.condPtrStructArg]
+          Type: 288 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 285 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,10 +691,10 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 286 EventRootType Probe[main.condPtrStructArg]
+          Type: 290 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 24, index: 0, name: x}
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 287 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 291 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 288 EventRootType Probe[main.condPtrStructArg]
+          Type: 292 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 293 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,10 +751,10 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 294 EventRootType Probe[main.condReturnAndLocal]
+          Type: 298 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 26, index: 0, name: a}
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 295 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 299 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 296 EventRootType Probe[main.condReturnAndLocal]
+          Type: 300 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 297 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 301 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -814,7 +814,7 @@ Probes:
           Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -853,7 +853,7 @@ Probes:
           Type: 266 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -877,6 +877,58 @@ Probes:
               DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
+    - id: condString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: x_eq_hello
+          expr:
+            dsl: x == "hello"
+            json: {eq: [{ref: x}, hello]}
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 268 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 269 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
+          Condition: null
+    - id: condString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.condString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={x == "hello"}
+      segments:
+        - eq=
+        - json: {eq: [{ref: x}, hello]}
+          dsl: x == "hello"
+      captureSnapshot: false
+      subprogram: {subprogram: 22}
+      events:
+        - Kind: Entry
+          Type: 270 EventRootType Probe[main.condString]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 271 EventRootType Probe[main.condString]Return
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={x == "hello"}
+        Segments:
+            - eq=
+            - JSON: {Left: {Ref: x}, Right: {Value: hello}}
+              DSL: x == "hello"
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: condString_nocond
       version: 0
       type: LOG_PROBE
@@ -888,11 +940,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 268 EventRootType Probe[main.condString]
+          Type: 272 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 269 EventRootType Probe[main.condString]Return
+          Type: 273 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,10 +961,10 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 270 EventRootType Probe[main.condString]
+          Type: 274 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 22, index: 0, name: x}
@@ -925,7 +977,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 271 EventRootType Probe[main.condString]Return
+          Type: 275 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,10 +997,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 272 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -962,7 +1014,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 273 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +1031,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 274 EventRootType Probe[main.condStructArg]
+          Type: 278 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +1048,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 275 EventRootType Probe[main.condStructArg]Return
+          Type: 279 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,10 +1073,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 276 EventRootType Probe[main.condStructArg]
+          Type: 280 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
-            Type: 14 BaseType float64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1038,7 +1090,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 277 EventRootType Probe[main.condStructArg]Return
+          Type: 281 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,10 +1115,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 278 EventRootType Probe[main.condStructArg]
+          Type: 282 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
-            Type: 12 BaseType int32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1080,7 +1132,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 279 EventRootType Probe[main.condStructArg]Return
+          Type: 283 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,10 +1157,10 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 280 EventRootType Probe[main.condStructArg]
+          Type: 284 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
-            Type: 9 GoStringHeaderType string
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 23, index: 0, name: x}
@@ -1121,7 +1173,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 281 EventRootType Probe[main.condStructArg]Return
+          Type: 285 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1195,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 282 EventRootType Probe[main.condStructArg]
+          Type: 286 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 283 EventRootType Probe[main.condStructArg]Return
+          Type: 287 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1165,7 +1217,7 @@ Probes:
           Type: 242 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xc9448", Frameless: false}]
           Condition:
-            Type: 6 BaseType uint16
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 16, index: 0, name: x}
@@ -1223,7 +1275,7 @@ Probes:
           Type: 246 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xc94e8", Frameless: false}]
           Condition:
-            Type: 2 BaseType uint32
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 17, index: 0, name: x}
@@ -1281,7 +1333,7 @@ Probes:
           Type: 250 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xc9588", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 18, index: 0, name: x}
@@ -1339,7 +1391,7 @@ Probes:
           Type: 236 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1379,7 +1431,7 @@ Probes:
           Type: 238 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
-            Type: 3 BaseType uint8
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 15, index: 0, name: x}
@@ -1433,7 +1485,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 374 EventRootType Probe[main.inlined]
+          Type: 390 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xc8040"
               Frameless: false
@@ -1441,7 +1493,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 375 EventRootType Probe[main.inlined]Return
+          Type: 391 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xc8f0c", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1571,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 364 EventRootType Probe[main.lenErrInt]
+          Type: 380 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xca55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 365 EventRootType Probe[main.lenErrInt]Return
+          Type: 381 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1589,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 368 EventRootType Probe[main.lenErrStruct]
+          Type: 384 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xca63c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 369 EventRootType Probe[main.lenErrStruct]Return
+          Type: 385 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xca700", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1607,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 366 EventRootType Probe[main.lenErrInt]
+          Type: 382 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xca55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 367 EventRootType Probe[main.lenErrInt]Return
+          Type: 383 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1631,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 370 EventRootType Probe[main.lenErrStruct]
+          Type: 386 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xca63c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 371 EventRootType Probe[main.lenErrStruct]Return
+          Type: 387 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xca700", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1604,10 +1656,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenMap]
+          Type: 338 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1624,7 +1676,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenMap]Return
+          Type: 339 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,6 +1685,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(m)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: m}}
+          dsl: isEmpty(m)
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(m)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: m}}
+              DSL: isEmpty(m)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenMap_len_capture
@@ -1649,11 +1730,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenMap]
+          Type: 342 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenMap]Return
+          Type: 343 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
     - id: lenMap_len_eq_cond
@@ -1670,10 +1751,10 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenMap]
+          Type: 344 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 34, index: 0, name: m}
@@ -1690,7 +1771,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenMap]Return
+          Type: 345 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1712,11 +1793,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenMap]
+          Type: 346 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenMap]Return
+          Type: 347 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1738,11 +1819,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenMap]
+          Type: 348 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenMap]Return
+          Type: 349 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1756,11 +1837,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenPtrString]
+          Type: 350 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xca22c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenPtrString]Return
+          Type: 351 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1782,11 +1863,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenPtrString]
+          Type: 352 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xca22c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenPtrString]Return
+          Type: 353 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1800,11 +1881,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.lenPtrStructFields]
+          Type: 372 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 373 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1821,11 +1902,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.lenPtrStructFields]
+          Type: 374 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 375 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1850,11 +1931,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.lenPtrStructFields]
+          Type: 376 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 361 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 377 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1879,11 +1960,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 362 EventRootType Probe[main.lenPtrStructFields]
+          Type: 378 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 379 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1906,10 +1987,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenSlice]
+          Type: 326 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1923,7 +2004,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenSlice]Return
+          Type: 327 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1932,6 +2013,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_capture
@@ -1948,11 +2058,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenSlice]
+          Type: 330 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenSlice]Return
+          Type: 331 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
     - id: lenSlice_len_eq_cond
@@ -1969,10 +2079,10 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenSlice]
+          Type: 332 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 33, index: 0, name: s}
@@ -1986,7 +2096,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenSlice]Return
+          Type: 333 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2008,11 +2118,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenSlice]
+          Type: 334 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenSlice]Return
+          Type: 335 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2034,12 +2144,85 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenSlice]
+          Type: 336 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenSlice]Return
+          Type: 337 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len_eq_5
+          expr:
+            dsl: len(s) == 5
+            json: {eq: [{len: {ref: s}}, 5]}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+    - id: lenString_eq_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: eq={len(s) == 5}
+      segments:
+        - eq=
+        - json: {eq: [{len: {ref: s}}, 5]}
+          dsl: len(s) == 5
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: eq={len(s) == 5}
+        Segments:
+            - eq=
+            - JSON: {Left: {Operand: {Ref: s}}, Right: {Value: 5}}
+              DSL: len(s) == 5
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_isEmpty
+          expr: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
       version: 0
@@ -2053,10 +2236,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 304 EventRootType Probe[main.lenString]
+          Type: 314 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2070,7 +2253,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 305 EventRootType Probe[main.lenString]Return
+          Type: 315 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2079,6 +2262,35 @@ Probes:
             - tag=
             - JSON: {Ref: tag}
               DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_isEmpty_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: empty={isEmpty(s)}
+      segments:
+        - empty=
+        - json: {isEmpty: {ref: s}}
+          dsl: isEmpty(s)
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: empty={isEmpty(s)}
+        Segments:
+            - empty=
+            - JSON: {Operand: {Ref: s}}
+              DSL: isEmpty(s)
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenString_len_capture
@@ -2095,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.lenString]
+          Type: 318 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 307 EventRootType Probe[main.lenString]Return
+          Type: 319 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
     - id: lenString_len_eq_cond
@@ -2116,10 +2328,10 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 308 EventRootType Probe[main.lenString]
+          Type: 320 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 32, index: 0, name: s}
@@ -2133,7 +2345,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 309 EventRootType Probe[main.lenString]Return
+          Type: 321 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2155,11 +2367,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 310 EventRootType Probe[main.lenString]
+          Type: 322 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 311 EventRootType Probe[main.lenString]Return
+          Type: 323 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2181,11 +2393,11 @@ Probes:
       subprogram: {subprogram: 32}
       events:
         - Kind: Entry
-          Type: 312 EventRootType Probe[main.lenString]
+          Type: 324 EventRootType Probe[main.lenString]
           InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 313 EventRootType Probe[main.lenString]Return
+          Type: 325 EventRootType Probe[main.lenString]Return
           InjectionPoints: [{PC: "0xca004", Frameless: false}]
           Condition: null
     - id: lenStructFields_nocond
@@ -2199,11 +2411,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2220,11 +2432,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenStructFields]
+          Type: 356 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenStructFields]Return
+          Type: 357 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2249,11 +2461,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenStructFields]
+          Type: 358 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenStructFields]Return
+          Type: 359 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2278,11 +2490,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenStructFields]
+          Type: 360 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenStructFields]Return
+          Type: 361 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2307,11 +2519,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenStructFields]
+          Type: 362 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenStructFields]Return
+          Type: 363 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2336,11 +2548,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenStructFields]
+          Type: 364 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenStructFields]Return
+          Type: 365 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2365,10 +2577,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenStructFields]
+          Type: 366 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition:
-            Type: 8 BaseType uint64
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2385,7 +2597,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenStructFields]Return
+          Type: 367 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2410,10 +2622,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenStructFields]
+          Type: 368 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2427,7 +2639,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenStructFields]Return
+          Type: 369 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2452,10 +2664,10 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenStructFields]
+          Type: 370 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition:
-            Type: 7 BaseType int
+            Type: 4 BaseType bool
             Operations:
                 - __kind: LocationOp
                   Variable: {subprogram: 36, index: 0, name: x}
@@ -2469,7 +2681,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenStructFields]Return
+          Type: 371 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2640,11 +2852,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 372 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 388 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xca740", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 373 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 389 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xca8bc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -4191,7 +4403,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 376
+      ID: 392
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4217,7 +4429,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 377
+      ID: 393
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4578,7 +4790,7 @@ Types:
       ID: 221
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 302
+      ID: 306
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4594,7 +4806,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 303
+      ID: 307
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4620,7 +4832,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 290
+      ID: 294
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4636,7 +4848,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 292
+      ID: 296
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4662,13 +4874,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 291
+      ID: 295
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 293
+      ID: 297
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 298
+      ID: 302
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4694,7 +4906,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 304
       Name: Probe[main.condOnly]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4720,45 +4932,45 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 299
+      ID: 303
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 301
+      ID: 305
       Name: Probe[main.condOnly]Return
-    - __kind: EventRootType
-      ID: 284
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 286
-      Name: Probe[main.condPtrStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 24, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
     - __kind: EventRootType
       ID: 288
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 290
+      Name: Probe[main.condPtrStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 24, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 292
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4784,16 +4996,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
-      ID: 287
-      Name: Probe[main.condPtrStructArg]Return
-    - __kind: EventRootType
       ID: 289
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 291
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 293
+      Name: Probe[main.condPtrStructArg]Return
+    - __kind: EventRootType
+      ID: 298
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4809,7 +5021,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 296
+      ID: 300
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4835,10 +5047,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 295
+      ID: 299
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 297
+      ID: 301
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4888,6 +5100,48 @@ Types:
     - __kind: EventRootType
       ID: 268
       Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x_eq_hello
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x == "hello"
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+                - __kind: ExprReadStringOp
+                  MaxLen: 255
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAGhlbGxv
+                - __kind: ExprCmpEqStringOp
+    - __kind: EventRootType
+      ID: 272
+      Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
       Expressions:
@@ -4912,7 +5166,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 274
       Name: Probe[main.condString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4950,7 +5204,13 @@ Types:
       ID: 271
       Name: Probe[main.condString]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 273
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 275
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 276
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4958,38 +5218,6 @@ Types:
         - Name: tag_val
           Offset: 1
           Kind: capture_expression
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 274
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 23, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 276
-      Name: Probe[main.condStructArg]
-      ByteSize: 17
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: tag
-          Offset: 1
-          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -5032,6 +5260,38 @@ Types:
     - __kind: EventRootType
       ID: 282
       Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 284
+      Name: Probe[main.condStructArg]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 23, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 286
+      Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
       Expressions:
@@ -5056,12 +5316,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
-      ID: 275
-      Name: Probe[main.condStructArg]Return
-    - __kind: EventRootType
       ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
@@ -5072,6 +5326,12 @@ Types:
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 283
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 285
+      Name: Probe[main.condStructArg]Return
+    - __kind: EventRootType
+      ID: 287
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
       ID: 242
@@ -5285,7 +5545,7 @@ Types:
       ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 374
+      ID: 390
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5301,7 +5561,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 375
+      ID: 391
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 195
@@ -5361,7 +5621,7 @@ Types:
       ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 364
+      ID: 380
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5387,16 +5647,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 366
+      ID: 382
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 365
+      ID: 381
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 367
+      ID: 383
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 368
+      ID: 384
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5422,16 +5682,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 370
+      ID: 386
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 369
+      ID: 385
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 371
+      ID: 387
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 324
+      ID: 338
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5447,7 +5707,32 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 326
+      ID: 340
+      Name: Probe[main.lenMap]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 342
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5466,7 +5751,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 328
+      ID: 344
       Name: Probe[main.lenMap]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5482,7 +5767,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 330
+      ID: 346
       Name: Probe[main.lenMap]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5501,7 +5786,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 348
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5527,22 +5812,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 325
+      ID: 339
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 327
+      ID: 341
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 329
+      ID: 343
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 331
+      ID: 345
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 333
+      ID: 347
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 334
+      ID: 349
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 350
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5561,7 +5849,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 352
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5587,13 +5875,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 335
+      ID: 351
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 337
+      ID: 353
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5619,7 +5907,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5641,7 +5929,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5660,7 +5948,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 362
+      ID: 378
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5679,19 +5967,19 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 363
+      ID: 379
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 314
+      ID: 326
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5707,7 +5995,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 316
+      ID: 328
+      Name: Probe[main.lenSlice]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 330
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5723,7 +6033,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 318
+      ID: 332
       Name: Probe[main.lenSlice]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5739,7 +6049,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 334
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5755,7 +6065,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 322
+      ID: 336
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5781,22 +6091,91 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 315
+      ID: 327
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 317
+      ID: 329
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 319
+      ID: 331
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 333
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
-      ID: 304
+      ID: 337
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len_eq_5
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s) == 5
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_isEmpty
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 314
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5812,7 +6191,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 306
+      ID: 316
+      Name: Probe[main.lenString]
+      ByteSize: 2
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: isEmpty(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5828,7 +6229,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 308
+      ID: 320
       Name: Probe[main.lenString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5844,7 +6245,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 310
+      ID: 322
       Name: Probe[main.lenString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5860,7 +6261,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 312
+      ID: 324
       Name: Probe[main.lenString]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -5886,12 +6287,6 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 305
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
-      ID: 307
-      Name: Probe[main.lenString]Return
-    - __kind: EventRootType
       ID: 309
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
@@ -5901,7 +6296,25 @@ Types:
       ID: 313
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 338
+      ID: 315
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 354
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5927,7 +6340,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5946,7 +6359,7 @@ Types:
                   Bias: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5965,7 +6378,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5984,7 +6397,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6000,7 +6413,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -6016,7 +6429,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6032,7 +6445,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6048,7 +6461,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -6063,32 +6476,32 @@ Types:
                   Variable: {subprogram: 36, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-    - __kind: EventRootType
-      ID: 339
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 341
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 343
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 345
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 347
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 349
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 351
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 353
-      Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 355
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 357
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 359
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 361
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 363
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 365
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 367
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 369
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 371
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 212
@@ -6234,10 +6647,10 @@ Types:
       ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 372
+      ID: 388
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 373
+      ID: 389
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -8156,7 +8569,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47456
       GoKind: 26
-MaxTypeID: 377
+MaxTypeID: 393
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -8234,7 +8647,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoMapType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoMapType for equality comparison'
     - probe_definition:
         id: condErr_rhs_ref
         version: 0
@@ -8264,7 +8677,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.GoSliceHeaderType for equality comparison'
     - probe_definition:
         id: condErr_string_vs_int
         version: 0
@@ -8279,7 +8692,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: string variable compared with non-string literal int64'
+        Message: 'failed to resolve condition: eq: string variable compared with non-string literal int64'
     - probe_definition:
         id: condErr_struct_direct
         version: 0
@@ -8294,7 +8707,7 @@ Issues:
         captureSnapshot: true
       issue:
         Kind: 8
-        Message: 'failed to resolve condition: condition: unsupported LHS type *ir.StructureType for equality comparison'
+        Message: 'failed to resolve condition: eq: unsupported LHS type *ir.StructureType for equality comparison'
     - probe_definition:
         id: condErr_uint32_negative
         version: 0

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -11,7 +11,7 @@ Probes:
       subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 360 EventRootType Probe[main.PointerChainArg]
+          Type: 376 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xc826c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -33,7 +33,7 @@ Probes:
       subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 361 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 377 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xc82a4", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -1433,7 +1433,7 @@ Probes:
       subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 358 EventRootType Probe[main.inlined]
+          Type: 374 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xc8040"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 359 EventRootType Probe[main.inlined]Return
+          Type: 375 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xc8f0c", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1519,11 +1519,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 348 EventRootType Probe[main.lenErrInt]
+          Type: 364 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xca55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 349 EventRootType Probe[main.lenErrInt]Return
+          Type: 365 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
           Condition: null
     - id: lenErrStruct_nocond
@@ -1537,11 +1537,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 352 EventRootType Probe[main.lenErrStruct]
+          Type: 368 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xca63c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 353 EventRootType Probe[main.lenErrStruct]Return
+          Type: 369 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xca700", Frameless: false}]
           Condition: null
     - id: lenErr_int
@@ -1555,11 +1555,11 @@ Probes:
       subprogram: {subprogram: 38}
       events:
         - Kind: Entry
-          Type: 350 EventRootType Probe[main.lenErrInt]
+          Type: 366 EventRootType Probe[main.lenErrInt]
           InjectionPoints: [{PC: "0xca55c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 351 EventRootType Probe[main.lenErrInt]Return
+          Type: 367 EventRootType Probe[main.lenErrInt]Return
           InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1579,11 +1579,11 @@ Probes:
       subprogram: {subprogram: 39}
       events:
         - Kind: Entry
-          Type: 354 EventRootType Probe[main.lenErrStruct]
+          Type: 370 EventRootType Probe[main.lenErrStruct]
           InjectionPoints: [{PC: "0xca63c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 355 EventRootType Probe[main.lenErrStruct]Return
+          Type: 371 EventRootType Probe[main.lenErrStruct]Return
           InjectionPoints: [{PC: "0xca700", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1592,6 +1592,115 @@ Probes:
             - len=
             - Error: len/isEmpty not supported on type "main.condFields" (struct)
               DSL: len(x)
+    - id: lenMap_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when: {dsl: isEmpty(m), json: {isEmpty: {ref: m}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenMap_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: m_len
+          expr: {dsl: len(m), json: {len: {ref: m}}}
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+    - id: lenMap_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      when:
+        dsl: len(m) == 3
+        json: {eq: [{len: {ref: m}}, 3]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AwAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_len_template
       version: 0
       type: LOG_PROBE
@@ -1603,19 +1712,21 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 318 EventRootType Probe[main.lenMap]
+          Type: 330 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 319 EventRootType Probe[main.lenMap]Return
+          Type: 331 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(m)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Ref: m}}
               DSL: len(m)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenMap_nocond
       version: 0
       type: LOG_PROBE
@@ -1627,11 +1738,11 @@ Probes:
       subprogram: {subprogram: 34}
       events:
         - Kind: Entry
-          Type: 320 EventRootType Probe[main.lenMap]
+          Type: 332 EventRootType Probe[main.lenMap]
           InjectionPoints: [{PC: "0xca13c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 321 EventRootType Probe[main.lenMap]Return
+          Type: 333 EventRootType Probe[main.lenMap]Return
           InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
           Condition: null
     - id: lenPtrString_len_template
@@ -1645,11 +1756,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 322 EventRootType Probe[main.lenPtrString]
+          Type: 334 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xca22c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 323 EventRootType Probe[main.lenPtrString]Return
+          Type: 335 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1671,11 +1782,11 @@ Probes:
       subprogram: {subprogram: 35}
       events:
         - Kind: Entry
-          Type: 324 EventRootType Probe[main.lenPtrString]
+          Type: 336 EventRootType Probe[main.lenPtrString]
           InjectionPoints: [{PC: "0xca22c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          Type: 337 EventRootType Probe[main.lenPtrString]Return
           InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
           Condition: null
     - id: lenPtrStructFields_nocond
@@ -1689,11 +1800,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 340 EventRootType Probe[main.lenPtrStructFields]
+          Type: 356 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 341 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 357 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
     - id: lenPtrStruct_field_map
@@ -1710,19 +1821,21 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 342 EventRootType Probe[main.lenPtrStructFields]
+          Type: 358 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 343 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 359 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenPtrStruct_field_slice
       version: 0
       type: LOG_PROBE
@@ -1737,11 +1850,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 344 EventRootType Probe[main.lenPtrStructFields]
+          Type: 360 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 345 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 361 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1766,11 +1879,11 @@ Probes:
       subprogram: {subprogram: 37}
       events:
         - Kind: Entry
-          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          Type: 362 EventRootType Probe[main.lenPtrStructFields]
           InjectionPoints: [{PC: "0xca43c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          Type: 363 EventRootType Probe[main.lenPtrStructFields]Return
           InjectionPoints: [{PC: "0xca50c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1779,6 +1892,109 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+    - id: lenSlice_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenSlice_len_template
@@ -1792,11 +2008,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 314 EventRootType Probe[main.lenSlice]
+          Type: 320 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 315 EventRootType Probe[main.lenSlice]Return
+          Type: 321 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1818,11 +2034,11 @@ Probes:
       subprogram: {subprogram: 33}
       events:
         - Kind: Entry
-          Type: 316 EventRootType Probe[main.lenSlice]
+          Type: 322 EventRootType Probe[main.lenSlice]
           InjectionPoints: [{PC: "0xca04c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 317 EventRootType Probe[main.lenSlice]Return
+          Type: 323 EventRootType Probe[main.lenSlice]Return
           InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
           Condition: null
     - id: lenString_isEmpty_cond
@@ -1983,11 +2199,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 326 EventRootType Probe[main.lenStructFields]
+          Type: 338 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
     - id: lenStruct_field_map
@@ -2004,19 +2220,21 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 328 EventRootType Probe[main.lenStructFields]
+          Type: 340 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          Type: 341 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: len={len(x.Dict)}
         Segments:
             - len=
-            - Error: len/isEmpty not supported on type "map[string]int" (map)
+            - JSON: {Operand: {Base: {Ref: x}, Member: Dict}}
               DSL: len(x.Dict)
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: lenStruct_field_ptrslice
       version: 0
       type: LOG_PROBE
@@ -2031,11 +2249,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 330 EventRootType Probe[main.lenStructFields]
+          Type: 342 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          Type: 343 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2060,11 +2278,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 332 EventRootType Probe[main.lenStructFields]
+          Type: 344 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          Type: 345 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2089,11 +2307,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 334 EventRootType Probe[main.lenStructFields]
+          Type: 346 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          Type: 347 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2118,11 +2336,11 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 336 EventRootType Probe[main.lenStructFields]
+          Type: 348 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          Type: 349 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2131,6 +2349,93 @@ Probes:
             - len=
             - JSON: {Operand: {Base: {Ref: x}, Member: S}}
               DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_map_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Dict)
+        json: {isEmpty: {getmember: [{ref: x}, Dict]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 350 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 351 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_slice_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.Items)
+        json: {isEmpty: {getmember: [{ref: x}, Items]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 352 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 353 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
               EventKind: Entry
               EventExpressionIndex: 0
     - id: lenStruct_isEmpty_string_cond
@@ -2147,7 +2452,7 @@ Probes:
       subprogram: {subprogram: 36}
       events:
         - Kind: Entry
-          Type: 338 EventRootType Probe[main.lenStructFields]
+          Type: 354 EventRootType Probe[main.lenStructFields]
           InjectionPoints: [{PC: "0xca30c", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -2164,7 +2469,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          Type: 355 EventRootType Probe[main.lenStructFields]Return
           InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -2335,11 +2640,11 @@ Probes:
       subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 356 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 372 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xca740", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 357 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 373 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xca8bc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -3886,7 +4191,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 360
+      ID: 376
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3912,7 +4217,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 361
+      ID: 377
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4980,7 +5285,7 @@ Types:
       ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 358
+      ID: 374
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4996,7 +5301,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 359
+      ID: 375
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
       ID: 195
@@ -5056,7 +5361,7 @@ Types:
       ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 348
+      ID: 364
       Name: Probe[main.lenErrInt]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5082,16 +5387,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 350
+      ID: 366
       Name: Probe[main.lenErrInt]
     - __kind: EventRootType
-      ID: 349
+      ID: 365
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 351
+      ID: 367
       Name: Probe[main.lenErrInt]Return
     - __kind: EventRootType
-      ID: 352
+      ID: 368
       Name: Probe[main.lenErrStruct]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -5117,19 +5422,86 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 354
+      ID: 370
       Name: Probe[main.lenErrStruct]
     - __kind: EventRootType
-      ID: 353
+      ID: 369
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 355
+      ID: 371
       Name: Probe[main.lenErrStruct]Return
     - __kind: EventRootType
-      ID: 318
+      ID: 324
       Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 320
+      ID: 326
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenMap]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenMap]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(m)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
       Name: Probe[main.lenMap]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5155,13 +5527,22 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 319
+      ID: 325
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 321
+      ID: 327
       Name: Probe[main.lenMap]Return
     - __kind: EventRootType
-      ID: 322
+      ID: 329
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 334
       Name: Probe[main.lenPtrString]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5180,7 +5561,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 324
+      ID: 336
       Name: Probe[main.lenPtrString]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5206,13 +5587,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 323
+      ID: 335
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 325
+      ID: 337
       Name: Probe[main.lenPtrString]Return
     - __kind: EventRootType
-      ID: 340
+      ID: 356
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -5238,10 +5619,29 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 342
+      ID: 358
       Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 344
+      ID: 360
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5260,7 +5660,7 @@ Types:
                   Bias: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 346
+      ID: 362
       Name: Probe[main.lenPtrStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5279,19 +5679,67 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 341
+      ID: 357
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 343
+      ID: 359
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 345
+      ID: 361
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
-      ID: 347
+      ID: 363
       Name: Probe[main.lenPtrStructFields]Return
     - __kind: EventRootType
       ID: 314
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenSlice]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 320
       Name: Probe[main.lenSlice]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5307,7 +5755,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 316
+      ID: 322
       Name: Probe[main.lenSlice]
       ByteSize: 41
       PresenceBitsetSize: 1
@@ -5337,6 +5785,15 @@ Types:
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 317
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 323
       Name: Probe[main.lenSlice]Return
     - __kind: EventRootType
       ID: 304
@@ -5444,7 +5901,7 @@ Types:
       ID: 313
       Name: Probe[main.lenString]Return
     - __kind: EventRootType
-      ID: 326
+      ID: 338
       Name: Probe[main.lenStructFields]
       ByteSize: 89
       PresenceBitsetSize: 1
@@ -5470,10 +5927,26 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 328
+      ID: 340
       Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Dict)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 8 BaseType uint64
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 40
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 0
+                  ByteSize: 8
     - __kind: EventRootType
-      ID: 330
+      ID: 342
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5492,7 +5965,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 332
+      ID: 344
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5511,7 +5984,7 @@ Types:
                   Bias: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 334
+      ID: 346
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5527,7 +6000,7 @@ Types:
                   Offset: 24
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 336
+      ID: 348
       Name: Probe[main.lenStructFields]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -5543,7 +6016,7 @@ Types:
                   Offset: 8
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 338
+      ID: 350
       Name: Probe[main.lenStructFields]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -5559,25 +6032,63 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 327
-      Name: Probe[main.lenStructFields]Return
+      ID: 352
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
-      ID: 329
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 331
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 333
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 335
-      Name: Probe[main.lenStructFields]Return
-    - __kind: EventRootType
-      ID: 337
-      Name: Probe[main.lenStructFields]Return
+      ID: 354
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
     - __kind: EventRootType
       ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 355
       Name: Probe[main.lenStructFields]Return
     - __kind: EventRootType
       ID: 212
@@ -5723,10 +6234,10 @@ Types:
       ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 356
+      ID: 372
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 357
+      ID: 373
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -7645,7 +8156,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47456
       GoKind: 26
-MaxTypeID: 361
+MaxTypeID: 377
 Issues:
     - probe_definition:
         id: condErr_bad_field

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -12,7 +12,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 305 EventRootType Probe[main.PointerChainArg]
-          InjectionPoints: [{PC: "0xc8264", Frameless: false}]
+          InjectionPoints: [{PC: "0xc826c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'ptr: {ptr}'
@@ -34,7 +34,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 306 EventRootType Probe[main.PointerSmallChainArg]
-          InjectionPoints: [{PC: "0xc8298", Frameless: false}]
+          InjectionPoints: [{PC: "0xc82a4", Frameless: false}]
           Condition: null
     - id: bigMapArg
       version: 0
@@ -47,11 +47,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 211 EventRootType Probe[main.bigMapArg]
-          InjectionPoints: [{PC: "0xc8bd8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9008", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 212 EventRootType Probe[main.bigMapArg]Return
-          InjectionPoints: [{PC: "0xc8c24", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9054", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -74,7 +74,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 255 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xc9338", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -91,7 +91,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 256 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xc939c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -114,7 +114,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 257 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xc9338", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -131,7 +131,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 258 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xc939c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -153,11 +153,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 259 EventRootType Probe[main.condBool]
-          InjectionPoints: [{PC: "0xc9338", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 260 EventRootType Probe[main.condBool]Return
-          InjectionPoints: [{PC: "0xc939c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
       version: 0
@@ -171,11 +171,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 251 EventRootType Probe[main.condFloat32]
-          InjectionPoints: [{PC: "0xc91f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9628", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 252 EventRootType Probe[main.condFloat32]Return
-          InjectionPoints: [{PC: "0xc9258", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9688", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
       version: 0
@@ -189,11 +189,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 253 EventRootType Probe[main.condFloat64]
-          InjectionPoints: [{PC: "0xc9298", Frameless: false}]
+          InjectionPoints: [{PC: "0xc96c8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 254 EventRootType Probe[main.condFloat64]Return
-          InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9728", Frameless: false}]
           Condition: null
     - id: condInt16_cond
       version: 0
@@ -208,7 +208,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 219 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xc8d88", Frameless: false}]
+          InjectionPoints: [{PC: "0xc91b8", Frameless: false}]
           Condition:
             Type: 102 BaseType int16
             Operations:
@@ -225,7 +225,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 220 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xc8de4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9214", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -247,11 +247,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 221 EventRootType Probe[main.condInt16]
-          InjectionPoints: [{PC: "0xc8d88", Frameless: false}]
+          InjectionPoints: [{PC: "0xc91b8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 222 EventRootType Probe[main.condInt16]Return
-          InjectionPoints: [{PC: "0xc8de4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9214", Frameless: false}]
           Condition: null
     - id: condInt32_cond
       version: 0
@@ -266,7 +266,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 223 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xc8e28", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -283,7 +283,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 224 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xc8e84", Frameless: false}]
+          InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -309,7 +309,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 225 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xc8e28", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -326,7 +326,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 226 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xc8e84", Frameless: false}]
+          InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
       version: 0
@@ -340,11 +340,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 227 EventRootType Probe[main.condInt32]
-          InjectionPoints: [{PC: "0xc8e28", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 228 EventRootType Probe[main.condInt32]Return
-          InjectionPoints: [{PC: "0xc8e84", Frameless: false}]
+          InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
     - id: condInt64_cond
       version: 0
@@ -359,7 +359,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 229 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xc8ec8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
             Operations:
@@ -376,7 +376,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 230 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xc8f24", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9354", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -398,11 +398,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 231 EventRootType Probe[main.condInt64]
-          InjectionPoints: [{PC: "0xc8ec8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 232 EventRootType Probe[main.condInt64]Return
-          InjectionPoints: [{PC: "0xc8f24", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9354", Frameless: false}]
           Condition: null
     - id: condInt8_cond
       version: 0
@@ -417,7 +417,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 215 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xc8cd8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9108", Frameless: false}]
           Condition:
             Type: 19 BaseType int8
             Operations:
@@ -434,7 +434,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 216 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xc8d3c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc916c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -456,11 +456,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 217 EventRootType Probe[main.condInt8]
-          InjectionPoints: [{PC: "0xc8cd8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9108", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 218 EventRootType Probe[main.condInt8]Return
-          InjectionPoints: [{PC: "0xc8d3c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc916c", Frameless: false}]
           Condition: null
     - id: condLine_cond
       version: 0
@@ -468,7 +468,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -484,7 +484,7 @@ Probes:
       events:
         - Kind: Line
           Type: 299 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xc9888", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -505,7 +505,7 @@ Probes:
       where:
         methodName: main.condLine
         sourceFile: main.go
-        lines: ["343"]
+        lines: ["381"]
       tags:
         - skip_integration:arch=arm64,toolchain=go1.23.11
         - skip_integration:arch=amd64,toolchain=go1.23.11
@@ -517,7 +517,7 @@ Probes:
       events:
         - Kind: Line
           Type: 300 EventRootType Probe[main.condLine]Line
-          InjectionPoints: [{PC: "0xc9888", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
       version: 0
@@ -534,7 +534,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 287 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xc9688", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -554,7 +554,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xc96f4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: condNilPtr {tag}
@@ -576,11 +576,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 289 EventRootType Probe[main.condNilPtrStruct]
-          InjectionPoints: [{PC: "0xc9688", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
-          InjectionPoints: [{PC: "0xc96f4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
     - id: condOnly_cond
       version: 0
@@ -595,7 +595,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 295 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xc97d8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -612,7 +612,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 296 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xc9834", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
       version: 0
@@ -626,11 +626,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 297 EventRootType Probe[main.condOnly]
-          InjectionPoints: [{PC: "0xc97d8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 298 EventRootType Probe[main.condOnly]Return
-          InjectionPoints: [{PC: "0xc9834", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
       version: 0
@@ -647,7 +647,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 281 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xc957c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -667,7 +667,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 282 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xc963c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -692,7 +692,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 283 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xc957c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -711,7 +711,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 284 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xc963c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -733,11 +733,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 285 EventRootType Probe[main.condPtrStructArg]
-          InjectionPoints: [{PC: "0xc957c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 286 EventRootType Probe[main.condPtrStructArg]Return
-          InjectionPoints: [{PC: "0xc963c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
       version: 0
@@ -752,7 +752,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 291 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xc9738", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition:
             Type: 7 BaseType int
             Operations:
@@ -769,7 +769,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xc9794", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: b={b}
@@ -791,11 +791,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 293 EventRootType Probe[main.condReturnAndLocal]
-          InjectionPoints: [{PC: "0xc9738", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
-          InjectionPoints: [{PC: "0xc9794", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
     - id: condString_cond
       version: 0
@@ -812,7 +812,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 261 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xc93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -828,7 +828,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 262 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -851,7 +851,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 263 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xc93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -867,7 +867,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 264 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -889,11 +889,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 265 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xc93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 266 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
       version: 0
@@ -910,7 +910,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 267 EventRootType Probe[main.condString]
-          InjectionPoints: [{PC: "0xc93e8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -926,7 +926,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 268 EventRootType Probe[main.condString]Return
-          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
       version: 0
@@ -946,7 +946,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 269 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -963,7 +963,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 270 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
       version: 0
@@ -980,7 +980,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 271 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
             Operations:
@@ -997,7 +997,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 272 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1022,7 +1022,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 273 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 14 BaseType float64
             Operations:
@@ -1039,7 +1039,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 274 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1064,7 +1064,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 275 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
             Operations:
@@ -1081,7 +1081,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 276 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1106,7 +1106,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 277 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -1122,7 +1122,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 278 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1144,11 +1144,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 279 EventRootType Probe[main.condStructArg]
-          InjectionPoints: [{PC: "0xc948c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 280 EventRootType Probe[main.condStructArg]Return
-          InjectionPoints: [{PC: "0xc9540", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condUint16_cond
       version: 0
@@ -1163,7 +1163,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 239 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xc9018", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
             Operations:
@@ -1180,7 +1180,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 240 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xc9074", Frameless: false}]
+          InjectionPoints: [{PC: "0xc94a4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1202,11 +1202,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 241 EventRootType Probe[main.condUint16]
-          InjectionPoints: [{PC: "0xc9018", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9448", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 242 EventRootType Probe[main.condUint16]Return
-          InjectionPoints: [{PC: "0xc9074", Frameless: false}]
+          InjectionPoints: [{PC: "0xc94a4", Frameless: false}]
           Condition: null
     - id: condUint32_cond
       version: 0
@@ -1221,7 +1221,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 243 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xc90b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc94e8", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
             Operations:
@@ -1238,7 +1238,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 244 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xc9114", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9544", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1260,11 +1260,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 245 EventRootType Probe[main.condUint32]
-          InjectionPoints: [{PC: "0xc90b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc94e8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 246 EventRootType Probe[main.condUint32]Return
-          InjectionPoints: [{PC: "0xc9114", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9544", Frameless: false}]
           Condition: null
     - id: condUint64_cond
       version: 0
@@ -1279,7 +1279,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 247 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xc9158", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9588", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
             Operations:
@@ -1296,7 +1296,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 248 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xc91b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc95e4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1318,11 +1318,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 249 EventRootType Probe[main.condUint64]
-          InjectionPoints: [{PC: "0xc9158", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9588", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 250 EventRootType Probe[main.condUint64]Return
-          InjectionPoints: [{PC: "0xc91b4", Frameless: false}]
+          InjectionPoints: [{PC: "0xc95e4", Frameless: false}]
           Condition: null
     - id: condUint8_cond
       version: 0
@@ -1337,7 +1337,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 233 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xc8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1354,7 +1354,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 234 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xc8fcc", Frameless: false}]
+          InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1377,7 +1377,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 235 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xc8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
             Operations:
@@ -1394,7 +1394,7 @@ Probes:
                 - __kind: ConditionCheckOp
         - Kind: Return
           Type: 236 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xc8fcc", Frameless: false}]
+          InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: tag={tag}
@@ -1416,11 +1416,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 237 EventRootType Probe[main.condUint8]
-          InjectionPoints: [{PC: "0xc8f68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 238 EventRootType Probe[main.condUint8]Return
-          InjectionPoints: [{PC: "0xc8fcc", Frameless: false}]
+          InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
     - id: inlined
       version: 0
@@ -1437,12 +1437,12 @@ Probes:
           InjectionPoints:
             - PC: "0xc8040"
               Frameless: false
-            - PC: "0xc8aa8"
+            - PC: "0xc8ed8"
               Frameless: false
           Condition: null
         - Kind: Return
           Type: 304 EventRootType Probe[main.inlined]Return
-          InjectionPoints: [{PC: "0xc8adc", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8f0c", Frameless: false}]
           Condition: null
     - id: intArg
       version: 0
@@ -1455,11 +1455,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 192 EventRootType Probe[main.intArg]
-          InjectionPoints: [{PC: "0xc87d8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8c08", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 193 EventRootType Probe[main.intArg]Return
-          InjectionPoints: [{PC: "0xc880c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8c3c", Frameless: false}]
           Condition: null
     - id: intArrayArg
       version: 0
@@ -1472,11 +1472,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 202 EventRootType Probe[main.intArrayArg]
-          InjectionPoints: [{PC: "0xc8938", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8d68", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 203 EventRootType Probe[main.intArrayArg]Return
-          InjectionPoints: [{PC: "0xc8978", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8da8", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
       version: 0
@@ -1489,7 +1489,7 @@ Probes:
       events:
         - Kind: Entry
           Type: 208 EventRootType Probe[main.stringArrayArgFrameless]
-          InjectionPoints: [{PC: "0xc8a80", Frameless: true}]
+          InjectionPoints: [{PC: "0xc8eb0", Frameless: true}]
           Condition: null
     - id: intSliceArg
       version: 0
@@ -1502,11 +1502,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 200 EventRootType Probe[main.intSliceArg]
-          InjectionPoints: [{PC: "0xc88b8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8ce8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 201 EventRootType Probe[main.intSliceArg]Return
-          InjectionPoints: [{PC: "0xc88f0", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8d20", Frameless: false}]
           Condition: null
     - id: logProbe_no_snapshot_stringArg
       version: 0
@@ -1519,11 +1519,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 194 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xc8848", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 195 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xc8880", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1544,11 +1544,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 196 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xc8848", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 197 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xc8880", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'x: {x}'
@@ -1567,11 +1567,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 209 EventRootType Probe[main.mapArg]
-          InjectionPoints: [{PC: "0xc8b68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8f98", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 210 EventRootType Probe[main.mapArg]Return
-          InjectionPoints: [{PC: "0xc8b94", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8fc4", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 'm: {m}'
@@ -1592,11 +1592,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 213 EventRootType Probe[main.noArgs]
-          InjectionPoints: [{PC: "0xc8c68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc9098", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 214 EventRootType Probe[main.noArgs]Return
-          InjectionPoints: [{PC: "0xc8c9c", Frameless: false}]
+          InjectionPoints: [{PC: "0xc90cc", Frameless: false}]
           Condition: null
     - id: stringArg
       version: 0
@@ -1609,11 +1609,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 198 EventRootType Probe[main.stringArg]
-          InjectionPoints: [{PC: "0xc8848", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 199 EventRootType Probe[main.stringArg]Return
-          InjectionPoints: [{PC: "0xc8880", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
         TemplateString: 's: {s}'
@@ -1634,11 +1634,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 206 EventRootType Probe[main.stringArrayArg]
-          InjectionPoints: [{PC: "0xc8a28", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8e58", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 207 EventRootType Probe[main.stringArrayArg]Return
-          InjectionPoints: [{PC: "0xc8a68", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8e98", Frameless: false}]
           Condition: null
     - id: stringSliceArg
       version: 0
@@ -1651,11 +1651,11 @@ Probes:
       events:
         - Kind: Entry
           Type: 204 EventRootType Probe[main.stringSliceArg]
-          InjectionPoints: [{PC: "0xc89a8", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8dd8", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 205 EventRootType Probe[main.stringSliceArg]Return
-          InjectionPoints: [{PC: "0xc89e0", Frameless: false}]
+          InjectionPoints: [{PC: "0xc8e10", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
       version: 0
@@ -1669,33 +1669,33 @@ Probes:
       events:
         - Kind: Entry
           Type: 301 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
-          InjectionPoints: [{PC: "0xc9b30", Frameless: false}]
+          InjectionPoints: [{PC: "0xca740", Frameless: false}]
           Condition: null
         - Kind: Return
           Type: 302 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
-          InjectionPoints: [{PC: "0xc9cac", Frameless: false}]
+          InjectionPoints: [{PC: "0xca8bc", Frameless: false}]
           Condition: null
 Subprograms:
     - ID: 1
       Name: main.intArg
-      OutOfLinePCRanges: [0xc87c0..0xc8830]
+      OutOfLinePCRanges: [0xc8bf0..0xc8c60]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc87c0..0xc87e0
+            - Range: 0xc8bf0..0xc8c10
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 2
       Name: main.stringArg
-      OutOfLinePCRanges: [0xc8830..0xc88a0]
+      OutOfLinePCRanges: [0xc8c60..0xc8cd0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8830..0xc8854
+            - Range: 0xc8c60..0xc8c84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1704,13 +1704,13 @@ Subprograms:
           Role: Parameter
     - ID: 3
       Name: main.intSliceArg
-      OutOfLinePCRanges: [0xc88a0..0xc8920]
+      OutOfLinePCRanges: [0xc8cd0..0xc8d50]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xc88a0..0xc88c4
+            - Range: 0xc8cd0..0xc8cf4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1721,24 +1721,24 @@ Subprograms:
           Role: Parameter
     - ID: 4
       Name: main.intArrayArg
-      OutOfLinePCRanges: [0xc8920..0xc8990]
+      OutOfLinePCRanges: [0xc8d50..0xc8dc0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 113 ArrayType [3]int
           Locations:
-            - Range: 0xc8920..0xc8990
+            - Range: 0xc8d50..0xc8dc0
               Pieces: [{Size: 24, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 5
       Name: main.stringSliceArg
-      OutOfLinePCRanges: [0xc8990..0xc8a10]
+      OutOfLinePCRanges: [0xc8dc0..0xc8e40]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 114 GoSliceHeaderType []string
           Locations:
-            - Range: 0xc8990..0xc89b4
+            - Range: 0xc8dc0..0xc8de4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -1749,76 +1749,76 @@ Subprograms:
           Role: Parameter
     - ID: 6
       Name: main.stringArrayArg
-      OutOfLinePCRanges: [0xc8a10..0xc8a80]
+      OutOfLinePCRanges: [0xc8e40..0xc8eb0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0xc8a10..0xc8a80
+            - Range: 0xc8e40..0xc8eb0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 7
       Name: main.stringArrayArgFrameless
-      OutOfLinePCRanges: [0xc8a80..0xc8a90]
+      OutOfLinePCRanges: [0xc8eb0..0xc8ec0]
       InlinePCRanges: []
       Variables:
         - Name: s
           Type: 115 ArrayType [3]string
           Locations:
-            - Range: 0xc8a80..0xc8a90
+            - Range: 0xc8eb0..0xc8ec0
               Pieces: [{Size: 48, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 8
       Name: main.mapArg
-      OutOfLinePCRanges: [0xc8b50..0xc8bc0]
+      OutOfLinePCRanges: [0xc8f80..0xc8ff0]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xc8b50..0xc8b84
+            - Range: 0xc8f80..0xc8fb4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 9
       Name: main.bigMapArg
-      OutOfLinePCRanges: [0xc8bc0..0xc8c50]
+      OutOfLinePCRanges: [0xc8ff0..0xc9080]
       InlinePCRanges: []
       Variables:
         - Name: m
           Type: 121 GoMapType map[string]main.bigStruct
           Locations:
-            - Range: 0xc8bc0..0xc8bf0
+            - Range: 0xc8ff0..0xc9020
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc8bf0..0xc8c50
+            - Range: 0xc9020..0xc9080
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
     - ID: 10
       Name: main.noArgs
-      OutOfLinePCRanges: [0xc8c50..0xc8cc0]
+      OutOfLinePCRanges: [0xc9080..0xc90f0]
       InlinePCRanges: []
       Variables: []
     - ID: 11
       Name: main.condInt8
-      OutOfLinePCRanges: [0xc8cc0..0xc8d70]
+      OutOfLinePCRanges: [0xc90f0..0xc91a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 19 BaseType int8
           Locations:
-            - Range: 0xc8cc0..0xc8d08
+            - Range: 0xc90f0..0xc9138
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8cc0..0xc8d0c
+            - Range: 0xc90f0..0xc913c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc8d0c..0xc8d10
+            - Range: 0xc913c..0xc9140
               Pieces:
                 - Size: 8
                   Op: null
@@ -1827,31 +1827,31 @@ Subprograms:
           Role: Parameter
     - ID: 12
       Name: main.condInt16
-      OutOfLinePCRanges: [0xc8d70..0xc8e10]
+      OutOfLinePCRanges: [0xc91a0..0xc9240]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 102 BaseType int16
           Locations:
-            - Range: 0xc8d70..0xc8da0
+            - Range: 0xc91a0..0xc91d0
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8d70..0xc8d94
+            - Range: 0xc91a0..0xc91c4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc8d94..0xc8da0
+            - Range: 0xc91c4..0xc91d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc8da0..0xc8e10
+            - Range: 0xc91d0..0xc9240
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1860,31 +1860,31 @@ Subprograms:
           Role: Parameter
     - ID: 13
       Name: main.condInt32
-      OutOfLinePCRanges: [0xc8e10..0xc8eb0]
+      OutOfLinePCRanges: [0xc9240..0xc92e0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 12 BaseType int32
           Locations:
-            - Range: 0xc8e10..0xc8e40
+            - Range: 0xc9240..0xc9270
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8e10..0xc8e34
+            - Range: 0xc9240..0xc9264
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc8e34..0xc8e40
+            - Range: 0xc9264..0xc9270
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc8e40..0xc8eb0
+            - Range: 0xc9270..0xc92e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1893,31 +1893,31 @@ Subprograms:
           Role: Parameter
     - ID: 14
       Name: main.condInt64
-      OutOfLinePCRanges: [0xc8eb0..0xc8f50]
+      OutOfLinePCRanges: [0xc92e0..0xc9380]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 13 BaseType int64
           Locations:
-            - Range: 0xc8eb0..0xc8ee0
+            - Range: 0xc92e0..0xc9310
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8eb0..0xc8ed4
+            - Range: 0xc92e0..0xc9304
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc8ed4..0xc8ee0
+            - Range: 0xc9304..0xc9310
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc8ee0..0xc8f50
+            - Range: 0xc9310..0xc9380
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1926,25 +1926,25 @@ Subprograms:
           Role: Parameter
     - ID: 15
       Name: main.condUint8
-      OutOfLinePCRanges: [0xc8f50..0xc9000]
+      OutOfLinePCRanges: [0xc9380..0xc9430]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 3 BaseType uint8
           Locations:
-            - Range: 0xc8f50..0xc8f98
+            - Range: 0xc9380..0xc93c8
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc8f50..0xc8f9c
+            - Range: 0xc9380..0xc93cc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc8f9c..0xc8fa0
+            - Range: 0xc93cc..0xc93d0
               Pieces:
                 - Size: 8
                   Op: null
@@ -1953,31 +1953,31 @@ Subprograms:
           Role: Parameter
     - ID: 16
       Name: main.condUint16
-      OutOfLinePCRanges: [0xc9000..0xc90a0]
+      OutOfLinePCRanges: [0xc9430..0xc94d0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 6 BaseType uint16
           Locations:
-            - Range: 0xc9000..0xc9030
+            - Range: 0xc9430..0xc9460
               Pieces: [{Size: 2, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9000..0xc9024
+            - Range: 0xc9430..0xc9454
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc9024..0xc9030
+            - Range: 0xc9454..0xc9460
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc9030..0xc90a0
+            - Range: 0xc9460..0xc94d0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -1986,31 +1986,31 @@ Subprograms:
           Role: Parameter
     - ID: 17
       Name: main.condUint32
-      OutOfLinePCRanges: [0xc90a0..0xc9140]
+      OutOfLinePCRanges: [0xc94d0..0xc9570]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 2 BaseType uint32
           Locations:
-            - Range: 0xc90a0..0xc90d0
+            - Range: 0xc94d0..0xc9500
               Pieces: [{Size: 4, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc90a0..0xc90c4
+            - Range: 0xc94d0..0xc94f4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc90c4..0xc90d0
+            - Range: 0xc94f4..0xc9500
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc90d0..0xc9140
+            - Range: 0xc9500..0xc9570
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2019,31 +2019,31 @@ Subprograms:
           Role: Parameter
     - ID: 18
       Name: main.condUint64
-      OutOfLinePCRanges: [0xc9140..0xc91e0]
+      OutOfLinePCRanges: [0xc9570..0xc9610]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 8 BaseType uint64
           Locations:
-            - Range: 0xc9140..0xc9170
+            - Range: 0xc9570..0xc95a0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9140..0xc9164
+            - Range: 0xc9570..0xc9594
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc9164..0xc9170
+            - Range: 0xc9594..0xc95a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc9170..0xc91e0
+            - Range: 0xc95a0..0xc9610
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2052,31 +2052,31 @@ Subprograms:
           Role: Parameter
     - ID: 19
       Name: main.condFloat32
-      OutOfLinePCRanges: [0xc91e0..0xc9280]
+      OutOfLinePCRanges: [0xc9610..0xc96b0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 17 BaseType float32
           Locations:
-            - Range: 0xc91e0..0xc9214
+            - Range: 0xc9610..0xc9644
               Pieces: [{Size: 4, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc91e0..0xc9204
+            - Range: 0xc9610..0xc9634
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xc9204..0xc9210
+            - Range: 0xc9634..0xc9640
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc9210..0xc9280
+            - Range: 0xc9640..0xc96b0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2085,31 +2085,31 @@ Subprograms:
           Role: Parameter
     - ID: 20
       Name: main.condFloat64
-      OutOfLinePCRanges: [0xc9280..0xc9320]
+      OutOfLinePCRanges: [0xc96b0..0xc9750]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 14 BaseType float64
           Locations:
-            - Range: 0xc9280..0xc92b4
+            - Range: 0xc96b0..0xc96e4
               Pieces: [{Size: 8, Op: {RegNo: 64, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9280..0xc92a4
+            - Range: 0xc96b0..0xc96d4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xc92a4..0xc92b0
+            - Range: 0xc96d4..0xc96e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc92b0..0xc9320
+            - Range: 0xc96e0..0xc9750
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2118,25 +2118,25 @@ Subprograms:
           Role: Parameter
     - ID: 21
       Name: main.condBool
-      OutOfLinePCRanges: [0xc9320..0xc93d0]
+      OutOfLinePCRanges: [0xc9750..0xc9800]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 4 BaseType bool
           Locations:
-            - Range: 0xc9320..0xc9368
+            - Range: 0xc9750..0xc9798
               Pieces: [{Size: 1, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9320..0xc936c
+            - Range: 0xc9750..0xc979c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc936c..0xc9370
+            - Range: 0xc979c..0xc97a0
               Pieces:
                 - Size: 8
                   Op: null
@@ -2145,13 +2145,13 @@ Subprograms:
           Role: Parameter
     - ID: 22
       Name: main.condString
-      OutOfLinePCRanges: [0xc93d0..0xc9470]
+      OutOfLinePCRanges: [0xc9800..0xc98a0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc93d0..0xc9404
+            - Range: 0xc9800..0xc9834
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2161,19 +2161,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc93d0..0xc93f8
+            - Range: 0xc9800..0xc9828
               Pieces:
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
-            - Range: 0xc93f8..0xc9404
+            - Range: 0xc9828..0xc9834
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
                 - Size: 8
                   Op: {CfaOffset: 32}
-            - Range: 0xc9404..0xc9470
+            - Range: 0xc9834..0xc98a0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 24}
@@ -2182,31 +2182,31 @@ Subprograms:
           Role: Parameter
     - ID: 23
       Name: main.condStructArg
-      OutOfLinePCRanges: [0xc9470..0xc9560]
+      OutOfLinePCRanges: [0xc98a0..0xc9990]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0xc9470..0xc9560
+            - Range: 0xc98a0..0xc9990
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9470..0xc9498
+            - Range: 0xc98a0..0xc98c8
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xc9498..0xc94b0
+            - Range: 0xc98c8..0xc98e0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xc94b0..0xc9560
+            - Range: 0xc98e0..0xc9990
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2215,33 +2215,33 @@ Subprograms:
           Role: Parameter
     - ID: 24
       Name: main.condPtrStructArg
-      OutOfLinePCRanges: [0xc9560..0xc9670]
+      OutOfLinePCRanges: [0xc9990..0xc9aa0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0xc9560..0xc95a4
+            - Range: 0xc9990..0xc99d4
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc95a4..0xc9670
+            - Range: 0xc99d4..0xc9aa0
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9560..0xc958c
+            - Range: 0xc9990..0xc99bc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc958c..0xc95a8
+            - Range: 0xc99bc..0xc99d8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc95a8..0xc9670
+            - Range: 0xc99d8..0xc9aa0
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2250,25 +2250,25 @@ Subprograms:
           Role: Parameter
     - ID: 25
       Name: main.condNilPtrStruct
-      OutOfLinePCRanges: [0xc9670..0xc9720]
+      OutOfLinePCRanges: [0xc9aa0..0xc9b50]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 128 PointerType *main.condFields
           Locations:
-            - Range: 0xc9670..0xc96c0
+            - Range: 0xc9aa0..0xc9af0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9670..0xc96c4
+            - Range: 0xc9aa0..0xc9af4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc96c4..0xc96c8
+            - Range: 0xc9af4..0xc9af8
               Pieces:
                 - Size: 8
                   Op: null
@@ -2277,66 +2277,66 @@ Subprograms:
           Role: Parameter
     - ID: 26
       Name: main.condReturnAndLocal
-      OutOfLinePCRanges: [0xc9720..0xc97c0]
+      OutOfLinePCRanges: [0xc9b50..0xc9bf0]
       InlinePCRanges: []
       Variables:
         - Name: a
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc9720..0xc973c
+            - Range: 0xc9b50..0xc9b6c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: b
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc9720..0xc9744
+            - Range: 0xc9b50..0xc9b74
               Pieces: [{Size: 8, Op: {RegNo: 1, Shift: 0}}]
           Role: Parameter
         - Name: ~r0
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc9720..0xc9794
+            - Range: 0xc9b50..0xc9bc4
               Pieces: []
-            - Range: 0xc9794..0xc9795
+            - Range: 0xc9bc4..0xc9bc5
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc9795..0xc97c0
+            - Range: 0xc9bc5..0xc9bf0
               Pieces: []
           Role: Return
         - Name: sum
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc973c..0xc9764
+            - Range: 0xc9b6c..0xc9b94
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc9764..0xc97c0
+            - Range: 0xc9b94..0xc9bf0
               Pieces: [{Size: 8, Op: {CfaOffset: -48}}]
           Role: Local
     - ID: 27
       Name: main.condOnly
-      OutOfLinePCRanges: [0xc97c0..0xc9860]
+      OutOfLinePCRanges: [0xc9bf0..0xc9c90]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc97c0..0xc97f0
+            - Range: 0xc9bf0..0xc9c20
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc97c0..0xc97e4
+            - Range: 0xc9bf0..0xc9c14
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc97e4..0xc97f0
+            - Range: 0xc9c14..0xc9c20
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc97f0..0xc9860
+            - Range: 0xc9c20..0xc9c90
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2345,33 +2345,33 @@ Subprograms:
           Role: Parameter
     - ID: 28
       Name: main.condLine
-      OutOfLinePCRanges: [0xc9860..0xc9920]
+      OutOfLinePCRanges: [0xc9c90..0xc9d50]
       InlinePCRanges: []
       Variables:
         - Name: n
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc9860..0xc9888
+            - Range: 0xc9c90..0xc9cb8
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc9888..0xc9920
+            - Range: 0xc9cb8..0xc9d50
               Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9860..0xc988c
+            - Range: 0xc9c90..0xc9cbc
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc988c..0xc989c
+            - Range: 0xc9cbc..0xc9ccc
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
                 - Size: 8
                   Op: {CfaOffset: 24}
-            - Range: 0xc989c..0xc9920
+            - Range: 0xc9ccc..0xc9d50
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 16}
@@ -2381,18 +2381,18 @@ Subprograms:
         - Name: result
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc9888..0xc989c
+            - Range: 0xc9cb8..0xc9ccc
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Local
     - ID: 29
       Name: main.condSliceArg
-      OutOfLinePCRanges: [0xc9920..0xc99d0]
+      OutOfLinePCRanges: [0xc9d50..0xc9e00]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 112 GoSliceHeaderType []int
           Locations:
-            - Range: 0xc9920..0xc9954
+            - Range: 0xc9d50..0xc9d84
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
@@ -2404,19 +2404,19 @@ Subprograms:
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9920..0xc9948
+            - Range: 0xc9d50..0xc9d78
               Pieces:
                 - Size: 8
                   Op: {RegNo: 3, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 4, Shift: 0}
-            - Range: 0xc9948..0xc9954
+            - Range: 0xc9d78..0xc9d84
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
                 - Size: 8
                   Op: {CfaOffset: 40}
-            - Range: 0xc9954..0xc99d0
+            - Range: 0xc9d84..0xc9e00
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 32}
@@ -2425,25 +2425,25 @@ Subprograms:
           Role: Parameter
     - ID: 30
       Name: main.condMapArg
-      OutOfLinePCRanges: [0xc99d0..0xc9a70]
+      OutOfLinePCRanges: [0xc9e00..0xc9ea0]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 116 GoMapType map[string]int
           Locations:
-            - Range: 0xc99d0..0xc9a08
+            - Range: 0xc9e00..0xc9e38
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc99d0..0xc9a0c
+            - Range: 0xc9e00..0xc9e3c
               Pieces:
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 2, Shift: 0}
-            - Range: 0xc9a0c..0xc9a10
+            - Range: 0xc9e3c..0xc9e40
               Pieces:
                 - Size: 8
                   Op: null
@@ -2452,31 +2452,31 @@ Subprograms:
           Role: Parameter
     - ID: 31
       Name: main.condStructDirect
-      OutOfLinePCRanges: [0xc9a70..0xc9b10]
+      OutOfLinePCRanges: [0xc9ea0..0xc9f40]
       InlinePCRanges: []
       Variables:
         - Name: x
           Type: 126 StructureType main.condFields
           Locations:
-            - Range: 0xc9a70..0xc9b10
+            - Range: 0xc9ea0..0xc9f40
               Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
           Role: Parameter
         - Name: tag
           Type: 9 GoStringHeaderType string
           Locations:
-            - Range: 0xc9a70..0xc9aa4
+            - Range: 0xc9ea0..0xc9ed4
               Pieces:
                 - Size: 8
                   Op: {RegNo: 0, Shift: 0}
                 - Size: 8
                   Op: {RegNo: 1, Shift: 0}
-            - Range: 0xc9aa4..0xc9aa8
+            - Range: 0xc9ed4..0xc9ed8
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
                 - Size: 8
                   Op: {CfaOffset: 96}
-            - Range: 0xc9aa8..0xc9b10
+            - Range: 0xc9ed8..0xc9f40
               Pieces:
                 - Size: 8
                   Op: {CfaOffset: 88}
@@ -2485,58 +2485,58 @@ Subprograms:
           Role: Parameter
     - ID: 32
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
-      OutOfLinePCRanges: [0xc9b10..0xc9cd0]
+      OutOfLinePCRanges: [0xca720..0xca8e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
           Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
-            - Range: 0xc9b10..0xc9cac
+            - Range: 0xca720..0xca8bc
               Pieces: []
-            - Range: 0xc9cac..0xc9cad
+            - Range: 0xca8bc..0xca8bd
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
-            - Range: 0xc9cad..0xc9cd0
+            - Range: 0xca8bd..0xca8e0
               Pieces: []
           Role: Return
     - ID: 33
       Name: main.inlined
-      OutOfLinePCRanges: [0xc8a90..0xc8b00]
+      OutOfLinePCRanges: [0xc8ec0..0xc8f30]
       InlinePCRanges:
-        - Ranges: [0xc8040..0xc8074]
-          RootRanges: [0xc7ea0..0xc87c0]
+        - Ranges: [0xc8040..0xc8078]
+          RootRanges: [0xc7ea0..0xc8bf0]
       Variables:
         - Name: x
           Type: 7 BaseType int
           Locations:
-            - Range: 0xc8040..0xc8074
+            - Range: 0xc8040..0xc8078
               Pieces: []
-            - Range: 0xc8a90..0xc8ab0
+            - Range: 0xc8ec0..0xc8ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 34
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xc8264..0xc8290]
-          RootRanges: [0xc7ea0..0xc87c0]
+        - Ranges: [0xc826c..0xc829c]
+          RootRanges: [0xc7ea0..0xc8bf0]
       Variables:
         - Name: ptr
           Type: 134 PointerType *****int
           Locations:
-            - Range: 0xc823c..0xc8280
+            - Range: 0xc8244..0xc828c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
     - ID: 35
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
-        - Ranges: [0xc8298..0xc82c4]
-          RootRanges: [0xc7ea0..0xc87c0]
+        - Ranges: [0xc82a4..0xc82d4]
+          RootRanges: [0xc7ea0..0xc8bf0]
       Variables:
         - Name: ptr
           Type: 136 PointerType **int
           Locations:
-            - Range: 0xc8298..0xc82c4
+            - Range: 0xc82a4..0xc82d4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
@@ -2544,28 +2544,28 @@ Types:
       ID: 134
       Name: '*****int'
       ByteSize: 8
-      GoRuntimeType: 38816
+      GoRuntimeType: 39040
       GoKind: 22
       Pointee: 135 PointerType ****int
     - __kind: PointerType
       ID: 135
       Name: '****int'
       ByteSize: 8
-      GoRuntimeType: 38752
+      GoRuntimeType: 38976
       GoKind: 22
       Pointee: 191 PointerType ***int
     - __kind: PointerType
       ID: 191
       Name: '***int'
       ByteSize: 8
-      GoRuntimeType: 38688
+      GoRuntimeType: 38912
       GoKind: 22
       Pointee: 136 PointerType **int
     - __kind: PointerType
       ID: 136
       Name: '**int'
       ByteSize: 8
-      GoRuntimeType: 38624
+      GoRuntimeType: 38848
       GoKind: 22
       Pointee: 105 PointerType *int
     - __kind: PointerType
@@ -2608,7 +2608,7 @@ Types:
       ID: 40
       Name: '*[]runtime.ancestorInfo'
       ByteSize: 8
-      GoRuntimeType: 42848
+      GoRuntimeType: 43008
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
@@ -2630,70 +2630,70 @@ Types:
       ID: 10
       Name: '*bool'
       ByteSize: 8
-      GoRuntimeType: 32608
+      GoRuntimeType: 32704
       GoKind: 22
       Pointee: 4 BaseType bool
     - __kind: PointerType
       ID: 108
       Name: '*error'
       ByteSize: 8
-      GoRuntimeType: 31520
+      GoRuntimeType: 31616
       GoKind: 22
       Pointee: 15 GoInterfaceType error
     - __kind: PointerType
       ID: 109
       Name: '*float32'
       ByteSize: 8
-      GoRuntimeType: 32480
+      GoRuntimeType: 32576
       GoKind: 22
       Pointee: 17 BaseType float32
     - __kind: PointerType
       ID: 104
       Name: '*float64'
       ByteSize: 8
-      GoRuntimeType: 32544
+      GoRuntimeType: 32640
       GoKind: 22
       Pointee: 14 BaseType float64
     - __kind: PointerType
       ID: 105
       Name: '*int'
       ByteSize: 8
-      GoRuntimeType: 32160
+      GoRuntimeType: 32256
       GoKind: 22
       Pointee: 7 BaseType int
     - __kind: PointerType
       ID: 21
       Name: '*int32'
       ByteSize: 8
-      GoRuntimeType: 31904
+      GoRuntimeType: 32000
       GoKind: 22
       Pointee: 12 BaseType int32
     - __kind: PointerType
       ID: 107
       Name: '*int64'
       ByteSize: 8
-      GoRuntimeType: 32032
+      GoRuntimeType: 32128
       GoKind: 22
       Pointee: 13 BaseType int64
     - __kind: PointerType
       ID: 99
       Name: '*internal/runtime/atomic.Pointer[runtime.m]'
       ByteSize: 8
-      GoRuntimeType: 104928
+      GoRuntimeType: 105088
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
       ID: 164
       Name: '*main.bigStruct'
       ByteSize: 8
-      GoRuntimeType: 29984
+      GoRuntimeType: 30080
       GoKind: 22
       Pointee: 165 StructureType main.bigStruct
     - __kind: PointerType
       ID: 128
       Name: '*main.condFields'
       ByteSize: 8
-      GoRuntimeType: 29856
+      GoRuntimeType: 29888
       GoKind: 22
       Pointee: 126 StructureType main.condFields
     - __kind: PointerType
@@ -2740,91 +2740,91 @@ Types:
       ID: 27
       Name: '*runtime._defer'
       ByteSize: 8
-      GoRuntimeType: 32800
+      GoRuntimeType: 32896
       GoKind: 22
       Pointee: 28 UnresolvedPointeeType runtime._defer
     - __kind: PointerType
       ID: 25
       Name: '*runtime._panic'
       ByteSize: 8
-      GoRuntimeType: 89120
+      GoRuntimeType: 89280
       GoKind: 22
       Pointee: 26 UnresolvedPointeeType runtime._panic
     - __kind: PointerType
       ID: 69
       Name: '*runtime.cgoCallers'
       ByteSize: 8
-      GoRuntimeType: 34912
+      GoRuntimeType: 35008
       GoKind: 22
       Pointee: 70 UnresolvedPointeeType runtime.cgoCallers
     - __kind: PointerType
       ID: 48
       Name: '*runtime.coro'
       ByteSize: 8
-      GoRuntimeType: 33632
+      GoRuntimeType: 33728
       GoKind: 22
       Pointee: 49 UnresolvedPointeeType runtime.coro
     - __kind: PointerType
       ID: 59
       Name: '*runtime.g'
       ByteSize: 8
-      GoRuntimeType: 79968
+      GoRuntimeType: 80128
       GoKind: 22
       Pointee: 23 StructureType runtime.g
     - __kind: PointerType
       ID: 29
       Name: '*runtime.m'
       ByteSize: 8
-      GoRuntimeType: 89760
+      GoRuntimeType: 89920
       GoKind: 22
       Pointee: 30 StructureType runtime.m
     - __kind: PointerType
       ID: 68
       Name: '*runtime.p'
       ByteSize: 8
-      GoRuntimeType: 73056
+      GoRuntimeType: 73216
       GoKind: 22
       Pointee: 143 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
       ByteSize: 8
-      GoRuntimeType: 33568
+      GoRuntimeType: 33664
       GoKind: 22
       Pointee: 43 UnresolvedPointeeType runtime.sudog
     - __kind: PointerType
       ID: 50
       Name: '*runtime.synctestBubble'
       ByteSize: 8
-      GoRuntimeType: 102688
+      GoRuntimeType: 102848
       GoKind: 22
       Pointee: 51 UnresolvedPointeeType runtime.synctestBubble
     - __kind: PointerType
       ID: 45
       Name: '*runtime.timer'
       ByteSize: 8
-      GoRuntimeType: 136864
+      GoRuntimeType: 137280
       GoKind: 22
       Pointee: 46 UnresolvedPointeeType runtime.timer
     - __kind: PointerType
       ID: 83
       Name: '*runtime.traceBuf'
       ByteSize: 8
-      GoRuntimeType: 110112
+      GoRuntimeType: 110272
       GoKind: 22
       Pointee: 84 UnresolvedPointeeType runtime.traceBuf
     - __kind: PointerType
       ID: 53
       Name: '*runtime.xRegState'
       ByteSize: 8
-      GoRuntimeType: 33824
+      GoRuntimeType: 33920
       GoKind: 22
       Pointee: 54 UnresolvedPointeeType runtime.xRegState
     - __kind: PointerType
       ID: 101
       Name: '*string'
       ByteSize: 8
-      GoRuntimeType: 31584
+      GoRuntimeType: 31680
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
@@ -2856,42 +2856,42 @@ Types:
       ID: 110
       Name: '*uint'
       ByteSize: 8
-      GoRuntimeType: 32224
+      GoRuntimeType: 32320
       GoKind: 22
       Pointee: 11 BaseType uint
     - __kind: PointerType
       ID: 111
       Name: '*uint16'
       ByteSize: 8
-      GoRuntimeType: 31840
+      GoRuntimeType: 31936
       GoKind: 22
       Pointee: 6 BaseType uint16
     - __kind: PointerType
       ID: 22
       Name: '*uint32'
       ByteSize: 8
-      GoRuntimeType: 31968
+      GoRuntimeType: 32064
       GoKind: 22
       Pointee: 2 BaseType uint32
     - __kind: PointerType
       ID: 106
       Name: '*uint64'
       ByteSize: 8
-      GoRuntimeType: 32096
+      GoRuntimeType: 32192
       GoKind: 22
       Pointee: 8 BaseType uint64
     - __kind: PointerType
       ID: 5
       Name: '*uint8'
       ByteSize: 8
-      GoRuntimeType: 31712
+      GoRuntimeType: 31808
       GoKind: 22
       Pointee: 3 BaseType uint8
     - __kind: PointerType
       ID: 20
       Name: '*uintptr'
       ByteSize: 8
-      GoRuntimeType: 32288
+      GoRuntimeType: 32384
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
@@ -3300,7 +3300,7 @@ Types:
     - __kind: EventRootType
       ID: 300
       Name: Probe[main.condLine]Line
-      ByteSize: 33
+      ByteSize: 25
       PresenceBitsetSize: 1
       Expressions:
         - Name: n
@@ -3323,16 +3323,6 @@ Types:
                   Variable: {subprogram: 28, index: 1, name: tag}
                   Offset: 0
                   ByteSize: 16
-        - Name: result
-          Offset: 25
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 28, index: 2, name: result}
-                  Offset: 0
-                  ByteSize: 8
     - __kind: EventRootType
       ID: 287
       Name: Probe[main.condNilPtrStruct]
@@ -4240,7 +4230,7 @@ Types:
       ID: 95
       Name: '[10]runtime.heldLockInfo'
       ByteSize: 160
-      GoRuntimeType: 55200
+      GoRuntimeType: 55360
       GoKind: 17
       Count: 10
       HasCount: true
@@ -4249,7 +4239,7 @@ Types:
       ID: 190
       Name: '[128]uint8'
       ByteSize: 128
-      GoRuntimeType: 51936
+      GoRuntimeType: 52096
       GoKind: 17
       Count: 128
       HasCount: true
@@ -4258,7 +4248,7 @@ Types:
       ID: 82
       Name: '[2]*runtime.traceBuf'
       ByteSize: 16
-      GoRuntimeType: 58176
+      GoRuntimeType: 58336
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4267,7 +4257,7 @@ Types:
       ID: 81
       Name: '[2][2]*runtime.traceBuf'
       ByteSize: 32
-      GoRuntimeType: 58272
+      GoRuntimeType: 58432
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4276,7 +4266,7 @@ Types:
       ID: 87
       Name: '[2][8]runtime.pcvalueCacheEnt'
       ByteSize: 384
-      GoRuntimeType: 58464
+      GoRuntimeType: 58624
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4285,7 +4275,7 @@ Types:
       ID: 58
       Name: '[2]uint64'
       ByteSize: 16
-      GoRuntimeType: 56544
+      GoRuntimeType: 56704
       GoKind: 17
       Count: 2
       HasCount: true
@@ -4294,7 +4284,7 @@ Types:
       ID: 93
       Name: '[32]uint64'
       ByteSize: 256
-      GoRuntimeType: 60864
+      GoRuntimeType: 61024
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4303,7 +4293,7 @@ Types:
       ID: 73
       Name: '[32]uintptr'
       ByteSize: 256
-      GoRuntimeType: 55104
+      GoRuntimeType: 55264
       GoKind: 17
       Count: 32
       HasCount: true
@@ -4312,7 +4302,7 @@ Types:
       ID: 113
       Name: '[3]int'
       ByteSize: 24
-      GoRuntimeType: 51552
+      GoRuntimeType: 51808
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4321,7 +4311,7 @@ Types:
       ID: 127
       Name: '[3]int16'
       ByteSize: 6
-      GoRuntimeType: 51360
+      GoRuntimeType: 51520
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4330,7 +4320,7 @@ Types:
       ID: 57
       Name: '[3]internal/runtime/atomic.Uint32'
       ByteSize: 12
-      GoRuntimeType: 56448
+      GoRuntimeType: 56608
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4339,7 +4329,7 @@ Types:
       ID: 115
       Name: '[3]string'
       ByteSize: 48
-      GoRuntimeType: 51648
+      GoRuntimeType: 51904
       GoKind: 17
       Count: 3
       HasCount: true
@@ -4348,7 +4338,7 @@ Types:
       ID: 94
       Name: '[4]uint64'
       ByteSize: 32
-      GoRuntimeType: 60000
+      GoRuntimeType: 60160
       GoKind: 17
       Count: 4
       HasCount: true
@@ -4357,7 +4347,7 @@ Types:
       ID: 62
       Name: '[6]uintptr'
       ByteSize: 48
-      GoRuntimeType: 55008
+      GoRuntimeType: 55168
       GoKind: 17
       Count: 6
       HasCount: true
@@ -4366,7 +4356,7 @@ Types:
       ID: 88
       Name: '[8]runtime.pcvalueCacheEnt'
       ByteSize: 192
-      GoRuntimeType: 58368
+      GoRuntimeType: 58528
       GoKind: 17
       Count: 8
       HasCount: true
@@ -4375,7 +4365,7 @@ Types:
       ID: 66
       Name: '[]*runtime.p'
       ByteSize: 24
-      GoRuntimeType: 40096
+      GoRuntimeType: 40256
       GoKind: 23
       RawFields:
         - Name: array
@@ -4422,7 +4412,7 @@ Types:
       ID: 112
       Name: '[]int'
       ByteSize: 24
-      GoRuntimeType: 41888
+      GoRuntimeType: 42048
       GoKind: 23
       RawFields:
         - Name: array
@@ -4473,7 +4463,7 @@ Types:
       ID: 114
       Name: '[]string'
       ByteSize: 24
-      GoRuntimeType: 42144
+      GoRuntimeType: 42304
       GoKind: 23
       RawFields:
         - Name: array
@@ -4496,7 +4486,7 @@ Types:
       ID: 39
       Name: '[]uint8'
       ByteSize: 24
-      GoRuntimeType: 41504
+      GoRuntimeType: 41664
       GoKind: 23
       RawFields:
         - Name: array
@@ -4519,7 +4509,7 @@ Types:
       ID: 44
       Name: '[]uintptr'
       ByteSize: 24
-      GoRuntimeType: 42016
+      GoRuntimeType: 42176
       GoKind: 23
       RawFields:
         - Name: array
@@ -4542,25 +4532,25 @@ Types:
       ID: 4
       Name: bool
       ByteSize: 1
-      GoRuntimeType: 47232
+      GoRuntimeType: 47392
       GoKind: 1
     - __kind: BaseType
       ID: 18
       Name: complex128
       ByteSize: 16
-      GoRuntimeType: 47040
+      GoRuntimeType: 47200
       GoKind: 16
     - __kind: BaseType
       ID: 103
       Name: complex64
       ByteSize: 8
-      GoRuntimeType: 46976
+      GoRuntimeType: 47136
       GoKind: 15
     - __kind: GoInterfaceType
       ID: 15
       Name: error
       ByteSize: 16
-      GoRuntimeType: 71520
+      GoRuntimeType: 71680
       GoKind: 20
       RawFields:
         - Name: tab
@@ -4573,25 +4563,25 @@ Types:
       ID: 17
       Name: float32
       ByteSize: 4
-      GoRuntimeType: 47104
+      GoRuntimeType: 47264
       GoKind: 13
     - __kind: BaseType
       ID: 14
       Name: float64
       ByteSize: 8
-      GoRuntimeType: 47168
+      GoRuntimeType: 47328
       GoKind: 14
     - __kind: GoSubroutineType
       ID: 63
       Name: func()
       ByteSize: 8
-      GoRuntimeType: 39264
+      GoRuntimeType: 39424
       GoKind: 19
     - __kind: GoSubroutineType
       ID: 78
       Name: func(*runtime.g, unsafe.Pointer) bool
       ByteSize: 8
-      GoRuntimeType: 63232
+      GoRuntimeType: 63392
       GoKind: 19
     - __kind: GoSwissMapGroupsType
       ID: 182
@@ -4653,37 +4643,37 @@ Types:
       ID: 7
       Name: int
       ByteSize: 8
-      GoRuntimeType: 46784
+      GoRuntimeType: 46944
       GoKind: 2
     - __kind: BaseType
       ID: 102
       Name: int16
       ByteSize: 2
-      GoRuntimeType: 46400
+      GoRuntimeType: 46560
       GoKind: 4
     - __kind: BaseType
       ID: 12
       Name: int32
       ByteSize: 4
-      GoRuntimeType: 46528
+      GoRuntimeType: 46688
       GoKind: 5
     - __kind: BaseType
       ID: 13
       Name: int64
       ByteSize: 8
-      GoRuntimeType: 46656
+      GoRuntimeType: 46816
       GoKind: 6
     - __kind: BaseType
       ID: 19
       Name: int8
       ByteSize: 1
-      GoRuntimeType: 46272
+      GoRuntimeType: 46432
       GoKind: 3
     - __kind: StructureType
       ID: 92
       Name: internal/chacha8rand.State
       ByteSize: 304
-      GoRuntimeType: 126752
+      GoRuntimeType: 126912
       GoKind: 25
       RawFields:
         - Name: buf
@@ -4705,7 +4695,7 @@ Types:
       ID: 36
       Name: internal/runtime/atomic.Bool
       ByteSize: 1
-      GoRuntimeType: 82528
+      GoRuntimeType: 82688
       GoKind: 25
       RawFields:
         - Name: u
@@ -4715,7 +4705,7 @@ Types:
       ID: 76
       Name: internal/runtime/atomic.Int64
       ByteSize: 8
-      GoRuntimeType: 112800
+      GoRuntimeType: 112960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4735,7 +4725,7 @@ Types:
       ID: 33
       Name: internal/runtime/atomic.Uint32
       ByteSize: 4
-      GoRuntimeType: 100960
+      GoRuntimeType: 101120
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4748,7 +4738,7 @@ Types:
       ID: 37
       Name: internal/runtime/atomic.Uint8
       ByteSize: 1
-      GoRuntimeType: 100800
+      GoRuntimeType: 100960
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -4760,27 +4750,27 @@ Types:
     - __kind: StructureType
       ID: 77
       Name: internal/runtime/atomic.align64
-      GoRuntimeType: 69824
+      GoRuntimeType: 69984
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 34
       Name: internal/runtime/atomic.noCopy
-      GoRuntimeType: 69728
+      GoRuntimeType: 69888
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 187
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 77792
+      GoRuntimeType: 77952
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
       ID: 165
       Name: main.bigStruct
       ByteSize: 184
-      GoRuntimeType: 135104
+      GoRuntimeType: 135520
       GoKind: 25
       RawFields:
         - Name: Field1
@@ -4811,7 +4801,7 @@ Types:
       ID: 126
       Name: main.condFields
       ByteSize: 80
-      GoRuntimeType: 142656
+      GoRuntimeType: 143072
       GoKind: 25
       RawFields:
         - Name: I8
@@ -4997,35 +4987,35 @@ Types:
       ID: 174
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 75872
+      GoRuntimeType: 76160
       GoKind: 21
       HeaderType: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
       ByteSize: 8
-      GoRuntimeType: 76000
+      GoRuntimeType: 76032
       GoKind: 21
       HeaderType: 118 GoSwissMapHeaderType map<string,int>
     - __kind: GoMapType
       ID: 121
       Name: map[string]main.bigStruct
       ByteSize: 8
-      GoRuntimeType: 76128
+      GoRuntimeType: 76288
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
       ID: 129
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
-      GoRuntimeType: 76384
+      GoRuntimeType: 76544
       GoKind: 21
       HeaderType: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
       ID: 185
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 51744
+      GoRuntimeType: 52000
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5034,7 +5024,7 @@ Types:
       ID: 162
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
-      GoRuntimeType: 52032
+      GoRuntimeType: 52192
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5043,7 +5033,7 @@ Types:
       ID: 154
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
-      GoRuntimeType: 51840
+      GoRuntimeType: 51616
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5052,7 +5042,7 @@ Types:
       ID: 172
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
-      GoRuntimeType: 52224
+      GoRuntimeType: 52384
       GoKind: 17
       Count: 8
       HasCount: true
@@ -5061,7 +5051,7 @@ Types:
       ID: 184
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 83936
+      GoRuntimeType: 84352
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5074,7 +5064,7 @@ Types:
       ID: 153
       Name: noalg.map.group[string]int
       ByteSize: 200
-      GoRuntimeType: 84192
+      GoRuntimeType: 84096
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5087,7 +5077,7 @@ Types:
       ID: 161
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
-      GoRuntimeType: 84448
+      GoRuntimeType: 84608
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5100,7 +5090,7 @@ Types:
       ID: 171
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
-      GoRuntimeType: 84960
+      GoRuntimeType: 85120
       GoKind: 25
       RawFields:
         - Name: ctrl
@@ -5113,7 +5103,7 @@ Types:
       ID: 186
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 83808
+      GoRuntimeType: 84224
       GoKind: 25
       RawFields:
         - Name: key
@@ -5126,7 +5116,7 @@ Types:
       ID: 163
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
-      GoRuntimeType: 84320
+      GoRuntimeType: 84480
       GoKind: 25
       RawFields:
         - Name: key
@@ -5139,7 +5129,7 @@ Types:
       ID: 155
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
-      GoRuntimeType: 84064
+      GoRuntimeType: 83968
       GoKind: 25
       RawFields:
         - Name: key
@@ -5152,7 +5142,7 @@ Types:
       ID: 173
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
-      GoRuntimeType: 84832
+      GoRuntimeType: 84992
       GoKind: 25
       RawFields:
         - Name: key
@@ -5180,14 +5170,14 @@ Types:
     - __kind: StructureType
       ID: 90
       Name: runtime.dlogPerM
-      GoRuntimeType: 68960
+      GoRuntimeType: 69120
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 23
       Name: runtime.g
       ByteSize: 456
-      GoRuntimeType: 159168
+      GoRuntimeType: 159584
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5389,7 +5379,7 @@ Types:
       ID: 55
       Name: runtime.gTraceState
       ByteSize: 32
-      GoRuntimeType: 79840
+      GoRuntimeType: 80000
       GoKind: 25
       RawFields:
         - Name: traceSchedResourceState
@@ -5399,7 +5389,7 @@ Types:
       ID: 31
       Name: runtime.gobuf
       ByteSize: 48
-      GoRuntimeType: 129920
+      GoRuntimeType: 130336
       GoKind: 25
       RawFields:
         - Name: sp
@@ -5424,7 +5414,7 @@ Types:
       ID: 47
       Name: runtime.goroutineProfileStateHolder
       ByteSize: 4
-      GoRuntimeType: 95680
+      GoRuntimeType: 95840
       GoKind: 25
       RawFields:
         - Name: noCopy
@@ -5437,7 +5427,7 @@ Types:
       ID: 60
       Name: runtime.gsignalStack
       ByteSize: 40
-      GoRuntimeType: 118176
+      GoRuntimeType: 118336
       GoKind: 25
       RawFields:
         - Name: stack
@@ -5456,13 +5446,13 @@ Types:
       ID: 32
       Name: runtime.guintptr
       ByteSize: 8
-      GoRuntimeType: 61312
+      GoRuntimeType: 61472
       GoKind: 12
     - __kind: StructureType
       ID: 96
       Name: runtime.heldLockInfo
       ByteSize: 16
-      GoRuntimeType: 98080
+      GoRuntimeType: 98240
       GoKind: 25
       RawFields:
         - Name: lockAddr
@@ -5475,7 +5465,7 @@ Types:
       ID: 72
       Name: runtime.listNodeManual
       ByteSize: 16
-      GoRuntimeType: 97280
+      GoRuntimeType: 97440
       GoKind: 25
       RawFields:
         - Name: prev
@@ -5488,13 +5478,13 @@ Types:
       ID: 97
       Name: runtime.lockRank
       ByteSize: 8
-      GoRuntimeType: 61696
+      GoRuntimeType: 61856
       GoKind: 2
     - __kind: StructureType
       ID: 30
       Name: runtime.m
       ByteSize: 1824
-      GoRuntimeType: 164448
+      GoRuntimeType: 164864
       GoKind: 25
       RawFields:
         - Name: g0
@@ -5723,7 +5713,7 @@ Types:
       ID: 75
       Name: runtime.mLockProfile
       ByteSize: 56
-      GoRuntimeType: 130432
+      GoRuntimeType: 130848
       GoKind: 25
       RawFields:
         - Name: waitTime
@@ -5748,7 +5738,7 @@ Types:
       ID: 91
       Name: runtime.mOS
       ByteSize: 24
-      GoRuntimeType: 126080
+      GoRuntimeType: 126240
       GoKind: 25
       RawFields:
         - Name: profileTimer
@@ -5770,7 +5760,7 @@ Types:
       ID: 80
       Name: runtime.mTraceState
       ByteSize: 72
-      GoRuntimeType: 130688
+      GoRuntimeType: 131104
       GoKind: 25
       RawFields:
         - Name: writing
@@ -5795,7 +5785,7 @@ Types:
       ID: 74
       Name: runtime.mWaitList
       ByteSize: 16
-      GoRuntimeType: 97760
+      GoRuntimeType: 97920
       GoKind: 25
       RawFields:
         - Name: next
@@ -5808,7 +5798,7 @@ Types:
       ID: 98
       Name: runtime.mWeakPointer
       ByteSize: 8
-      GoRuntimeType: 103168
+      GoRuntimeType: 103328
       GoKind: 25
       RawFields:
         - Name: m
@@ -5818,13 +5808,13 @@ Types:
       ID: 38
       Name: runtime.muintptr
       ByteSize: 8
-      GoRuntimeType: 61408
+      GoRuntimeType: 61568
       GoKind: 12
     - __kind: StructureType
       ID: 71
       Name: runtime.note
       ByteSize: 8
-      GoRuntimeType: 80864
+      GoRuntimeType: 81024
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
@@ -5835,7 +5825,7 @@ Types:
       ID: 86
       Name: runtime.pcvalueCache
       ByteSize: 392
-      GoRuntimeType: 97920
+      GoRuntimeType: 98080
       GoKind: 25
       RawFields:
         - Name: entries
@@ -5848,7 +5838,7 @@ Types:
       ID: 89
       Name: runtime.pcvalueCacheEnt
       ByteSize: 24
-      GoRuntimeType: 119136
+      GoRuntimeType: 119296
       GoKind: 25
       RawFields:
         - Name: targetpc
@@ -5867,13 +5857,13 @@ Types:
       ID: 64
       Name: runtime.puintptr
       ByteSize: 8
-      GoRuntimeType: 61600
+      GoRuntimeType: 61760
       GoKind: 12
     - __kind: ArrayType
       ID: 61
       Name: runtime.sigset
       ByteSize: 8
-      GoRuntimeType: 65216
+      GoRuntimeType: 65376
       GoKind: 17
       Count: 2
       HasCount: true
@@ -5882,7 +5872,7 @@ Types:
       ID: 24
       Name: runtime.stack
       ByteSize: 16
-      GoRuntimeType: 94400
+      GoRuntimeType: 94560
       GoKind: 25
       RawFields:
         - Name: lo
@@ -5903,7 +5893,7 @@ Types:
       ID: 65
       Name: runtime.throwType
       ByteSize: 4
-      GoRuntimeType: 47424
+      GoRuntimeType: 47584
       GoKind: 10
     - __kind: UnresolvedPointeeType
       ID: 46
@@ -5913,7 +5903,7 @@ Types:
       ID: 79
       Name: runtime.traceBlockReason
       ByteSize: 1
-      GoRuntimeType: 47488
+      GoRuntimeType: 47648
       GoKind: 8
     - __kind: UnresolvedPointeeType
       ID: 84
@@ -5923,7 +5913,7 @@ Types:
       ID: 56
       Name: runtime.traceSchedResourceState
       ByteSize: 32
-      GoRuntimeType: 96000
+      GoRuntimeType: 96160
       GoKind: 25
       RawFields:
         - Name: statusTraced
@@ -5936,19 +5926,19 @@ Types:
       ID: 35
       Name: runtime.waitReason
       ByteSize: 1
-      GoRuntimeType: 105408
+      GoRuntimeType: 105568
       GoKind: 8
     - __kind: StructureType
       ID: 85
       Name: runtime.winlibcall
-      GoRuntimeType: 68864
+      GoRuntimeType: 69024
       GoKind: 25
       RawFields: []
     - __kind: StructureType
       ID: 52
       Name: runtime.xRegPerG
       ByteSize: 8
-      GoRuntimeType: 79712
+      GoRuntimeType: 79872
       GoKind: 25
       RawFields:
         - Name: state
@@ -5962,7 +5952,7 @@ Types:
       ID: 9
       Name: string
       ByteSize: 16
-      GoRuntimeType: 46208
+      GoRuntimeType: 46368
       GoKind: 24
       RawFields:
         - Name: str
@@ -6077,43 +6067,43 @@ Types:
       ID: 11
       Name: uint
       ByteSize: 8
-      GoRuntimeType: 46848
+      GoRuntimeType: 47008
       GoKind: 7
     - __kind: BaseType
       ID: 6
       Name: uint16
       ByteSize: 2
-      GoRuntimeType: 46464
+      GoRuntimeType: 46624
       GoKind: 9
     - __kind: BaseType
       ID: 2
       Name: uint32
       ByteSize: 4
-      GoRuntimeType: 46592
+      GoRuntimeType: 46752
       GoKind: 10
     - __kind: BaseType
       ID: 8
       Name: uint64
       ByteSize: 8
-      GoRuntimeType: 46720
+      GoRuntimeType: 46880
       GoKind: 11
     - __kind: BaseType
       ID: 3
       Name: uint8
       ByteSize: 1
-      GoRuntimeType: 46336
+      GoRuntimeType: 46496
       GoKind: 8
     - __kind: BaseType
       ID: 1
       Name: uintptr
       ByteSize: 8
-      GoRuntimeType: 46912
+      GoRuntimeType: 47072
       GoKind: 12
     - __kind: VoidPointerType
       ID: 16
       Name: unsafe.Pointer
       ByteSize: 8
-      GoRuntimeType: 47296
+      GoRuntimeType: 47456
       GoKind: 26
 MaxTypeID: 306
 Issues:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -8,10 +8,10 @@ Probes:
       template: 'ptr: {ptr}'
       segments: ['ptr: ', {json: {ref: ptr}, dsl: ptr}]
       captureSnapshot: true
-      subprogram: {subprogram: 34}
+      subprogram: {subprogram: 42}
       events:
         - Kind: Entry
-          Type: 305 EventRootType Probe[main.PointerChainArg]
+          Type: 360 EventRootType Probe[main.PointerChainArg]
           InjectionPoints: [{PC: "0xc826c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -30,10 +30,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 35}
+      subprogram: {subprogram: 43}
       events:
         - Kind: Entry
-          Type: 306 EventRootType Probe[main.PointerSmallChainArg]
+          Type: 361 EventRootType Probe[main.PointerSmallChainArg]
           InjectionPoints: [{PC: "0xc82a4", Frameless: false}]
           Condition: null
     - id: bigMapArg
@@ -46,11 +46,11 @@ Probes:
       subprogram: {subprogram: 9}
       events:
         - Kind: Entry
-          Type: 211 EventRootType Probe[main.bigMapArg]
+          Type: 214 EventRootType Probe[main.bigMapArg]
           InjectionPoints: [{PC: "0xc9008", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 212 EventRootType Probe[main.bigMapArg]Return
+          Type: 215 EventRootType Probe[main.bigMapArg]Return
           InjectionPoints: [{PC: "0xc9054", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -73,7 +73,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 255 EventRootType Probe[main.condBool]
+          Type: 258 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -90,7 +90,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 256 EventRootType Probe[main.condBool]Return
+          Type: 259 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -113,7 +113,7 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 257 EventRootType Probe[main.condBool]
+          Type: 260 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -130,7 +130,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 258 EventRootType Probe[main.condBool]Return
+          Type: 261 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -152,11 +152,11 @@ Probes:
       subprogram: {subprogram: 21}
       events:
         - Kind: Entry
-          Type: 259 EventRootType Probe[main.condBool]
+          Type: 262 EventRootType Probe[main.condBool]
           InjectionPoints: [{PC: "0xc9768", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 260 EventRootType Probe[main.condBool]Return
+          Type: 263 EventRootType Probe[main.condBool]Return
           InjectionPoints: [{PC: "0xc97cc", Frameless: false}]
           Condition: null
     - id: condFloat32_nocond
@@ -170,11 +170,11 @@ Probes:
       subprogram: {subprogram: 19}
       events:
         - Kind: Entry
-          Type: 251 EventRootType Probe[main.condFloat32]
+          Type: 254 EventRootType Probe[main.condFloat32]
           InjectionPoints: [{PC: "0xc9628", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 252 EventRootType Probe[main.condFloat32]Return
+          Type: 255 EventRootType Probe[main.condFloat32]Return
           InjectionPoints: [{PC: "0xc9688", Frameless: false}]
           Condition: null
     - id: condFloat64_nocond
@@ -188,11 +188,11 @@ Probes:
       subprogram: {subprogram: 20}
       events:
         - Kind: Entry
-          Type: 253 EventRootType Probe[main.condFloat64]
+          Type: 256 EventRootType Probe[main.condFloat64]
           InjectionPoints: [{PC: "0xc96c8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 254 EventRootType Probe[main.condFloat64]Return
+          Type: 257 EventRootType Probe[main.condFloat64]Return
           InjectionPoints: [{PC: "0xc9728", Frameless: false}]
           Condition: null
     - id: condInt16_cond
@@ -207,7 +207,7 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 219 EventRootType Probe[main.condInt16]
+          Type: 222 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xc91b8", Frameless: false}]
           Condition:
             Type: 102 BaseType int16
@@ -224,7 +224,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 220 EventRootType Probe[main.condInt16]Return
+          Type: 223 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xc9214", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -246,11 +246,11 @@ Probes:
       subprogram: {subprogram: 12}
       events:
         - Kind: Entry
-          Type: 221 EventRootType Probe[main.condInt16]
+          Type: 224 EventRootType Probe[main.condInt16]
           InjectionPoints: [{PC: "0xc91b8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 222 EventRootType Probe[main.condInt16]Return
+          Type: 225 EventRootType Probe[main.condInt16]Return
           InjectionPoints: [{PC: "0xc9214", Frameless: false}]
           Condition: null
     - id: condInt32_cond
@@ -265,7 +265,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 223 EventRootType Probe[main.condInt32]
+          Type: 226 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -282,7 +282,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 224 EventRootType Probe[main.condInt32]Return
+          Type: 227 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -308,7 +308,7 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 225 EventRootType Probe[main.condInt32]
+          Type: 228 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -325,7 +325,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 226 EventRootType Probe[main.condInt32]Return
+          Type: 229 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
     - id: condInt32_nocond
@@ -339,11 +339,11 @@ Probes:
       subprogram: {subprogram: 13}
       events:
         - Kind: Entry
-          Type: 227 EventRootType Probe[main.condInt32]
+          Type: 230 EventRootType Probe[main.condInt32]
           InjectionPoints: [{PC: "0xc9258", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 228 EventRootType Probe[main.condInt32]Return
+          Type: 231 EventRootType Probe[main.condInt32]Return
           InjectionPoints: [{PC: "0xc92b4", Frameless: false}]
           Condition: null
     - id: condInt64_cond
@@ -358,7 +358,7 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 229 EventRootType Probe[main.condInt64]
+          Type: 232 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
           Condition:
             Type: 13 BaseType int64
@@ -375,7 +375,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 230 EventRootType Probe[main.condInt64]Return
+          Type: 233 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xc9354", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -397,11 +397,11 @@ Probes:
       subprogram: {subprogram: 14}
       events:
         - Kind: Entry
-          Type: 231 EventRootType Probe[main.condInt64]
+          Type: 234 EventRootType Probe[main.condInt64]
           InjectionPoints: [{PC: "0xc92f8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 232 EventRootType Probe[main.condInt64]Return
+          Type: 235 EventRootType Probe[main.condInt64]Return
           InjectionPoints: [{PC: "0xc9354", Frameless: false}]
           Condition: null
     - id: condInt8_cond
@@ -416,7 +416,7 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 215 EventRootType Probe[main.condInt8]
+          Type: 218 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xc9108", Frameless: false}]
           Condition:
             Type: 19 BaseType int8
@@ -433,7 +433,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 216 EventRootType Probe[main.condInt8]Return
+          Type: 219 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xc916c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -455,11 +455,11 @@ Probes:
       subprogram: {subprogram: 11}
       events:
         - Kind: Entry
-          Type: 217 EventRootType Probe[main.condInt8]
+          Type: 220 EventRootType Probe[main.condInt8]
           InjectionPoints: [{PC: "0xc9108", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 218 EventRootType Probe[main.condInt8]Return
+          Type: 221 EventRootType Probe[main.condInt8]Return
           InjectionPoints: [{PC: "0xc916c", Frameless: false}]
           Condition: null
     - id: condLine_cond
@@ -483,7 +483,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 299 EventRootType Probe[main.condLine]Line
+          Type: 302 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -516,7 +516,7 @@ Probes:
       subprogram: {subprogram: 28}
       events:
         - Kind: Line
-          Type: 300 EventRootType Probe[main.condLine]Line
+          Type: 303 EventRootType Probe[main.condLine]Line
           InjectionPoints: [{PC: "0xc9cb4", Frameless: false}]
           Condition: null
     - id: condNilPtr_cond
@@ -533,7 +533,7 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 287 EventRootType Probe[main.condNilPtrStruct]
+          Type: 290 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -553,7 +553,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 288 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 291 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -575,11 +575,11 @@ Probes:
       subprogram: {subprogram: 25}
       events:
         - Kind: Entry
-          Type: 289 EventRootType Probe[main.condNilPtrStruct]
+          Type: 292 EventRootType Probe[main.condNilPtrStruct]
           InjectionPoints: [{PC: "0xc9ab8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 290 EventRootType Probe[main.condNilPtrStruct]Return
+          Type: 293 EventRootType Probe[main.condNilPtrStruct]Return
           InjectionPoints: [{PC: "0xc9b24", Frameless: false}]
           Condition: null
     - id: condOnly_cond
@@ -594,7 +594,7 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 295 EventRootType Probe[main.condOnly]
+          Type: 298 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -611,7 +611,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 296 EventRootType Probe[main.condOnly]Return
+          Type: 299 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condOnly_nocond
@@ -625,11 +625,11 @@ Probes:
       subprogram: {subprogram: 27}
       events:
         - Kind: Entry
-          Type: 297 EventRootType Probe[main.condOnly]
+          Type: 300 EventRootType Probe[main.condOnly]
           InjectionPoints: [{PC: "0xc9c08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 298 EventRootType Probe[main.condOnly]Return
+          Type: 301 EventRootType Probe[main.condOnly]Return
           InjectionPoints: [{PC: "0xc9c64", Frameless: false}]
           Condition: null
     - id: condPtrStruct_field_i32
@@ -646,7 +646,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 281 EventRootType Probe[main.condPtrStructArg]
+          Type: 284 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -666,7 +666,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 282 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 285 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -691,7 +691,7 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 283 EventRootType Probe[main.condPtrStructArg]
+          Type: 286 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -710,7 +710,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 284 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 287 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -732,11 +732,11 @@ Probes:
       subprogram: {subprogram: 24}
       events:
         - Kind: Entry
-          Type: 285 EventRootType Probe[main.condPtrStructArg]
+          Type: 288 EventRootType Probe[main.condPtrStructArg]
           InjectionPoints: [{PC: "0xc99ac", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 286 EventRootType Probe[main.condPtrStructArg]Return
+          Type: 289 EventRootType Probe[main.condPtrStructArg]Return
           InjectionPoints: [{PC: "0xc9a6c", Frameless: false}]
           Condition: null
     - id: condReturnAndLocal_cond_param
@@ -751,7 +751,7 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 291 EventRootType Probe[main.condReturnAndLocal]
+          Type: 294 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition:
             Type: 7 BaseType int
@@ -768,7 +768,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 292 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 295 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -790,11 +790,11 @@ Probes:
       subprogram: {subprogram: 26}
       events:
         - Kind: Entry
-          Type: 293 EventRootType Probe[main.condReturnAndLocal]
+          Type: 296 EventRootType Probe[main.condReturnAndLocal]
           InjectionPoints: [{PC: "0xc9b68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 294 EventRootType Probe[main.condReturnAndLocal]Return
+          Type: 297 EventRootType Probe[main.condReturnAndLocal]Return
           InjectionPoints: [{PC: "0xc9bc4", Frameless: false}]
           Condition: null
     - id: condString_cond
@@ -811,7 +811,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 261 EventRootType Probe[main.condString]
+          Type: 264 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -827,7 +827,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 262 EventRootType Probe[main.condString]Return
+          Type: 265 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -850,7 +850,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 263 EventRootType Probe[main.condString]
+          Type: 266 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -866,7 +866,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 264 EventRootType Probe[main.condString]Return
+          Type: 267 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -888,11 +888,11 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 265 EventRootType Probe[main.condString]
+          Type: 268 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 266 EventRootType Probe[main.condString]Return
+          Type: 269 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condString_snapshot_with_cond
@@ -909,7 +909,7 @@ Probes:
       subprogram: {subprogram: 22}
       events:
         - Kind: Entry
-          Type: 267 EventRootType Probe[main.condString]
+          Type: 270 EventRootType Probe[main.condString]
           InjectionPoints: [{PC: "0xc9818", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -925,7 +925,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 268 EventRootType Probe[main.condString]Return
+          Type: 271 EventRootType Probe[main.condString]Return
           InjectionPoints: [{PC: "0xc9878", Frameless: false}]
           Condition: null
     - id: condStruct_cond_i32_capture_tag
@@ -945,7 +945,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 269 EventRootType Probe[main.condStructArg]
+          Type: 272 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -962,7 +962,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 270 EventRootType Probe[main.condStructArg]Return
+          Type: 273 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condStruct_field_bool
@@ -979,7 +979,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 271 EventRootType Probe[main.condStructArg]
+          Type: 274 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 4 BaseType bool
@@ -996,7 +996,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 272 EventRootType Probe[main.condStructArg]Return
+          Type: 275 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1021,7 +1021,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 273 EventRootType Probe[main.condStructArg]
+          Type: 276 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 14 BaseType float64
@@ -1038,7 +1038,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 274 EventRootType Probe[main.condStructArg]Return
+          Type: 277 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1063,7 +1063,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 275 EventRootType Probe[main.condStructArg]
+          Type: 278 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 12 BaseType int32
@@ -1080,7 +1080,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 276 EventRootType Probe[main.condStructArg]Return
+          Type: 279 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1105,7 +1105,7 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 277 EventRootType Probe[main.condStructArg]
+          Type: 280 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition:
             Type: 9 GoStringHeaderType string
@@ -1121,7 +1121,7 @@ Probes:
                 - __kind: ExprCmpEqStringOp
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 278 EventRootType Probe[main.condStructArg]Return
+          Type: 281 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1143,11 +1143,11 @@ Probes:
       subprogram: {subprogram: 23}
       events:
         - Kind: Entry
-          Type: 279 EventRootType Probe[main.condStructArg]
+          Type: 282 EventRootType Probe[main.condStructArg]
           InjectionPoints: [{PC: "0xc98bc", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 280 EventRootType Probe[main.condStructArg]Return
+          Type: 283 EventRootType Probe[main.condStructArg]Return
           InjectionPoints: [{PC: "0xc9970", Frameless: false}]
           Condition: null
     - id: condUint16_cond
@@ -1162,7 +1162,7 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 239 EventRootType Probe[main.condUint16]
+          Type: 242 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xc9448", Frameless: false}]
           Condition:
             Type: 6 BaseType uint16
@@ -1179,7 +1179,7 @@ Probes:
                   ByteSize: 2
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 240 EventRootType Probe[main.condUint16]Return
+          Type: 243 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xc94a4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1201,11 +1201,11 @@ Probes:
       subprogram: {subprogram: 16}
       events:
         - Kind: Entry
-          Type: 241 EventRootType Probe[main.condUint16]
+          Type: 244 EventRootType Probe[main.condUint16]
           InjectionPoints: [{PC: "0xc9448", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 242 EventRootType Probe[main.condUint16]Return
+          Type: 245 EventRootType Probe[main.condUint16]Return
           InjectionPoints: [{PC: "0xc94a4", Frameless: false}]
           Condition: null
     - id: condUint32_cond
@@ -1220,7 +1220,7 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 243 EventRootType Probe[main.condUint32]
+          Type: 246 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xc94e8", Frameless: false}]
           Condition:
             Type: 2 BaseType uint32
@@ -1237,7 +1237,7 @@ Probes:
                   ByteSize: 4
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 244 EventRootType Probe[main.condUint32]Return
+          Type: 247 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xc9544", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1259,11 +1259,11 @@ Probes:
       subprogram: {subprogram: 17}
       events:
         - Kind: Entry
-          Type: 245 EventRootType Probe[main.condUint32]
+          Type: 248 EventRootType Probe[main.condUint32]
           InjectionPoints: [{PC: "0xc94e8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 246 EventRootType Probe[main.condUint32]Return
+          Type: 249 EventRootType Probe[main.condUint32]Return
           InjectionPoints: [{PC: "0xc9544", Frameless: false}]
           Condition: null
     - id: condUint64_cond
@@ -1278,7 +1278,7 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 247 EventRootType Probe[main.condUint64]
+          Type: 250 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xc9588", Frameless: false}]
           Condition:
             Type: 8 BaseType uint64
@@ -1295,7 +1295,7 @@ Probes:
                   ByteSize: 8
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 248 EventRootType Probe[main.condUint64]Return
+          Type: 251 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xc95e4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1317,11 +1317,11 @@ Probes:
       subprogram: {subprogram: 18}
       events:
         - Kind: Entry
-          Type: 249 EventRootType Probe[main.condUint64]
+          Type: 252 EventRootType Probe[main.condUint64]
           InjectionPoints: [{PC: "0xc9588", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 250 EventRootType Probe[main.condUint64]Return
+          Type: 253 EventRootType Probe[main.condUint64]Return
           InjectionPoints: [{PC: "0xc95e4", Frameless: false}]
           Condition: null
     - id: condUint8_cond
@@ -1336,7 +1336,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 233 EventRootType Probe[main.condUint8]
+          Type: 236 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1353,7 +1353,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 234 EventRootType Probe[main.condUint8]Return
+          Type: 237 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1376,7 +1376,7 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 235 EventRootType Probe[main.condUint8]
+          Type: 238 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition:
             Type: 3 BaseType uint8
@@ -1393,7 +1393,7 @@ Probes:
                   ByteSize: 1
                 - __kind: ConditionCheckOp
         - Kind: Return
-          Type: 236 EventRootType Probe[main.condUint8]Return
+          Type: 239 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1415,11 +1415,11 @@ Probes:
       subprogram: {subprogram: 15}
       events:
         - Kind: Entry
-          Type: 237 EventRootType Probe[main.condUint8]
+          Type: 240 EventRootType Probe[main.condUint8]
           InjectionPoints: [{PC: "0xc9398", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 238 EventRootType Probe[main.condUint8]Return
+          Type: 241 EventRootType Probe[main.condUint8]Return
           InjectionPoints: [{PC: "0xc93fc", Frameless: false}]
           Condition: null
     - id: inlined
@@ -1430,10 +1430,10 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 33}
+      subprogram: {subprogram: 41}
       events:
         - Kind: Entry
-          Type: 303 EventRootType Probe[main.inlined]
+          Type: 358 EventRootType Probe[main.inlined]
           InjectionPoints:
             - PC: "0xc8040"
               Frameless: false
@@ -1441,7 +1441,7 @@ Probes:
               Frameless: false
           Condition: null
         - Kind: Return
-          Type: 304 EventRootType Probe[main.inlined]Return
+          Type: 359 EventRootType Probe[main.inlined]Return
           InjectionPoints: [{PC: "0xc8f0c", Frameless: false}]
           Condition: null
     - id: intArg
@@ -1454,11 +1454,11 @@ Probes:
       subprogram: {subprogram: 1}
       events:
         - Kind: Entry
-          Type: 192 EventRootType Probe[main.intArg]
+          Type: 195 EventRootType Probe[main.intArg]
           InjectionPoints: [{PC: "0xc8c08", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 193 EventRootType Probe[main.intArg]Return
+          Type: 196 EventRootType Probe[main.intArg]Return
           InjectionPoints: [{PC: "0xc8c3c", Frameless: false}]
           Condition: null
     - id: intArrayArg
@@ -1471,11 +1471,11 @@ Probes:
       subprogram: {subprogram: 4}
       events:
         - Kind: Entry
-          Type: 202 EventRootType Probe[main.intArrayArg]
+          Type: 205 EventRootType Probe[main.intArrayArg]
           InjectionPoints: [{PC: "0xc8d68", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 203 EventRootType Probe[main.intArrayArg]Return
+          Type: 206 EventRootType Probe[main.intArrayArg]Return
           InjectionPoints: [{PC: "0xc8da8", Frameless: false}]
           Condition: null
     - id: intArrayArgFrameless
@@ -1488,7 +1488,7 @@ Probes:
       subprogram: {subprogram: 7}
       events:
         - Kind: Entry
-          Type: 208 EventRootType Probe[main.stringArrayArgFrameless]
+          Type: 211 EventRootType Probe[main.stringArrayArgFrameless]
           InjectionPoints: [{PC: "0xc8eb0", Frameless: true}]
           Condition: null
     - id: intSliceArg
@@ -1501,13 +1501,680 @@ Probes:
       subprogram: {subprogram: 3}
       events:
         - Kind: Entry
-          Type: 200 EventRootType Probe[main.intSliceArg]
+          Type: 203 EventRootType Probe[main.intSliceArg]
           InjectionPoints: [{PC: "0xc8ce8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 201 EventRootType Probe[main.intSliceArg]Return
+          Type: 204 EventRootType Probe[main.intSliceArg]Return
           InjectionPoints: [{PC: "0xc8d20", Frameless: false}]
           Condition: null
+    - id: lenErrInt_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 348 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xca55c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 349 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
+          Condition: null
+    - id: lenErrStruct_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 352 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xca63c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 353 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xca700", Frameless: false}]
+          Condition: null
+    - id: lenErr_int
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrInt}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 38}
+      events:
+        - Kind: Entry
+          Type: 350 EventRootType Probe[main.lenErrInt]
+          InjectionPoints: [{PC: "0xca55c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 351 EventRootType Probe[main.lenErrInt]Return
+          InjectionPoints: [{PC: "0xca5f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "int" (int)
+              DSL: len(x)
+    - id: lenErr_struct
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenErrStruct}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x)}
+      segments: [len=, {json: {len: {ref: x}}, dsl: len(x)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 39}
+      events:
+        - Kind: Entry
+          Type: 354 EventRootType Probe[main.lenErrStruct]
+          InjectionPoints: [{PC: "0xca63c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 355 EventRootType Probe[main.lenErrStruct]Return
+          InjectionPoints: [{PC: "0xca700", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "main.condFields" (struct)
+              DSL: len(x)
+    - id: lenMap_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(m)}
+      segments: [len=, {json: {len: {ref: m}}, dsl: len(m)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 318 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 319 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(m)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(m)
+    - id: lenMap_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenMap}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 34}
+      events:
+        - Kind: Entry
+          Type: 320 EventRootType Probe[main.lenMap]
+          InjectionPoints: [{PC: "0xca13c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 321 EventRootType Probe[main.lenMap]Return
+          InjectionPoints: [{PC: "0xca1e4", Frameless: false}]
+          Condition: null
+    - id: lenPtrString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 322 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xca22c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 323 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 35}
+      events:
+        - Kind: Entry
+          Type: 324 EventRootType Probe[main.lenPtrString]
+          InjectionPoints: [{PC: "0xca22c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 325 EventRootType Probe[main.lenPtrString]Return
+          InjectionPoints: [{PC: "0xca2bc", Frameless: false}]
+          Condition: null
+    - id: lenPtrStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 340 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xca43c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 341 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xca50c", Frameless: false}]
+          Condition: null
+    - id: lenPtrStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 342 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xca43c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 343 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xca50c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenPtrStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 344 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xca43c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 345 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xca50c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenPtrStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenPtrStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 37}
+      events:
+        - Kind: Entry
+          Type: 346 EventRootType Probe[main.lenPtrStructFields]
+          InjectionPoints: [{PC: "0xca43c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 347 EventRootType Probe[main.lenPtrStructFields]Return
+          InjectionPoints: [{PC: "0xca50c", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 314 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 315 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenSlice_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenSlice}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 33}
+      events:
+        - Kind: Entry
+          Type: 316 EventRootType Probe[main.lenSlice]
+          InjectionPoints: [{PC: "0xca04c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 317 EventRootType Probe[main.lenSlice]Return
+          InjectionPoints: [{PC: "0xca0f0", Frameless: false}]
+          Condition: null
+    - id: lenString_isEmpty_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when: {dsl: isEmpty(s), json: {isEmpty: {ref: s}}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 304 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 305 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_capture
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: false
+      captureExpressions:
+        - name: s_len
+          expr: {dsl: len(s), json: {len: {ref: s}}}
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 306 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 307 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+    - id: lenString_len_eq_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      when:
+        dsl: len(s) == 5
+        json: {eq: [{len: {ref: s}}, 5]}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 308 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: BQAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 309 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_len_template
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(s)}
+      segments: [len=, {json: {len: {ref: s}}, dsl: len(s)}]
+      captureSnapshot: false
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 310 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 311 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(s)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Ref: s}}
+              DSL: len(s)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenString_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenString}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 32}
+      events:
+        - Kind: Entry
+          Type: 312 EventRootType Probe[main.lenString]
+          InjectionPoints: [{PC: "0xc9f6c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 313 EventRootType Probe[main.lenString]Return
+          InjectionPoints: [{PC: "0xca004", Frameless: false}]
+          Condition: null
+    - id: lenStructFields_nocond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: ""
+      segments: []
+      captureSnapshot: true
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 326 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 327 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+    - id: lenStruct_field_map
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Dict)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Dict]}}
+          dsl: len(x.Dict)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 328 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 329 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Dict)}
+        Segments:
+            - len=
+            - Error: len/isEmpty not supported on type "map[string]int" (map)
+              DSL: len(x.Dict)
+    - id: lenStruct_field_ptrslice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrSlice)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrSlice]}}
+          dsl: len(x.PtrSlice)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 330 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 331 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrSlice)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrSlice}}
+              DSL: len(x.PtrSlice)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_ptrstr
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.PtrStr)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, PtrStr]}}
+          dsl: len(x.PtrStr)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 332 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 333 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.PtrStr)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: PtrStr}}
+              DSL: len(x.PtrStr)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_slice
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.Items)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, Items]}}
+          dsl: len(x.Items)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 334 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 335 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.Items)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: Items}}
+              DSL: len(x.Items)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_field_string
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      sampling: {snapshotsPerSecond: 10}
+      template: len={len(x.S)}
+      segments:
+        - len=
+        - json: {len: {getmember: [{ref: x}, S]}}
+          dsl: len(x.S)
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 336 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition: null
+        - Kind: Return
+          Type: 337 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: len={len(x.S)}
+        Segments:
+            - len=
+            - JSON: {Operand: {Base: {Ref: x}, Member: S}}
+              DSL: len(x.S)
+              EventKind: Entry
+              EventExpressionIndex: 0
+    - id: lenStruct_isEmpty_string_cond
+      version: 0
+      type: LOG_PROBE
+      where: {methodName: main.lenStructFields}
+      when:
+        dsl: isEmpty(x.S)
+        json: {isEmpty: {getmember: [{ref: x}, S]}}
+      sampling: {snapshotsPerSecond: 10}
+      template: tag={tag}
+      segments: [tag=, {json: {ref: tag}, dsl: tag}]
+      captureSnapshot: false
+      subprogram: {subprogram: 36}
+      events:
+        - Kind: Entry
+          Type: 338 EventRootType Probe[main.lenStructFields]
+          InjectionPoints: [{PC: "0xca30c", Frameless: false}]
+          Condition:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+                - __kind: ExprPushOffsetOp
+                  ByteSize: 8
+                - __kind: ExprLoadLiteralOp
+                  Data: AAAAAAAAAAA=
+                - __kind: ExprCmpEqBaseOp
+                  ByteSize: 8
+                - __kind: ConditionCheckOp
+        - Kind: Return
+          Type: 339 EventRootType Probe[main.lenStructFields]Return
+          InjectionPoints: [{PC: "0xca3f8", Frameless: false}]
+          Condition: null
+      probeTemplate:
+        TemplateString: tag={tag}
+        Segments:
+            - tag=
+            - JSON: {Ref: tag}
+              DSL: tag
+              EventKind: Entry
+              EventExpressionIndex: 0
     - id: logProbe_no_snapshot_stringArg
       version: 0
       type: LOG_PROBE
@@ -1518,11 +2185,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 194 EventRootType Probe[main.stringArg]
+          Type: 197 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 195 EventRootType Probe[main.stringArg]Return
+          Type: 198 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1543,11 +2210,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 196 EventRootType Probe[main.stringArg]
+          Type: 199 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 197 EventRootType Probe[main.stringArg]Return
+          Type: 200 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1566,11 +2233,11 @@ Probes:
       subprogram: {subprogram: 8}
       events:
         - Kind: Entry
-          Type: 209 EventRootType Probe[main.mapArg]
+          Type: 212 EventRootType Probe[main.mapArg]
           InjectionPoints: [{PC: "0xc8f98", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 210 EventRootType Probe[main.mapArg]Return
+          Type: 213 EventRootType Probe[main.mapArg]Return
           InjectionPoints: [{PC: "0xc8fc4", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1591,11 +2258,11 @@ Probes:
       subprogram: {subprogram: 10}
       events:
         - Kind: Entry
-          Type: 213 EventRootType Probe[main.noArgs]
+          Type: 216 EventRootType Probe[main.noArgs]
           InjectionPoints: [{PC: "0xc9098", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 214 EventRootType Probe[main.noArgs]Return
+          Type: 217 EventRootType Probe[main.noArgs]Return
           InjectionPoints: [{PC: "0xc90cc", Frameless: false}]
           Condition: null
     - id: stringArg
@@ -1608,11 +2275,11 @@ Probes:
       subprogram: {subprogram: 2}
       events:
         - Kind: Entry
-          Type: 198 EventRootType Probe[main.stringArg]
+          Type: 201 EventRootType Probe[main.stringArg]
           InjectionPoints: [{PC: "0xc8c78", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 199 EventRootType Probe[main.stringArg]Return
+          Type: 202 EventRootType Probe[main.stringArg]Return
           InjectionPoints: [{PC: "0xc8cb0", Frameless: false}]
           Condition: null
       probeTemplate:
@@ -1633,11 +2300,11 @@ Probes:
       subprogram: {subprogram: 6}
       events:
         - Kind: Entry
-          Type: 206 EventRootType Probe[main.stringArrayArg]
+          Type: 209 EventRootType Probe[main.stringArrayArg]
           InjectionPoints: [{PC: "0xc8e58", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 207 EventRootType Probe[main.stringArrayArg]Return
+          Type: 210 EventRootType Probe[main.stringArrayArg]Return
           InjectionPoints: [{PC: "0xc8e98", Frameless: false}]
           Condition: null
     - id: stringSliceArg
@@ -1650,11 +2317,11 @@ Probes:
       subprogram: {subprogram: 5}
       events:
         - Kind: Entry
-          Type: 204 EventRootType Probe[main.stringSliceArg]
+          Type: 207 EventRootType Probe[main.stringSliceArg]
           InjectionPoints: [{PC: "0xc8dd8", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 205 EventRootType Probe[main.stringSliceArg]Return
+          Type: 208 EventRootType Probe[main.stringSliceArg]Return
           InjectionPoints: [{PC: "0xc8e10", Frameless: false}]
           Condition: null
     - id: usesMapsOfMapsThatDoNotAppearAsArguments
@@ -1665,14 +2332,14 @@ Probes:
       template: ""
       segments: []
       captureSnapshot: true
-      subprogram: {subprogram: 32}
+      subprogram: {subprogram: 40}
       events:
         - Kind: Entry
-          Type: 301 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
+          Type: 356 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
           InjectionPoints: [{PC: "0xca740", Frameless: false}]
           Condition: null
         - Kind: Return
-          Type: 302 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
+          Type: 357 EventRootType Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
           InjectionPoints: [{PC: "0xca8bc", Frameless: false}]
           Condition: null
 Subprograms:
@@ -2484,12 +3151,322 @@ Subprograms:
                   Op: {CfaOffset: 96}
           Role: Parameter
     - ID: 32
+      Name: main.lenString
+      OutOfLinePCRanges: [0xc9f50..0xca030]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xc9f50..0xc9fa0
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xc9fa0..0xc9fa4
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+            - Range: 0xc9fa4..0xca030
+              Pieces: [{Size: 8, Op: null}, {Size: 8, Op: {CfaOffset: 16}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xc9f50..0xc9f98
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+            - Range: 0xc9f98..0xc9fa8
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+            - Range: 0xc9fa8..0xca030
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 24}
+                - Size: 8
+                  Op: {CfaOffset: 32}
+          Role: Parameter
+    - ID: 33
+      Name: main.lenSlice
+      OutOfLinePCRanges: [0xca030..0xca120]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 112 GoSliceHeaderType []int
+          Locations:
+            - Range: 0xca030..0xca08c
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca08c..0xca090
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca090..0xca094
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca094..0xca120
+              Pieces:
+                - Size: 8
+                  Op: null
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: null
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca030..0xca080
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 3, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 4, Shift: 0}
+            - Range: 0xca080..0xca084
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+            - Range: 0xca084..0xca120
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 32}
+                - Size: 8
+                  Op: {CfaOffset: 40}
+          Role: Parameter
+    - ID: 34
+      Name: main.lenMap
+      OutOfLinePCRanges: [0xca120..0xca210]
+      InlinePCRanges: []
+      Variables:
+        - Name: m
+          Type: 116 GoMapType map[string]int
+          Locations:
+            - Range: 0xca120..0xca16c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xca16c..0xca210
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca120..0xca170
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca170..0xca174
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xca174..0xca210
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 35
+      Name: main.lenPtrString
+      OutOfLinePCRanges: [0xca210..0xca2f0]
+      InlinePCRanges: []
+      Variables:
+        - Name: s
+          Type: 101 PointerType *string
+          Locations:
+            - Range: 0xca210..0xca25c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xca25c..0xca2f0
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca210..0xca260
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca260..0xca264
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xca264..0xca2f0
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 36
+      Name: main.lenStructFields
+      OutOfLinePCRanges: [0xca2f0..0xca420]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 129 StructureType main.lenFields
+          Locations:
+            - Range: 0xca2f0..0xca420
+              Pieces: [{Size: 72, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca2f0..0xca364
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xca364..0xca368
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+            - Range: 0xca368..0xca420
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 80}
+                - Size: 8
+                  Op: {CfaOffset: 88}
+          Role: Parameter
+    - ID: 37
+      Name: main.lenPtrStructFields
+      OutOfLinePCRanges: [0xca420..0xca540]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 131 PointerType *main.lenFields
+          Locations:
+            - Range: 0xca420..0xca46c
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xca46c..0xca540
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca420..0xca470
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca470..0xca474
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xca474..0xca540
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 38
+      Name: main.lenErrInt
+      OutOfLinePCRanges: [0xca540..0xca620]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 7 BaseType int
+          Locations:
+            - Range: 0xca540..0xca594
+              Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
+            - Range: 0xca594..0xca620
+              Pieces: [{Size: 8, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca540..0xca598
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 2, Shift: 0}
+            - Range: 0xca598..0xca59c
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+            - Range: 0xca59c..0xca620
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 16}
+                - Size: 8
+                  Op: {CfaOffset: 24}
+          Role: Parameter
+    - ID: 39
+      Name: main.lenErrStruct
+      OutOfLinePCRanges: [0xca620..0xca720]
+      InlinePCRanges: []
+      Variables:
+        - Name: x
+          Type: 126 StructureType main.condFields
+          Locations:
+            - Range: 0xca620..0xca720
+              Pieces: [{Size: 80, Op: {CfaOffset: 8}}]
+          Role: Parameter
+        - Name: tag
+          Type: 9 GoStringHeaderType string
+          Locations:
+            - Range: 0xca620..0xca694
+              Pieces:
+                - Size: 8
+                  Op: {RegNo: 0, Shift: 0}
+                - Size: 8
+                  Op: {RegNo: 1, Shift: 0}
+            - Range: 0xca694..0xca698
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+            - Range: 0xca698..0xca720
+              Pieces:
+                - Size: 8
+                  Op: {CfaOffset: 88}
+                - Size: 8
+                  Op: {CfaOffset: 96}
+          Role: Parameter
+    - ID: 40
       Name: main.usesMapsOfMapsThatDoNotAppearAsArguments
       OutOfLinePCRanges: [0xca720..0xca8e0]
       InlinePCRanges: []
       Variables:
         - Name: ~r0
-          Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
           Locations:
             - Range: 0xca720..0xca8bc
               Pieces: []
@@ -2498,7 +3475,7 @@ Subprograms:
             - Range: 0xca8bd..0xca8e0
               Pieces: []
           Role: Return
-    - ID: 33
+    - ID: 41
       Name: main.inlined
       OutOfLinePCRanges: [0xc8ec0..0xc8f30]
       InlinePCRanges:
@@ -2513,7 +3490,7 @@ Subprograms:
             - Range: 0xc8ec0..0xc8ee0
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 34
+    - ID: 42
       Name: main.PointerChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2521,12 +3498,12 @@ Subprograms:
           RootRanges: [0xc7ea0..0xc8bf0]
       Variables:
         - Name: ptr
-          Type: 134 PointerType *****int
+          Type: 137 PointerType *****int
           Locations:
             - Range: 0xc8244..0xc828c
               Pieces: [{Size: 8, Op: {RegNo: 0, Shift: 0}}]
           Role: Parameter
-    - ID: 35
+    - ID: 43
       Name: main.PointerSmallChainArg
       OutOfLinePCRanges: []
       InlinePCRanges:
@@ -2534,35 +3511,35 @@ Subprograms:
           RootRanges: [0xc7ea0..0xc8bf0]
       Variables:
         - Name: ptr
-          Type: 136 PointerType **int
+          Type: 139 PointerType **int
           Locations:
             - Range: 0xc82a4..0xc82d4
               Pieces: [{Size: 8, Op: {RegNo: 5, Shift: 0}}]
           Role: Parameter
 Types:
     - __kind: PointerType
-      ID: 134
+      ID: 137
       Name: '*****int'
       ByteSize: 8
       GoRuntimeType: 39040
       GoKind: 22
-      Pointee: 135 PointerType ****int
+      Pointee: 138 PointerType ****int
     - __kind: PointerType
-      ID: 135
+      ID: 138
       Name: '****int'
       ByteSize: 8
       GoRuntimeType: 38976
       GoKind: 22
-      Pointee: 191 PointerType ***int
+      Pointee: 194 PointerType ***int
     - __kind: PointerType
-      ID: 191
+      ID: 194
       Name: '***int'
       ByteSize: 8
       GoRuntimeType: 38912
       GoKind: 22
-      Pointee: 136 PointerType **int
+      Pointee: 139 PointerType **int
     - __kind: PointerType
-      ID: 136
+      ID: 139
       Name: '**int'
       ByteSize: 8
       GoRuntimeType: 38848
@@ -2575,10 +3552,10 @@ Types:
       GoKind: 22
       Pointee: 68 PointerType *runtime.p
     - __kind: PointerType
-      ID: 177
+      ID: 180
       Name: '**table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 178 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 181 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 119
       Name: '**table<string,int>'
@@ -2590,20 +3567,27 @@ Types:
       ByteSize: 8
       Pointee: 125 PointerType *table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 132
+      ID: 135
       Name: '**table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 133 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 136 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 145
+      ID: 148
       Name: '*[]*runtime.p.array'
       ByteSize: 8
-      Pointee: 144 GoSliceDataType []*runtime.p.array
+      Pointee: 147 GoSliceDataType []*runtime.p.array
     - __kind: PointerType
-      ID: 147
+      ID: 130
+      Name: '*[]int'
+      ByteSize: 8
+      GoRuntimeType: 38784
+      GoKind: 22
+      Pointee: 112 GoSliceHeaderType []int
+    - __kind: PointerType
+      ID: 150
       Name: '*[]int.array'
       ByteSize: 8
-      Pointee: 146 GoSliceDataType []int.array
+      Pointee: 149 GoSliceDataType []int.array
     - __kind: PointerType
       ID: 40
       Name: '*[]runtime.ancestorInfo'
@@ -2612,20 +3596,20 @@ Types:
       GoKind: 22
       Pointee: 41 UnresolvedPointeeType []runtime.ancestorInfo
     - __kind: PointerType
-      ID: 149
+      ID: 152
       Name: '*[]string.array'
       ByteSize: 8
-      Pointee: 148 GoSliceDataType []string.array
+      Pointee: 151 GoSliceDataType []string.array
     - __kind: PointerType
-      ID: 140
+      ID: 143
       Name: '*[]uint8.array'
       ByteSize: 8
-      Pointee: 139 GoSliceDataType []uint8.array
+      Pointee: 142 GoSliceDataType []uint8.array
     - __kind: PointerType
-      ID: 142
+      ID: 145
       Name: '*[]uintptr.array'
       ByteSize: 8
-      Pointee: 141 GoSliceDataType []uintptr.array
+      Pointee: 144 GoSliceDataType []uintptr.array
     - __kind: PointerType
       ID: 10
       Name: '*bool'
@@ -2683,12 +3667,12 @@ Types:
       GoKind: 22
       Pointee: 100 UnresolvedPointeeType internal/runtime/atomic.Pointer[runtime.m]
     - __kind: PointerType
-      ID: 164
+      ID: 167
       Name: '*main.bigStruct'
       ByteSize: 8
       GoRuntimeType: 30080
       GoKind: 22
-      Pointee: 165 StructureType main.bigStruct
+      Pointee: 168 StructureType main.bigStruct
     - __kind: PointerType
       ID: 128
       Name: '*main.condFields'
@@ -2697,10 +3681,17 @@ Types:
       GoKind: 22
       Pointee: 126 StructureType main.condFields
     - __kind: PointerType
-      ID: 175
+      ID: 131
+      Name: '*main.lenFields'
+      ByteSize: 8
+      GoRuntimeType: 29952
+      GoKind: 22
+      Pointee: 129 StructureType main.lenFields
+    - __kind: PointerType
+      ID: 178
       Name: '*map<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 179 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 117
       Name: '*map<string,int>'
@@ -2712,30 +3703,30 @@ Types:
       ByteSize: 8
       Pointee: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: PointerType
-      ID: 130
+      ID: 133
       Name: '*map<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
-      ID: 183
+      ID: 186
       Name: '*noalg.map.group[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Pointee: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
-      ID: 152
+      ID: 155
       Name: '*noalg.map.group[string]int'
       ByteSize: 8
-      Pointee: 153 StructureType noalg.map.group[string]int
+      Pointee: 156 StructureType noalg.map.group[string]int
     - __kind: PointerType
-      ID: 160
+      ID: 163
       Name: '*noalg.map.group[string]main.bigStruct'
       ByteSize: 8
-      Pointee: 161 StructureType noalg.map.group[string]main.bigStruct
+      Pointee: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: PointerType
-      ID: 170
+      ID: 173
       Name: '*noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument'
       ByteSize: 8
-      Pointee: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Pointee: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: PointerType
       ID: 27
       Name: '*runtime._defer'
@@ -2784,7 +3775,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 73216
       GoKind: 22
-      Pointee: 143 UnresolvedPointeeType runtime.p
+      Pointee: 146 UnresolvedPointeeType runtime.p
     - __kind: PointerType
       ID: 42
       Name: '*runtime.sudog'
@@ -2828,30 +3819,30 @@ Types:
       GoKind: 22
       Pointee: 9 GoStringHeaderType string
     - __kind: PointerType
-      ID: 138
+      ID: 141
       Name: '*string.str'
       ByteSize: 8
-      Pointee: 137 GoStringDataType string.str
+      Pointee: 140 GoStringDataType string.str
     - __kind: PointerType
-      ID: 178
+      ID: 181
       Name: '*table<int,main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 181 StructureType table<int,main.aStructNotUsedAsAnArgument>
+      Pointee: 184 StructureType table<int,main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 120
       Name: '*table<string,int>'
       ByteSize: 8
-      Pointee: 150 StructureType table<string,int>
+      Pointee: 153 StructureType table<string,int>
     - __kind: PointerType
       ID: 125
       Name: '*table<string,main.bigStruct>'
       ByteSize: 8
-      Pointee: 158 StructureType table<string,main.bigStruct>
+      Pointee: 161 StructureType table<string,main.bigStruct>
     - __kind: PointerType
-      ID: 133
+      ID: 136
       Name: '*table<uint8,map[int]main.aStructNotUsedAsAnArgument>'
       ByteSize: 8
-      Pointee: 168 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Pointee: 171 StructureType table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: PointerType
       ID: 110
       Name: '*uint'
@@ -2895,7 +3886,7 @@ Types:
       GoKind: 22
       Pointee: 1 BaseType uintptr
     - __kind: EventRootType
-      ID: 305
+      ID: 360
       Name: Probe[main.PointerChainArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2904,24 +3895,24 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 134 PointerType *****int
+            Type: 137 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
         - Name: ptr
           Offset: 9
           Kind: template_segment
           Expression:
-            Type: 134 PointerType *****int
+            Type: 137 PointerType *****int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 34, index: 0, name: ptr}
+                  Variable: {subprogram: 42, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 306
+      ID: 361
       Name: Probe[main.PointerSmallChainArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -2930,14 +3921,14 @@ Types:
           Offset: 1
           Kind: argument
           Expression:
-            Type: 136 PointerType **int
+            Type: 139 PointerType **int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 35, index: 0, name: ptr}
+                  Variable: {subprogram: 43, index: 0, name: ptr}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 211
+      ID: 214
       Name: Probe[main.bigMapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2963,10 +3954,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 212
+      ID: 215
       Name: Probe[main.bigMapArg]Return
     - __kind: EventRootType
-      ID: 255
+      ID: 258
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2982,7 +3973,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 257
+      ID: 260
       Name: Probe[main.condBool]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -2998,7 +3989,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 259
+      ID: 262
       Name: Probe[main.condBool]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3024,16 +4015,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 256
+      ID: 259
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 258
+      ID: 261
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 260
+      ID: 263
       Name: Probe[main.condBool]Return
     - __kind: EventRootType
-      ID: 251
+      ID: 254
       Name: Probe[main.condFloat32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3049,10 +4040,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 252
+      ID: 255
       Name: Probe[main.condFloat32]Return
     - __kind: EventRootType
-      ID: 253
+      ID: 256
       Name: Probe[main.condFloat64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3068,10 +4059,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 254
+      ID: 257
       Name: Probe[main.condFloat64]Return
     - __kind: EventRootType
-      ID: 219
+      ID: 222
       Name: Probe[main.condInt16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3087,7 +4078,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 221
+      ID: 224
       Name: Probe[main.condInt16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3113,13 +4104,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 220
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
-      ID: 222
-      Name: Probe[main.condInt16]Return
-    - __kind: EventRootType
       ID: 223
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 225
+      Name: Probe[main.condInt16]Return
+    - __kind: EventRootType
+      ID: 226
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3135,7 +4126,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 225
+      ID: 228
       Name: Probe[main.condInt32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3151,7 +4142,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 227
+      ID: 230
       Name: Probe[main.condInt32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3177,16 +4168,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 224
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 226
-      Name: Probe[main.condInt32]Return
-    - __kind: EventRootType
-      ID: 228
+      ID: 227
       Name: Probe[main.condInt32]Return
     - __kind: EventRootType
       ID: 229
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 231
+      Name: Probe[main.condInt32]Return
+    - __kind: EventRootType
+      ID: 232
       Name: Probe[main.condInt64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3202,7 +4193,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 231
+      ID: 234
       Name: Probe[main.condInt64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3228,13 +4219,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 230
+      ID: 233
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 232
+      ID: 235
       Name: Probe[main.condInt64]Return
     - __kind: EventRootType
-      ID: 215
+      ID: 218
       Name: Probe[main.condInt8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3250,7 +4241,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 217
+      ID: 220
       Name: Probe[main.condInt8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3276,13 +4267,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 216
+      ID: 219
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 218
+      ID: 221
       Name: Probe[main.condInt8]Return
     - __kind: EventRootType
-      ID: 299
+      ID: 302
       Name: Probe[main.condLine]Line
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3298,7 +4289,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 300
+      ID: 303
       Name: Probe[main.condLine]Line
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3324,7 +4315,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 287
+      ID: 290
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3340,7 +4331,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 289
+      ID: 292
       Name: Probe[main.condNilPtrStruct]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3366,71 +4357,71 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 288
+      ID: 291
       Name: Probe[main.condNilPtrStruct]Return
     - __kind: EventRootType
-      ID: 290
+      ID: 293
       Name: Probe[main.condNilPtrStruct]Return
-    - __kind: EventRootType
-      ID: 295
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 297
-      Name: Probe[main.condOnly]
-      ByteSize: 25
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: tag
-          Offset: 9
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 27, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 296
-      Name: Probe[main.condOnly]Return
     - __kind: EventRootType
       ID: 298
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 300
+      Name: Probe[main.condOnly]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 27, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 299
       Name: Probe[main.condOnly]Return
     - __kind: EventRootType
-      ID: 281
+      ID: 301
+      Name: Probe[main.condOnly]Return
+    - __kind: EventRootType
+      ID: 284
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3446,7 +4437,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 283
+      ID: 286
       Name: Probe[main.condPtrStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3462,7 +4453,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 285
+      ID: 288
       Name: Probe[main.condPtrStructArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3488,16 +4479,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 282
+      ID: 285
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 284
+      ID: 287
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 286
+      ID: 289
       Name: Probe[main.condPtrStructArg]Return
     - __kind: EventRootType
-      ID: 291
+      ID: 294
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3513,7 +4504,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 293
+      ID: 296
       Name: Probe[main.condReturnAndLocal]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3539,10 +4530,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 292
+      ID: 295
       Name: Probe[main.condReturnAndLocal]Return
     - __kind: EventRootType
-      ID: 294
+      ID: 297
       Name: Probe[main.condReturnAndLocal]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -3558,7 +4549,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 261
+      ID: 264
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3574,7 +4565,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 263
+      ID: 266
       Name: Probe[main.condString]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3582,6 +4573,58 @@ Types:
         - Name: tag
           Offset: 1
           Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 268
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 270
+      Name: Probe[main.condString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 22, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -3591,70 +4634,18 @@ Types:
                   ByteSize: 16
     - __kind: EventRootType
       ID: 265
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
+      Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 267
-      Name: Probe[main.condString]
-      ByteSize: 33
-      PresenceBitsetSize: 1
-      Expressions:
-        - Name: x
-          Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: tag
-          Offset: 17
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 22, index: 1, name: tag}
-                  Offset: 0
-                  ByteSize: 16
-    - __kind: EventRootType
-      ID: 262
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 264
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 266
-      Name: Probe[main.condString]Return
-    - __kind: EventRootType
-      ID: 268
       Name: Probe[main.condString]Return
     - __kind: EventRootType
       ID: 269
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 271
+      Name: Probe[main.condString]Return
+    - __kind: EventRootType
+      ID: 272
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3670,7 +4661,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 271
+      ID: 274
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3686,7 +4677,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 273
+      ID: 276
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3702,7 +4693,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 275
+      ID: 278
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3718,7 +4709,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 277
+      ID: 280
       Name: Probe[main.condStructArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3734,7 +4725,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 279
+      ID: 282
       Name: Probe[main.condStructArg]
       ByteSize: 97
       PresenceBitsetSize: 1
@@ -3760,25 +4751,25 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 270
+      ID: 273
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 272
+      ID: 275
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 274
+      ID: 277
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 276
+      ID: 279
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 278
+      ID: 281
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 280
+      ID: 283
       Name: Probe[main.condStructArg]Return
     - __kind: EventRootType
-      ID: 239
+      ID: 242
       Name: Probe[main.condUint16]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3794,7 +4785,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 241
+      ID: 244
       Name: Probe[main.condUint16]
       ByteSize: 19
       PresenceBitsetSize: 1
@@ -3820,13 +4811,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 240
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
-      ID: 242
-      Name: Probe[main.condUint16]Return
-    - __kind: EventRootType
       ID: 243
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 245
+      Name: Probe[main.condUint16]Return
+    - __kind: EventRootType
+      ID: 246
       Name: Probe[main.condUint32]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3842,7 +4833,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 245
+      ID: 248
       Name: Probe[main.condUint32]
       ByteSize: 21
       PresenceBitsetSize: 1
@@ -3868,13 +4859,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 244
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
-      ID: 246
-      Name: Probe[main.condUint32]Return
-    - __kind: EventRootType
       ID: 247
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 249
+      Name: Probe[main.condUint32]Return
+    - __kind: EventRootType
+      ID: 250
       Name: Probe[main.condUint64]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3890,7 +4881,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 249
+      ID: 252
       Name: Probe[main.condUint64]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -3916,13 +4907,13 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 248
+      ID: 251
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 250
+      ID: 253
       Name: Probe[main.condUint64]Return
     - __kind: EventRootType
-      ID: 233
+      ID: 236
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3938,7 +4929,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 235
+      ID: 238
       Name: Probe[main.condUint8]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -3954,7 +4945,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 237
+      ID: 240
       Name: Probe[main.condUint8]
       ByteSize: 18
       PresenceBitsetSize: 1
@@ -3980,16 +4971,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 234
+      ID: 237
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 236
+      ID: 239
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 238
+      ID: 241
       Name: Probe[main.condUint8]Return
     - __kind: EventRootType
-      ID: 303
+      ID: 358
       Name: Probe[main.inlined]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4001,14 +4992,14 @@ Types:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 33, index: 0, name: x}
+                  Variable: {subprogram: 41, index: 0, name: x}
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 304
+      ID: 359
       Name: Probe[main.inlined]Return
     - __kind: EventRootType
-      ID: 192
+      ID: 195
       Name: Probe[main.intArg]
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4024,10 +5015,10 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 193
+      ID: 196
       Name: Probe[main.intArg]Return
     - __kind: EventRootType
-      ID: 202
+      ID: 205
       Name: Probe[main.intArrayArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4043,10 +5034,10 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 203
+      ID: 206
       Name: Probe[main.intArrayArg]Return
     - __kind: EventRootType
-      ID: 200
+      ID: 203
       Name: Probe[main.intSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4062,10 +5053,534 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 201
+      ID: 204
       Name: Probe[main.intSliceArg]Return
     - __kind: EventRootType
-      ID: 209
+      ID: 348
+      Name: Probe[main.lenErrInt]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 350
+      Name: Probe[main.lenErrInt]
+    - __kind: EventRootType
+      ID: 349
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 351
+      Name: Probe[main.lenErrInt]Return
+    - __kind: EventRootType
+      ID: 352
+      Name: Probe[main.lenErrStruct]
+      ByteSize: 97
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 126 StructureType main.condFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 80
+        - Name: tag
+          Offset: 81
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 39, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 354
+      Name: Probe[main.lenErrStruct]
+    - __kind: EventRootType
+      ID: 353
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 355
+      Name: Probe[main.lenErrStruct]Return
+    - __kind: EventRootType
+      ID: 318
+      Name: Probe[main.lenMap]
+    - __kind: EventRootType
+      ID: 320
+      Name: Probe[main.lenMap]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: m
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 116 GoMapType map[string]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 0, name: m}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 34, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 319
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 321
+      Name: Probe[main.lenMap]Return
+    - __kind: EventRootType
+      ID: 322
+      Name: Probe[main.lenPtrString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 324
+      Name: Probe[main.lenPtrString]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 101 PointerType *string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 35, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 323
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 325
+      Name: Probe[main.lenPtrString]Return
+    - __kind: EventRootType
+      ID: 340
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 25
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 131 PointerType *main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: tag
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 342
+      Name: Probe[main.lenPtrStructFields]
+    - __kind: EventRootType
+      ID: 344
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 346
+      Name: Probe[main.lenPtrStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 37, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 341
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 343
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 345
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 347
+      Name: Probe[main.lenPtrStructFields]Return
+    - __kind: EventRootType
+      ID: 314
+      Name: Probe[main.lenSlice]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 316
+      Name: Probe[main.lenSlice]
+      ByteSize: 41
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 112 GoSliceHeaderType []int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: tag
+          Offset: 25
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 33, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 315
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 317
+      Name: Probe[main.lenSlice]Return
+    - __kind: EventRootType
+      ID: 304
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 306
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s_len
+          Offset: 1
+          Kind: capture_expression
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 308
+      Name: Probe[main.lenString]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 310
+      Name: Probe[main.lenString]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(s)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 312
+      Name: Probe[main.lenString]
+      ByteSize: 33
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: s
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 0, name: s}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: tag
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 32, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 305
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 307
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 309
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 311
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 313
+      Name: Probe[main.lenString]Return
+    - __kind: EventRootType
+      ID: 326
+      Name: Probe[main.lenStructFields]
+      ByteSize: 89
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: x
+          Offset: 1
+          Kind: argument
+          Expression:
+            Type: 129 StructureType main.lenFields
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 72
+        - Name: tag
+          Offset: 73
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 328
+      Name: Probe[main.lenStructFields]
+    - __kind: EventRootType
+      ID: 330
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrSlice)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 56
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 332
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.PtrStr)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 48
+                  ByteSize: 8
+                - __kind: DereferenceOp
+                  Bias: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 334
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.Items)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 24
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 336
+      Name: Probe[main.lenStructFields]
+      ByteSize: 9
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: len(x.S)
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 0, name: x}
+                  Offset: 8
+                  ByteSize: 8
+    - __kind: EventRootType
+      ID: 338
+      Name: Probe[main.lenStructFields]
+      ByteSize: 17
+      PresenceBitsetSize: 1
+      Expressions:
+        - Name: tag
+          Offset: 1
+          Kind: template_segment
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 36, index: 1, name: tag}
+                  Offset: 0
+                  ByteSize: 16
+    - __kind: EventRootType
+      ID: 327
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 329
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 331
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 333
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 335
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 337
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 339
+      Name: Probe[main.lenStructFields]Return
+    - __kind: EventRootType
+      ID: 212
       Name: Probe[main.mapArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4091,16 +5606,16 @@ Types:
                   Offset: 0
                   ByteSize: 8
     - __kind: EventRootType
-      ID: 210
+      ID: 213
       Name: Probe[main.mapArg]Return
     - __kind: EventRootType
-      ID: 213
+      ID: 216
       Name: Probe[main.noArgs]
     - __kind: EventRootType
-      ID: 214
+      ID: 217
       Name: Probe[main.noArgs]Return
     - __kind: EventRootType
-      ID: 194
+      ID: 197
       Name: Probe[main.stringArg]
       ByteSize: 17
       PresenceBitsetSize: 1
@@ -4116,10 +5631,10 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 196
+      ID: 199
       Name: Probe[main.stringArg]
     - __kind: EventRootType
-      ID: 198
+      ID: 201
       Name: Probe[main.stringArg]
       ByteSize: 33
       PresenceBitsetSize: 1
@@ -4145,16 +5660,16 @@ Types:
                   Offset: 0
                   ByteSize: 16
     - __kind: EventRootType
-      ID: 195
+      ID: 198
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 197
+      ID: 200
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 199
+      ID: 202
       Name: Probe[main.stringArg]Return
     - __kind: EventRootType
-      ID: 208
+      ID: 211
       Name: Probe[main.stringArrayArgFrameless]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4170,7 +5685,7 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 206
+      ID: 209
       Name: Probe[main.stringArrayArg]
       ByteSize: 49
       PresenceBitsetSize: 1
@@ -4186,10 +5701,10 @@ Types:
                   Offset: 0
                   ByteSize: 48
     - __kind: EventRootType
-      ID: 207
+      ID: 210
       Name: Probe[main.stringArrayArg]Return
     - __kind: EventRootType
-      ID: 204
+      ID: 207
       Name: Probe[main.stringSliceArg]
       ByteSize: 25
       PresenceBitsetSize: 1
@@ -4205,13 +5720,13 @@ Types:
                   Offset: 0
                   ByteSize: 24
     - __kind: EventRootType
-      ID: 205
+      ID: 208
       Name: Probe[main.stringSliceArg]Return
     - __kind: EventRootType
-      ID: 301
+      ID: 356
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]
     - __kind: EventRootType
-      ID: 302
+      ID: 357
       Name: Probe[main.usesMapsOfMapsThatDoNotAppearAsArguments]Return
       ByteSize: 9
       PresenceBitsetSize: 1
@@ -4220,10 +5735,10 @@ Types:
           Offset: 1
           Kind: local
           Expression:
-            Type: 129 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
+            Type: 132 GoMapType map[uint8]map[int]main.aStructNotUsedAsAnArgument
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 32, index: 0, name: ~r0}
+                  Variable: {subprogram: 40, index: 0, name: ~r0}
                   Offset: 0
                   ByteSize: 8
     - __kind: ArrayType
@@ -4236,7 +5751,7 @@ Types:
       HasCount: true
       Element: 96 StructureType runtime.heldLockInfo
     - __kind: ArrayType
-      ID: 190
+      ID: 193
       Name: '[128]uint8'
       ByteSize: 128
       GoRuntimeType: 52096
@@ -4377,37 +5892,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 144 GoSliceDataType []*runtime.p.array
+      Data: 147 GoSliceDataType []*runtime.p.array
     - __kind: GoSliceDataType
-      ID: 144
+      ID: 147
       Name: '[]*runtime.p.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 68 PointerType *runtime.p
     - __kind: GoSliceDataType
-      ID: 188
+      ID: 191
       Name: '[]*table<int,main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 178 PointerType *table<int,main.aStructNotUsedAsAnArgument>
+      Element: 181 PointerType *table<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceDataType
-      ID: 156
+      ID: 159
       Name: '[]*table<string,int>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 120 PointerType *table<string,int>
     - __kind: GoSliceDataType
-      ID: 166
+      ID: 169
       Name: '[]*table<string,main.bigStruct>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
       Element: 125 PointerType *table<string,main.bigStruct>
     - __kind: GoSliceDataType
-      ID: 179
+      ID: 182
       Name: '[]*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array'
       DynamicSizeClass: hashmap
       ByteSize: 8
-      Element: 133 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      Element: 136 PointerType *table<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: GoSliceHeaderType
       ID: 112
       Name: '[]int'
@@ -4424,37 +5939,37 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 146 GoSliceDataType []int.array
+      Data: 149 GoSliceDataType []int.array
     - __kind: GoSliceDataType
-      ID: 146
+      ID: 149
       Name: '[]int.array'
       DynamicSizeClass: slice
       ByteSize: 8
       Element: 7 BaseType int
     - __kind: GoSliceDataType
-      ID: 189
+      ID: 192
       Name: '[]noalg.map.group[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      Element: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSliceDataType
-      ID: 157
+      ID: 160
       Name: '[]noalg.map.group[string]int.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 153 StructureType noalg.map.group[string]int
+      Element: 156 StructureType noalg.map.group[string]int
     - __kind: GoSliceDataType
-      ID: 167
+      ID: 170
       Name: '[]noalg.map.group[string]main.bigStruct.array'
       DynamicSizeClass: hashmap
       ByteSize: 200
-      Element: 161 StructureType noalg.map.group[string]main.bigStruct
+      Element: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSliceDataType
-      ID: 180
+      ID: 183
       Name: '[]noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array'
       DynamicSizeClass: hashmap
       ByteSize: 136
-      Element: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      Element: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 41
       Name: '[]runtime.ancestorInfo'
@@ -4475,9 +5990,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 148 GoSliceDataType []string.array
+      Data: 151 GoSliceDataType []string.array
     - __kind: GoSliceDataType
-      ID: 148
+      ID: 151
       Name: '[]string.array'
       DynamicSizeClass: slice
       ByteSize: 16
@@ -4498,9 +6013,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 139 GoSliceDataType []uint8.array
+      Data: 142 GoSliceDataType []uint8.array
     - __kind: GoSliceDataType
-      ID: 139
+      ID: 142
       Name: '[]uint8.array'
       DynamicSizeClass: slice
       ByteSize: 1
@@ -4521,9 +6036,9 @@ Types:
         - Name: cap
           Offset: 16
           Type: 7 BaseType int
-      Data: 141 GoSliceDataType []uintptr.array
+      Data: 144 GoSliceDataType []uintptr.array
     - __kind: GoSliceDataType
-      ID: 141
+      ID: 144
       Name: '[]uintptr.array'
       DynamicSizeClass: slice
       ByteSize: 8
@@ -4584,61 +6099,61 @@ Types:
       GoRuntimeType: 63392
       GoKind: 19
     - __kind: GoSwissMapGroupsType
-      ID: 182
+      ID: 185
       Name: groupReference<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 183 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
+          Type: 186 PointerType *noalg.map.group[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 189 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 192 GoSliceDataType []noalg.map.group[int]main.aStructNotUsedAsAnArgument.array
     - __kind: GoSwissMapGroupsType
-      ID: 151
+      ID: 154
       Name: groupReference<string,int>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 152 PointerType *noalg.map.group[string]int
+          Type: 155 PointerType *noalg.map.group[string]int
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 153 StructureType noalg.map.group[string]int
-      GroupSliceType: 157 GoSliceDataType []noalg.map.group[string]int.array
+      GroupType: 156 StructureType noalg.map.group[string]int
+      GroupSliceType: 160 GoSliceDataType []noalg.map.group[string]int.array
     - __kind: GoSwissMapGroupsType
-      ID: 159
+      ID: 162
       Name: groupReference<string,main.bigStruct>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 160 PointerType *noalg.map.group[string]main.bigStruct
+          Type: 163 PointerType *noalg.map.group[string]main.bigStruct
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 161 StructureType noalg.map.group[string]main.bigStruct
-      GroupSliceType: 167 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
+      GroupType: 164 StructureType noalg.map.group[string]main.bigStruct
+      GroupSliceType: 170 GoSliceDataType []noalg.map.group[string]main.bigStruct.array
     - __kind: GoSwissMapGroupsType
-      ID: 169
+      ID: 172
       Name: groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 16
       GoKind: 25
       RawFields:
         - Name: data
           Offset: 0
-          Type: 170 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+          Type: 173 PointerType *noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
         - Name: lengthMask
           Offset: 8
           Type: 8 BaseType uint64
-      GroupType: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
-      GroupSliceType: 180 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
+      GroupType: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      GroupSliceType: 183 GoSliceDataType []noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument.array
     - __kind: BaseType
       ID: 7
       Name: int
@@ -4760,14 +6275,14 @@ Types:
       GoKind: 25
       RawFields: []
     - __kind: StructureType
-      ID: 187
+      ID: 190
       Name: main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 77952
       GoKind: 25
       RawFields: [{Name: a, Offset: 0, Type: 7 BaseType int}]
     - __kind: StructureType
-      ID: 165
+      ID: 168
       Name: main.bigStruct
       ByteSize: 184
       GoRuntimeType: 135520
@@ -4796,7 +6311,7 @@ Types:
           Type: 7 BaseType int
         - Name: data
           Offset: 56
-          Type: 190 ArrayType [128]uint8
+          Type: 193 ArrayType [128]uint8
     - __kind: StructureType
       ID: 126
       Name: main.condFields
@@ -4843,8 +6358,33 @@ Types:
         - Name: arr
           Offset: 72
           Type: 127 ArrayType [3]int16
+    - __kind: StructureType
+      ID: 129
+      Name: main.lenFields
+      ByteSize: 72
+      GoRuntimeType: 128800
+      GoKind: 25
+      RawFields:
+        - Name: S
+          Offset: 0
+          Type: 9 GoStringHeaderType string
+        - Name: Items
+          Offset: 16
+          Type: 112 GoSliceHeaderType []int
+        - Name: Dict
+          Offset: 40
+          Type: 116 GoMapType map[string]int
+        - Name: PtrStr
+          Offset: 48
+          Type: 101 PointerType *string
+        - Name: PtrSlice
+          Offset: 56
+          Type: 130 PointerType *[]int
+        - Name: pad
+          Offset: 64
+          Type: 127 ArrayType [3]int16
     - __kind: GoSwissMapHeaderType
-      ID: 176
+      ID: 179
       Name: map<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4857,7 +6397,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 177 PointerType **table<int,main.aStructNotUsedAsAnArgument>
+          Type: 180 PointerType **table<int,main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4876,8 +6416,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 188 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
-      GroupType: 184 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 191 GoSliceDataType []*table<int,main.aStructNotUsedAsAnArgument>.array
+      GroupType: 187 StructureType noalg.map.group[int]main.aStructNotUsedAsAnArgument
     - __kind: GoSwissMapHeaderType
       ID: 118
       Name: map<string,int>
@@ -4911,8 +6451,8 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 156 GoSliceDataType []*table<string,int>.array
-      GroupType: 153 StructureType noalg.map.group[string]int
+      TablePtrSliceType: 159 GoSliceDataType []*table<string,int>.array
+      GroupType: 156 StructureType noalg.map.group[string]int
     - __kind: GoSwissMapHeaderType
       ID: 123
       Name: map<string,main.bigStruct>
@@ -4946,10 +6486,10 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 166 GoSliceDataType []*table<string,main.bigStruct>.array
-      GroupType: 161 StructureType noalg.map.group[string]main.bigStruct
+      TablePtrSliceType: 169 GoSliceDataType []*table<string,main.bigStruct>.array
+      GroupType: 164 StructureType noalg.map.group[string]main.bigStruct
     - __kind: GoSwissMapHeaderType
-      ID: 131
+      ID: 134
       Name: map<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 48
       GoKind: 25
@@ -4962,7 +6502,7 @@ Types:
           Type: 1 BaseType uintptr
         - Name: dirPtr
           Offset: 16
-          Type: 132 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 135 PointerType **table<uint8,map[int]main.aStructNotUsedAsAnArgument>
         - Name: dirLen
           Offset: 24
           Type: 7 BaseType int
@@ -4981,15 +6521,15 @@ Types:
         - Name: clearSeq
           Offset: 40
           Type: 8 BaseType uint64
-      TablePtrSliceType: 179 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
-      GroupType: 171 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
+      TablePtrSliceType: 182 GoSliceDataType []*table<uint8,map[int]main.aStructNotUsedAsAnArgument>.array
+      GroupType: 174 StructureType noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
     - __kind: GoMapType
-      ID: 174
+      ID: 177
       Name: map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 76160
       GoKind: 21
-      HeaderType: 176 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
+      HeaderType: 179 GoSwissMapHeaderType map<int,main.aStructNotUsedAsAnArgument>
     - __kind: GoMapType
       ID: 116
       Name: map[string]int
@@ -5005,50 +6545,50 @@ Types:
       GoKind: 21
       HeaderType: 123 GoSwissMapHeaderType map<string,main.bigStruct>
     - __kind: GoMapType
-      ID: 129
+      ID: 132
       Name: map[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 8
       GoRuntimeType: 76544
       GoKind: 21
-      HeaderType: 131 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
+      HeaderType: 134 GoSwissMapHeaderType map<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: ArrayType
-      ID: 185
+      ID: 188
       Name: noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 52000
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 186 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
+      Element: 189 StructureType noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: ArrayType
-      ID: 162
+      ID: 165
       Name: noalg.[8]struct { key string; elem *main.bigStruct }
       ByteSize: 192
       GoRuntimeType: 52192
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 163 StructureType noalg.struct { key string; elem *main.bigStruct }
+      Element: 166 StructureType noalg.struct { key string; elem *main.bigStruct }
     - __kind: ArrayType
-      ID: 154
+      ID: 157
       Name: noalg.[8]struct { key string; elem int }
       ByteSize: 192
       GoRuntimeType: 51616
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 155 StructureType noalg.struct { key string; elem int }
+      Element: 158 StructureType noalg.struct { key string; elem int }
     - __kind: ArrayType
-      ID: 172
+      ID: 175
       Name: noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 128
       GoRuntimeType: 52384
       GoKind: 17
       Count: 8
       HasCount: true
-      Element: 173 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+      Element: 176 StructureType noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 184
+      ID: 187
       Name: noalg.map.group[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 84352
@@ -5059,9 +6599,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 185 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
+          Type: 188 ArrayType noalg.[8]struct { key int; elem main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 153
+      ID: 156
       Name: noalg.map.group[string]int
       ByteSize: 200
       GoRuntimeType: 84096
@@ -5072,9 +6612,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 154 ArrayType noalg.[8]struct { key string; elem int }
+          Type: 157 ArrayType noalg.[8]struct { key string; elem int }
     - __kind: StructureType
-      ID: 161
+      ID: 164
       Name: noalg.map.group[string]main.bigStruct
       ByteSize: 200
       GoRuntimeType: 84608
@@ -5085,9 +6625,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 162 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
+          Type: 165 ArrayType noalg.[8]struct { key string; elem *main.bigStruct }
     - __kind: StructureType
-      ID: 171
+      ID: 174
       Name: noalg.map.group[uint8]map[int]main.aStructNotUsedAsAnArgument
       ByteSize: 136
       GoRuntimeType: 85120
@@ -5098,9 +6638,9 @@ Types:
           Type: 8 BaseType uint64
         - Name: slots
           Offset: 8
-          Type: 172 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
+          Type: 175 ArrayType noalg.[8]struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
     - __kind: StructureType
-      ID: 186
+      ID: 189
       Name: noalg.struct { key int; elem main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 84224
@@ -5111,9 +6651,9 @@ Types:
           Type: 7 BaseType int
         - Name: elem
           Offset: 8
-          Type: 187 StructureType main.aStructNotUsedAsAnArgument
+          Type: 190 StructureType main.aStructNotUsedAsAnArgument
     - __kind: StructureType
-      ID: 163
+      ID: 166
       Name: noalg.struct { key string; elem *main.bigStruct }
       ByteSize: 24
       GoRuntimeType: 84480
@@ -5124,9 +6664,9 @@ Types:
           Type: 9 GoStringHeaderType string
         - Name: elem
           Offset: 16
-          Type: 164 PointerType *main.bigStruct
+          Type: 167 PointerType *main.bigStruct
     - __kind: StructureType
-      ID: 155
+      ID: 158
       Name: noalg.struct { key string; elem int }
       ByteSize: 24
       GoRuntimeType: 83968
@@ -5139,7 +6679,7 @@ Types:
           Offset: 16
           Type: 7 BaseType int
     - __kind: StructureType
-      ID: 173
+      ID: 176
       Name: noalg.struct { key uint8; elem map[int]main.aStructNotUsedAsAnArgument }
       ByteSize: 16
       GoRuntimeType: 84992
@@ -5150,7 +6690,7 @@ Types:
           Type: 3 BaseType uint8
         - Name: elem
           Offset: 8
-          Type: 174 GoMapType map[int]main.aStructNotUsedAsAnArgument
+          Type: 177 GoMapType map[int]main.aStructNotUsedAsAnArgument
     - __kind: UnresolvedPointeeType
       ID: 28
       Name: runtime._defer
@@ -5818,7 +7358,7 @@ Types:
       GoKind: 25
       RawFields: [{Name: key, Offset: 0, Type: 1 BaseType uintptr}]
     - __kind: UnresolvedPointeeType
-      ID: 143
+      ID: 146
       Name: runtime.p
       ByteSize: 8
     - __kind: StructureType
@@ -5957,18 +7497,18 @@ Types:
       RawFields:
         - Name: str
           Offset: 0
-          Type: 138 PointerType *string.str
+          Type: 141 PointerType *string.str
         - Name: len
           Offset: 8
           Type: 7 BaseType int
-      Data: 137 GoStringDataType string.str
+      Data: 140 GoStringDataType string.str
     - __kind: GoStringDataType
-      ID: 137
+      ID: 140
       Name: string.str
       DynamicSizeClass: string
       ByteSize: 1
     - __kind: StructureType
-      ID: 181
+      ID: 184
       Name: table<int,main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -5990,9 +7530,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 182 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
+          Type: 185 GoSwissMapGroupsType groupReference<int,main.aStructNotUsedAsAnArgument>
     - __kind: StructureType
-      ID: 150
+      ID: 153
       Name: table<string,int>
       ByteSize: 32
       GoKind: 25
@@ -6014,9 +7554,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 151 GoSwissMapGroupsType groupReference<string,int>
+          Type: 154 GoSwissMapGroupsType groupReference<string,int>
     - __kind: StructureType
-      ID: 158
+      ID: 161
       Name: table<string,main.bigStruct>
       ByteSize: 32
       GoKind: 25
@@ -6038,9 +7578,9 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 159 GoSwissMapGroupsType groupReference<string,main.bigStruct>
+          Type: 162 GoSwissMapGroupsType groupReference<string,main.bigStruct>
     - __kind: StructureType
-      ID: 168
+      ID: 171
       Name: table<uint8,map[int]main.aStructNotUsedAsAnArgument>
       ByteSize: 32
       GoKind: 25
@@ -6062,7 +7602,7 @@ Types:
           Type: 7 BaseType int
         - Name: groups
           Offset: 16
-          Type: 169 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
+          Type: 172 GoSwissMapGroupsType groupReference<uint8,map[int]main.aStructNotUsedAsAnArgument>
     - __kind: BaseType
       ID: 11
       Name: uint
@@ -6105,7 +7645,7 @@ Types:
       ByteSize: 8
       GoRuntimeType: 47456
       GoKind: 26
-MaxTypeID: 306
+MaxTypeID: 361
 Issues:
     - probe_definition:
         id: condErr_bad_field
@@ -6336,6 +7876,36 @@ Issues:
       issue:
         Kind: 7
         Message: condition variable "x" not available at any event
+    - probe_definition:
+        id: lenErr_int_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrInt}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "int" (int)'
+    - probe_definition:
+        id: lenErr_struct_isEmpty_cond
+        version: 0
+        type: LOG_PROBE
+        where: {methodName: main.lenErrStruct}
+        tags: ['issue:ConditionExpressionUnresolvable']
+        when: {dsl: isEmpty(x), json: {isEmpty: {ref: x}}}
+        capture: {maxReferenceDepth: 1}
+        sampling: {snapshotsPerSecond: 10}
+        template: tag={tag}
+        segments: [tag=, {json: {ref: tag}, dsl: tag}]
+        captureSnapshot: false
+      issue:
+        Kind: 8
+        Message: 'failed to resolve condition: failed to resolve isEmpty operand: len/isEmpty not supported on type "main.condFields" (struct)'
     - probe_definition:
         id: spanProbe
         version: 0

--- a/pkg/dyninst/irgen/type_catalog.go
+++ b/pkg/dyninst/irgen/type_catalog.go
@@ -32,6 +32,7 @@ func (a *idAllocator[I]) next() I {
 type typeCatalog struct {
 	ptrSize              uint8
 	boolType             ir.TypeID
+	uint64Type           ir.TypeID
 	dwarf                *dwarf.Data
 	idAlloc              idAllocator[ir.TypeID]
 	typesByDwarfType     map[dwarf.Offset]ir.TypeID
@@ -231,9 +232,12 @@ func (c *typeCatalog) buildType(
 		); err != nil {
 			return nil, fmt.Errorf("invalid encoding: %w", err)
 		}
-		// Store the bool type ID if we find it. It's useful later.
+		// Store well-known type IDs for later use.
 		if goAttrs.GoKind == reflect.Bool && common.Name == "bool" {
 			c.boolType = id
+		}
+		if goAttrs.GoKind == reflect.Uint64 && common.Name == "uint64" {
+			c.uint64Type = id
 		}
 		return &ir.BaseType{
 			TypeCommon:       common,

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.23.11.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
-		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 380, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 491, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.24.3.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.25.0.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=amd64,toolchain=go1.26rc1.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.23.11.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
-		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 380, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
+		Var: m: map[string]map[int]main.aStructNotUsedAsAnArgument (declared at line 491, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.24.3.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.25.0.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
+++ b/pkg/dyninst/symdb/testdata/snapshot/simple.streaming.arch=arm64,toolchain=go1.26rc1.out
@@ -1,108 +1,138 @@
 Main module: github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs
 Package: main
-	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [189:190] injectible: [190-190]
-		Arg: ptr: *****int (declared at line 0, available: [190-190])
-	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:194] injectible: [194-194]
-		Arg: ptr: **int (declared at line 0, available: [194-194])
-	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [181:187] injectible: [181-183], [186-187]
-		Arg: m: map[string]main.bigStruct (declared at line 181, available: [181-187])
-	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [278:280] injectible: [278-280]
-		Arg: x: bool (declared at line 278, available: [278-279])
-		Arg: tag: string (declared at line 278, available: [278-279])
-	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [268:270] injectible: [268-270]
-		Arg: x: float32 (declared at line 268, available: [268-270])
-		Arg: tag: string (declared at line 268, available: [268-270])
-	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [273:275] injectible: [273-275]
-		Arg: x: float64 (declared at line 273, available: [273-275])
-		Arg: tag: string (declared at line 273, available: [273-275])
-	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [233:235] injectible: [233-235]
-		Arg: x: int16 (declared at line 233, available: [233-235])
-		Arg: tag: string (declared at line 233, available: [233-235])
-	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [238:240] injectible: [238-240]
-		Arg: x: int32 (declared at line 238, available: [238-240])
-		Arg: tag: string (declared at line 238, available: [238-240])
-	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [243:245] injectible: [243-245]
-		Arg: x: int64 (declared at line 243, available: [243-245])
-		Arg: tag: string (declared at line 243, available: [243-245])
-	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:230] injectible: [228-230]
-		Arg: x: int8 (declared at line 228, available: [228-229])
-		Arg: tag: string (declared at line 228, available: [228-229])
-	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [339:344] injectible: [339-339], [342-344]
-		Arg: n: int (declared at line 339, available: [339-344])
-		Arg: tag: string (declared at line 339, available: [339-344])
-		Var: result: int (declared at line 342, available: [343-343])
-	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [356:358] injectible: [356-358]
-		Arg: x: map[string]int (declared at line 356, available: [356-357])
-		Arg: tag: string (declared at line 356, available: [356-357])
-	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [309:311] injectible: [309-311]
-		Arg: x: *main.condFields (declared at line 309, available: [309-310])
-		Arg: tag: string (declared at line 309, available: [309-310])
-	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
-		Arg: x: int (declared at line 330, available: [330-332])
+	Function: PointerChainArg (main.PointerChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [228:229] injectible: [229-229]
+		Arg: ptr: *****int (declared at line 0, available: [229-229])
+	Function: PointerSmallChainArg (main.PointerSmallChainArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [232:233] injectible: [233-233]
+		Arg: ptr: **int (declared at line 0, available: [233-233])
+	Function: bigMapArg (main.bigMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [220:226] injectible: [220-222], [225-226]
+		Arg: m: map[string]main.bigStruct (declared at line 220, available: [220-226])
+	Function: condBool (main.condBool) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [317:319] injectible: [317-319]
+		Arg: x: bool (declared at line 317, available: [317-318])
+		Arg: tag: string (declared at line 317, available: [317-318])
+	Function: condFloat32 (main.condFloat32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [307:309] injectible: [307-309]
+		Arg: x: float32 (declared at line 307, available: [307-309])
+		Arg: tag: string (declared at line 307, available: [307-309])
+	Function: condFloat64 (main.condFloat64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [312:314] injectible: [312-314]
+		Arg: x: float64 (declared at line 312, available: [312-314])
+		Arg: tag: string (declared at line 312, available: [312-314])
+	Function: condInt16 (main.condInt16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [272:274] injectible: [272-274]
+		Arg: x: int16 (declared at line 272, available: [272-274])
+		Arg: tag: string (declared at line 272, available: [272-274])
+	Function: condInt32 (main.condInt32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [277:279] injectible: [277-279]
+		Arg: x: int32 (declared at line 277, available: [277-279])
+		Arg: tag: string (declared at line 277, available: [277-279])
+	Function: condInt64 (main.condInt64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [282:284] injectible: [282-284]
+		Arg: x: int64 (declared at line 282, available: [282-284])
+		Arg: tag: string (declared at line 282, available: [282-284])
+	Function: condInt8 (main.condInt8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [267:269] injectible: [267-269]
+		Arg: x: int8 (declared at line 267, available: [267-268])
+		Arg: tag: string (declared at line 267, available: [267-268])
+	Function: condLine (main.condLine) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [378:383] injectible: [378-378], [381-383]
+		Arg: n: int (declared at line 378, available: [378-383])
+		Arg: tag: string (declared at line 378, available: [378-383])
+		Var: result: int (declared at line 381, available: [382-382])
+	Function: condMapArg (main.condMapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [395:397] injectible: [395-397]
+		Arg: x: map[string]int (declared at line 395, available: [395-396])
+		Arg: tag: string (declared at line 395, available: [395-396])
+	Function: condNilPtrStruct (main.condNilPtrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [348:350] injectible: [348-350]
+		Arg: x: *main.condFields (declared at line 348, available: [348-349])
+		Arg: tag: string (declared at line 348, available: [348-349])
+	Function: condOnly (main.condOnly) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [369:371] injectible: [369-371]
+		Arg: x: int (declared at line 369, available: [369-371])
+		Arg: tag: string (declared at line 369, available: [369-371])
+	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [338:340] injectible: [338-340]
+		Arg: x: *main.condFields (declared at line 338, available: [338-340])
+		Arg: tag: string (declared at line 338, available: [338-340])
+	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [357:360] injectible: [357-360]
+		Arg: a: int (declared at line 357, available: [357-358])
+		Arg: b: int (declared at line 357, available: [357-359])
+		Arg: ~r0: int (declared at line 357, available: )
+		Var: sum: int (declared at line 358, available: [357-360])
+	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [388:390] injectible: [388-390]
+		Arg: x: []int (declared at line 388, available: [388-390])
+		Arg: tag: string (declared at line 388, available: [388-390])
+	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [322:324] injectible: [322-324]
+		Arg: x: string (declared at line 322, available: [322-324])
+		Arg: tag: string (declared at line 322, available: [322-324])
+	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [330:332] injectible: [330-332]
+		Arg: x: main.condFields (declared at line 330, available: [330-332])
 		Arg: tag: string (declared at line 330, available: [330-332])
-	Function: condPtrStructArg (main.condPtrStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [299:301] injectible: [299-301]
-		Arg: x: *main.condFields (declared at line 299, available: [299-301])
-		Arg: tag: string (declared at line 299, available: [299-301])
-	Function: condReturnAndLocal (main.condReturnAndLocal) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [318:321] injectible: [318-321]
-		Arg: a: int (declared at line 318, available: [318-319])
-		Arg: b: int (declared at line 318, available: [318-320])
-		Arg: ~r0: int (declared at line 318, available: )
-		Var: sum: int (declared at line 319, available: [318-321])
-	Function: condSliceArg (main.condSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [349:351] injectible: [349-351]
-		Arg: x: []int (declared at line 349, available: [349-351])
-		Arg: tag: string (declared at line 349, available: [349-351])
-	Function: condString (main.condString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [283:285] injectible: [283-285]
-		Arg: x: string (declared at line 283, available: [283-285])
-		Arg: tag: string (declared at line 283, available: [283-285])
-	Function: condStructArg (main.condStructArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [291:293] injectible: [291-293]
-		Arg: x: main.condFields (declared at line 291, available: [291-293])
-		Arg: tag: string (declared at line 291, available: [291-293])
-	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [364:366] injectible: [364-366]
-		Arg: x: main.condFields (declared at line 364, available: [364-366])
-		Arg: tag: string (declared at line 364, available: [364-366])
-	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [253:255] injectible: [253-255]
-		Arg: x: uint16 (declared at line 253, available: [253-255])
-		Arg: tag: string (declared at line 253, available: [253-255])
-	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [258:260] injectible: [258-260]
-		Arg: x: uint32 (declared at line 258, available: [258-260])
-		Arg: tag: string (declared at line 258, available: [258-260])
-	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [263:265] injectible: [263-265]
-		Arg: x: uint64 (declared at line 263, available: [263-265])
-		Arg: tag: string (declared at line 263, available: [263-265])
-	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [248:250] injectible: [248-250]
-		Arg: x: uint8 (declared at line 248, available: [248-249])
-		Arg: tag: string (declared at line 248, available: [248-249])
-	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [159:161] injectible: [159-161]
-		Arg: f: func(int) (declared at line 159, available: [159-160])
-	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [154:156] injectible: [155-155]
-		Arg: x: int (declared at line 0, available: [154-155])
-	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [121:123] injectible: [121-123]
-		Arg: x: int (declared at line 121, available: [121-122])
-	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [136:138] injectible: [136-138]
-		Arg: s: [3]int (declared at line 136, available: [136-138])
-	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [131:133] injectible: [131-133]
-		Arg: s: []int (declared at line 131, available: [131-132])
-	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:118] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-118]
-		Var: ptr5: *****int (declared at line 36, available: [37-37])
-		Var: &val: *int (declared at line 31, available: [14-118])
-		Var: &ptr1: **int (declared at line 32, available: [14-118])
-		Var: &ptr2: ***int (declared at line 33, available: [14-118])
-		Var: &ptr3: ****int (declared at line 34, available: [14-118])
+	Function: condStructDirect (main.condStructDirect) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [403:405] injectible: [403-405]
+		Arg: x: main.condFields (declared at line 403, available: [403-405])
+		Arg: tag: string (declared at line 403, available: [403-405])
+	Function: condUint16 (main.condUint16) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [292:294] injectible: [292-294]
+		Arg: x: uint16 (declared at line 292, available: [292-294])
+		Arg: tag: string (declared at line 292, available: [292-294])
+	Function: condUint32 (main.condUint32) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [297:299] injectible: [297-299]
+		Arg: x: uint32 (declared at line 297, available: [297-299])
+		Arg: tag: string (declared at line 297, available: [297-299])
+	Function: condUint64 (main.condUint64) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [302:304] injectible: [302-304]
+		Arg: x: uint64 (declared at line 302, available: [302-304])
+		Arg: tag: string (declared at line 302, available: [302-304])
+	Function: condUint8 (main.condUint8) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [287:289] injectible: [287-289]
+		Arg: x: uint8 (declared at line 287, available: [287-288])
+		Arg: tag: string (declared at line 287, available: [287-288])
+	Function: funcArg (main.funcArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
+		Arg: f: func(int) (declared at line 198, available: [198-199])
+	Function: inlined (main.inlined) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [193:195] injectible: [194-194]
+		Arg: x: int (declared at line 0, available: [193-194])
+	Function: intArg (main.intArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [160:162] injectible: [160-162]
+		Arg: x: int (declared at line 160, available: [160-161])
+	Function: intArrayArg (main.intArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [175:177] injectible: [175-177]
+		Arg: s: [3]int (declared at line 175, available: [175-177])
+	Function: intSliceArg (main.intSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [170:172] injectible: [170-172]
+		Arg: s: []int (declared at line 170, available: [170-171])
+	Function: lenErrInt (main.lenErrInt) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [466:469] injectible: [466-469]
+		Arg: x: int (declared at line 466, available: [466-469])
+		Arg: tag: string (declared at line 466, available: [466-469])
+	Function: lenErrStruct (main.lenErrStruct) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [474:477] injectible: [474-477]
+		Arg: x: main.condFields (declared at line 474, available: [474-477])
+		Arg: tag: string (declared at line 474, available: [474-477])
+	Function: lenMap (main.lenMap) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [428:431] injectible: [428-431]
+		Arg: m: map[string]int (declared at line 428, available: [428-431])
+		Arg: tag: string (declared at line 428, available: [428-431])
+	Function: lenPtrString (main.lenPtrString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [434:437] injectible: [434-437]
+		Arg: s: *string (declared at line 434, available: [434-437])
+		Arg: tag: string (declared at line 434, available: [434-437])
+	Function: lenPtrStructFields (main.lenPtrStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [458:461] injectible: [458-461]
+		Arg: x: *main.lenFields (declared at line 458, available: [458-461])
+		Arg: tag: string (declared at line 458, available: [458-461])
+	Function: lenSlice (main.lenSlice) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [422:425] injectible: [422-425]
+		Arg: s: []int (declared at line 422, available: [422-425])
+		Arg: tag: string (declared at line 422, available: [422-425])
+	Function: lenString (main.lenString) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [416:419] injectible: [416-419]
+		Arg: s: string (declared at line 416, available: [416-419])
+		Arg: tag: string (declared at line 416, available: [416-419])
+	Function: lenStructFields (main.lenStructFields) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [452:455] injectible: [452-455]
+		Arg: x: main.lenFields (declared at line 452, available: [452-455])
+		Arg: tag: string (declared at line 452, available: [452-455])
+	Function: main (main.main) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [14:157] injectible: [14-17], [19-26], [28-35], [37-40], [46-69], [73-73], [78-78], [85-88], [90-93], [97-98], [101-102], [105-106], [111-112], [115-117], [121-130], [133-137], [139-141], [145-147], [149-149], [151-151], [155-157]
+		Var: &emptyStr: *string (declared at line 129, available: [14-157])
+		Var: &sl: *[]int (declared at line 133, available: [14-157])
+		Var: mp: map[string]int (declared at line 134, available: [14-157])
+		Var: &val: *int (declared at line 31, available: [14-157])
+		Var: &ptr1: **int (declared at line 32, available: [14-157])
+		Var: &ptr2: ***int (declared at line 33, available: [14-157])
+		Var: &ptr3: ****int (declared at line 34, available: [14-157])
 		Var: &ptr4: *****int (declared at line 35, available: [37-37])
+		Var: ptr5: *****int (declared at line 36, available: [37-37])
+		Var: &str: *string (declared at line 127, available: [14-157])
 		Var: err: error (declared at line 15, available: [16-17])
-	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [164:166] injectible: [164-166]
-		Arg: m: map[string]int (declared at line 164, available: [164-165])
-	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [198:200] injectible: [198-200]
-	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [126:128] injectible: [126-128]
-		Arg: s: string (declared at line 126, available: [126-127])
-	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [146:148] injectible: [146-148]
-		Arg: s: [3]string (declared at line 146, available: [146-148])
-	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [152:152] injectible: [152-152]
-		Arg: s: [3]string (declared at line 151, available: [152-152])
-	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [141:143] injectible: [141-143]
-		Arg: s: []string (declared at line 141, available: [141-142])
-	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [377:387] injectible: [377-377], [380-381], [383-384], [386-387]
-		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 377, available: )
+	Function: mapArg (main.mapArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [203:205] injectible: [203-205]
+		Arg: m: map[string]int (declared at line 203, available: [203-204])
+	Function: noArgs (main.noArgs) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [237:239] injectible: [237-239]
+	Function: sink (main.sink) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [413:413] injectible: [413-413]
+		Arg: args: []interface {} (declared at line 410, available: [413-413])
+	Function: stringArg (main.stringArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [165:167] injectible: [165-167]
+		Arg: s: string (declared at line 165, available: [165-166])
+	Function: stringArrayArg (main.stringArrayArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [185:187] injectible: [185-187]
+		Arg: s: [3]string (declared at line 185, available: [185-187])
+	Function: stringArrayArgFrameless (main.stringArrayArgFrameless) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [191:191] injectible: [191-191]
+		Arg: s: [3]string (declared at line 190, available: [191-191])
+	Function: stringSliceArg (main.stringSliceArg) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [180:182] injectible: [180-182]
+		Arg: s: []string (declared at line 180, available: [180-181])
+	Function: usesMapsOfMapsThatDoNotAppearAsArguments (main.usesMapsOfMapsThatDoNotAppearAsArguments) in github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go [488:498] injectible: [488-488], [491-492], [494-495], [497-498]
+		Arg: ~r0: map[uint8]map[int]main.aStructNotUsedAsAnArgument (declared at line 488, available: )
 	Type: main.condFields
 		Field: I8: int8
 		Field: I16: int16
@@ -117,3 +147,10 @@ Package: main
 		Field: B: bool
 		Field: S: string
 		Field: arr: [3]int16
+	Type: main.lenFields
+		Field: S: string
+		Field: Items: []int
+		Field: Dict: map[string]int
+		Field: PtrStr: *string
+		Field: PtrSlice: *[]int
+		Field: pad: [3]int16

--- a/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 190
+            "lineNumber": 229
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/PointerSmallChainArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.PointerSmallChainArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 194
+            "lineNumber": 233
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/bigMapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.bigMapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 187
+            "lineNumber": 226
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condBool_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condBool_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condBool",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 280
+            "lineNumber": 319
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condBool",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 280
+            "lineNumber": 319
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condFloat32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condFloat32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condFloat32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 270
+            "lineNumber": 309
           },
           {
             "function": "main.main",
@@ -77,7 +77,7 @@
           {
             "function": "main.condFloat32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 270
+            "lineNumber": 309
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condFloat64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condFloat64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condFloat64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 275
+            "lineNumber": 314
           },
           {
             "function": "main.main",
@@ -77,7 +77,7 @@
           {
             "function": "main.condFloat64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 275
+            "lineNumber": 314
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt16_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt16_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 235
+            "lineNumber": 274
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condInt16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 235
+            "lineNumber": 274
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt32_cond_with_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt32_cond_with_capture.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 240
+            "lineNumber": 279
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 240
+            "lineNumber": 279
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condInt32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 240
+            "lineNumber": 279
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 245
+            "lineNumber": 284
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condInt64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 245
+            "lineNumber": 284
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condInt8_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condInt8_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condInt8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 230
+            "lineNumber": 269
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condInt8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 230
+            "lineNumber": 269
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condLine_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 343
+            "lineNumber": 381
           },
           {
             "function": "main.main",
@@ -41,12 +41,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 343
+            "line": 381
           }
         },
         "captures": {
           "lines": {
-            "343": {
+            "381": {
               "captureExpressions": {
                 "tag_val": {
                   "type": "string",

--- a/pkg/dyninst/testdata/decoded/simple/condLine_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condLine_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 343
+            "lineNumber": 381
           },
           {
             "function": "main.main",
@@ -41,12 +41,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 343
+            "line": 381
           }
         },
         "captures": {
           "lines": {
-            "343": {
+            "381": {
               "locals": {
                 "n": {
                   "type": "int",
@@ -55,10 +55,6 @@
                 "tag": {
                   "type": "string",
                   "value": "match"
-                },
-                "result": {
-                  "type": "int",
-                  "value": "14"
                 }
               }
             }
@@ -88,7 +84,7 @@
           {
             "function": "main.condLine",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 343
+            "lineNumber": 381
           },
           {
             "function": "main.main",
@@ -111,12 +107,12 @@
           "location": {
             "method": "main.condLine",
             "file": "main.go",
-            "line": 343
+            "line": 381
           }
         },
         "captures": {
           "lines": {
-            "343": {
+            "381": {
               "locals": {
                 "n": {
                   "type": "int",
@@ -125,10 +121,6 @@
                 "tag": {
                   "type": "string",
                   "value": "miss"
-                },
-                "result": {
-                  "type": "int",
-                  "value": "0"
                 }
               }
             }

--- a/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
@@ -53,7 +53,7 @@
       "evaluationErrors": [
         {
           "expr": "x.I32 == 300",
-          "message": "nil pointer encountered evaluating condition"
+          "message": "nil pointer dereference"
         }
       ]
     },

--- a/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condNilPtr_cond.json
@@ -53,7 +53,7 @@
       "evaluationErrors": [
         {
           "expr": "x.I32 == 300",
-          "message": "error evaluating condition"
+          "message": "nil pointer encountered evaluating condition"
         }
       ]
     },

--- a/pkg/dyninst/testdata/decoded/simple/condNilPtr_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condNilPtr_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condNilPtrStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 311
+            "lineNumber": 350
           },
           {
             "function": "main.main",
@@ -149,7 +149,7 @@
           {
             "function": "main.condNilPtrStruct",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 311
+            "lineNumber": 350
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condOnly_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condOnly_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 332
+            "lineNumber": 371
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condOnly_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condOnly_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 332
+            "lineNumber": 371
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condOnly",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 332
+            "lineNumber": 371
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condPtrStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condPtrStruct_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condPtrStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 301
+            "lineNumber": 340
           },
           {
             "function": "main.main",
@@ -149,7 +149,7 @@
           {
             "function": "main.condPtrStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 301
+            "lineNumber": 340
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condReturnAndLocal_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condReturnAndLocal_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condReturnAndLocal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 321
+            "lineNumber": 360
           },
           {
             "function": "main.main",
@@ -89,7 +89,7 @@
           {
             "function": "main.condReturnAndLocal",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 321
+            "lineNumber": 360
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condString_eq_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_eq_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.condString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 324
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 68
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "condString_eq_capture",
+          "location": {
+            "method": "main.condString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x_eq_hello": {
+                "type": "bool",
+                "value": "true"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.condString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 324
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 69
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "condString_eq_capture",
+          "location": {
+            "method": "main.condString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "x_eq_hello": {
+                "type": "bool",
+                "value": "false"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/condString_eq_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_eq_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "condString_eq_template",
+          "location": {
+            "method": "main.condString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "eq=true"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.condString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "condString_eq_template",
+          "location": {
+            "method": "main.condString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "eq=false"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/condString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 285
+            "lineNumber": 324
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 285
+            "lineNumber": 324
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condString_snapshot_with_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condString_snapshot_with_cond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condString",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 285
+            "lineNumber": 324
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condStruct_cond_i32_capture_tag.json
+++ b/pkg/dyninst/testdata/decoded/simple/condStruct_cond_i32_capture_tag.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 293
+            "lineNumber": 332
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condStruct_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 293
+            "lineNumber": 332
           },
           {
             "function": "main.main",
@@ -148,7 +148,7 @@
           {
             "function": "main.condStructArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 293
+            "lineNumber": 332
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint16_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint16_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 255
+            "lineNumber": 294
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condUint16",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 255
+            "lineNumber": 294
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint32_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint32_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 260
+            "lineNumber": 299
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condUint32",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 260
+            "lineNumber": 299
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint64_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint64_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 265
+            "lineNumber": 304
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condUint64",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 265
+            "lineNumber": 304
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/condUint8_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/condUint8_nocond.json
@@ -18,7 +18,7 @@
           {
             "function": "main.condUint8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 250
+            "lineNumber": 289
           },
           {
             "function": "main.main",
@@ -81,7 +81,7 @@
           {
             "function": "main.condUint8",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 250
+            "lineNumber": 289
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/inlined.json
+++ b/pkg/dyninst/testdata/decoded/simple/inlined.json
@@ -18,7 +18,7 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 155
+            "lineNumber": 194
           },
           {
             "function": "main.main",
@@ -82,12 +82,12 @@
           {
             "function": "main.inlined",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 156
+            "lineNumber": 195
           },
           {
             "function": "main.funcArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 160
+            "lineNumber": 199
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 123
+            "lineNumber": 162
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 138
+            "lineNumber": 177
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
+++ b/pkg/dyninst/testdata/decoded/simple/intArrayArgFrameless.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArgFrameless",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 152
+            "lineNumber": 191
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/intSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.intSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 133
+            "lineNumber": 172
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/lenErrInt_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErrInt_nocond.json
@@ -1,0 +1,65 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenErrInt",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenErrInt",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 469
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 155
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenErrInt_nocond",
+          "location": {
+            "method": "main.lenErrInt"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "int",
+                "value": "42"
+              },
+              "tag": {
+                "type": "string",
+                "value": "err"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenErrStruct_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErrStruct_nocond.json
@@ -1,0 +1,132 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenErrStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenErrStruct",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 477
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 156
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenErrStruct_nocond",
+          "location": {
+            "method": "main.lenErrStruct"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "main.condFields",
+                "fields": {
+                  "I8": {
+                    "type": "int8",
+                    "value": "0"
+                  },
+                  "I16": {
+                    "type": "int16",
+                    "value": "0"
+                  },
+                  "I32": {
+                    "type": "int32",
+                    "value": "1"
+                  },
+                  "I64": {
+                    "type": "int64",
+                    "value": "0"
+                  },
+                  "U8": {
+                    "type": "uint8",
+                    "value": "0"
+                  },
+                  "U16": {
+                    "type": "uint16",
+                    "value": "0"
+                  },
+                  "U32": {
+                    "type": "uint32",
+                    "value": "0"
+                  },
+                  "U64": {
+                    "type": "uint64",
+                    "value": "0"
+                  },
+                  "F32": {
+                    "type": "float32",
+                    "value": "0"
+                  },
+                  "F64": {
+                    "type": "float64",
+                    "value": "0"
+                  },
+                  "B": {
+                    "type": "bool",
+                    "value": "false"
+                  },
+                  "S": {
+                    "type": "string",
+                    "value": ""
+                  },
+                  "arr": {
+                    "type": "[3]int16",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                }
+              },
+              "tag": {
+                "type": "string",
+                "value": "err"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenErr_int.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErr_int.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenErrInt",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenErr_int",
+          "location": {
+            "method": "main.lenErrInt"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"int\" (int)}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenErr_struct.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenErr_struct.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenErrStruct",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenErr_struct",
+          "location": {
+            "method": "main.lenErrStruct"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"main.condFields\" (struct)}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
@@ -1,0 +1,36 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenMap_isEmpty_cond",
+          "location": {
+            "method": "main.lenMap"
+          }
+        }
+      },
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "isEmpty(m)",
+          "message": "nil pointer encountered evaluating condition"
+        }
+      ]
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_cond.json
@@ -25,7 +25,7 @@
       "evaluationErrors": [
         {
           "expr": "isEmpty(m)",
-          "message": "nil pointer encountered evaluating condition"
+          "message": "nil pointer dereference"
         }
       ]
     },

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
@@ -49,10 +49,16 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "isEmpty(m)",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "empty={nil}"
+    "message": "empty={error: nil pointer dereference}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_isEmpty_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenMap_isEmpty_template",
+          "location": {
+            "method": "main.lenMap"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty=false"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenMap_isEmpty_template",
+          "location": {
+            "method": "main.lenMap"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty={nil}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
@@ -99,18 +99,14 @@
           "location": {
             "method": "main.lenMap"
           }
-        },
-        "captures": {
-          "entry": {
-            "captureExpressions": {
-              "m_len": {
-                "type": "uint64",
-                "notCapturedReason": "nil"
-              }
-            }
-          }
         }
-      }
+      },
+      "evaluationErrors": [
+        {
+          "expr": "m_len",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]"

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 431
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 125
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenMap_len_capture",
+          "location": {
+            "method": "main.lenMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "m_len": {
+                "type": "uint64",
+                "value": "3"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 431
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 126
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenMap_len_capture",
+          "location": {
+            "method": "main.lenMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "m_len": {
+                "type": "uint64",
+                "notCapturedReason": "nil"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
@@ -4,7 +4,7 @@
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.lenPtrStructFields",
+      "method": "main.lenMap",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -15,9 +15,9 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "lenPtrStruct_field_map",
+          "id": "lenMap_len_eq_cond",
           "location": {
-            "method": "main.lenPtrStructFields"
+            "method": "main.lenMap"
           }
         }
       },
@@ -25,14 +25,14 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len=2"
+    "message": "tag=match"
   },
   {
     "service": "simple",
     "ddsource": "dd_debugger",
     "logger": {
       "name": "",
-      "method": "main.lenPtrStructFields",
+      "method": "main.lenMap",
       "version": 0,
       "thread_id": "[goid]",
       "thread_name": ""
@@ -43,16 +43,22 @@
         "timestamp": "[ts]",
         "language": "go",
         "probe": {
-          "id": "lenPtrStruct_field_map",
+          "id": "lenMap_len_eq_cond",
           "location": {
-            "method": "main.lenPtrStructFields"
+            "method": "main.lenMap"
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "len(m) == 3",
+          "message": "nil pointer encountered evaluating condition"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={nil}"
+    "message": "tag=miss"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_eq_cond.json
@@ -53,7 +53,7 @@
       "evaluationErrors": [
         {
           "expr": "len(m) == 3",
-          "message": "nil pointer encountered evaluating condition"
+          "message": "nil pointer dereference"
         }
       ]
     },

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
@@ -25,7 +25,7 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+    "message": "len=3"
   },
   {
     "service": "simple",
@@ -53,6 +53,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+    "message": "len={nil}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenMap_len_template",
+          "location": {
+            "method": "main.lenMap"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenMap_len_template",
+          "location": {
+            "method": "main.lenMap"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_len_template.json
@@ -49,10 +49,16 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "len(m)",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={nil}"
+    "message": "len={error: nil pointer dereference}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenMap_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenMap_nocond.json
@@ -1,0 +1,160 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 431
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 125
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenMap_nocond",
+          "location": {
+            "method": "main.lenMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[string]int",
+                "size": "3",
+                "entries": [
+                  [
+                    {
+                      "type": "string",
+                      "value": "a"
+                    },
+                    {
+                      "type": "int",
+                      "value": "1"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "string",
+                      "value": "b"
+                    },
+                    {
+                      "type": "int",
+                      "value": "2"
+                    }
+                  ],
+                  [
+                    {
+                      "type": "string",
+                      "value": "c"
+                    },
+                    {
+                      "type": "int",
+                      "value": "3"
+                    }
+                  ]
+                ]
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenMap",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenMap",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 431
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 126
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenMap_nocond",
+          "location": {
+            "method": "main.lenMap"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "m": {
+                "type": "map[string]int",
+                "isNull": true
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrString_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrString_len_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrString_len_template",
+          "location": {
+            "method": "main.lenPtrString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrString_len_template",
+          "location": {
+            "method": "main.lenPtrString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrString_nocond.json
@@ -1,0 +1,130 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenPtrString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 437
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 128
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenPtrString_nocond",
+          "location": {
+            "method": "main.lenPtrString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "*string",
+                "address": "[addr]",
+                "value": "hello"
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenPtrString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 437
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 130
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenPtrString_nocond",
+          "location": {
+            "method": "main.lenPtrString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "*string",
+                "address": "[addr]",
+                "value": ""
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStructFields_nocond.json
@@ -1,0 +1,261 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenPtrStructFields",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 461
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 145
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenPtrStructFields_nocond",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "*main.lenFields",
+                "address": "[addr]",
+                "fields": {
+                  "S": {
+                    "type": "string",
+                    "value": "hello"
+                  },
+                  "Items": {
+                    "type": "[]int",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "1"
+                      },
+                      {
+                        "type": "int",
+                        "value": "2"
+                      },
+                      {
+                        "type": "int",
+                        "value": "3"
+                      }
+                    ]
+                  },
+                  "Dict": {
+                    "type": "map[string]int",
+                    "size": "2",
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "a"
+                        },
+                        {
+                          "type": "int",
+                          "value": "1"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "b"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        }
+                      ]
+                    ]
+                  },
+                  "PtrStr": {
+                    "type": "*string",
+                    "address": "[addr]",
+                    "value": "hello"
+                  },
+                  "PtrSlice": {
+                    "type": "*[]int",
+                    "address": "[addr]",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "1"
+                      },
+                      {
+                        "type": "int",
+                        "value": "2"
+                      },
+                      {
+                        "type": "int",
+                        "value": "3"
+                      }
+                    ]
+                  },
+                  "pad": {
+                    "type": "[3]int16",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                }
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenPtrStructFields",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 461
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 149
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenPtrStructFields_nocond",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "*main.lenFields",
+                "address": "[addr]",
+                "fields": {
+                  "S": {
+                    "type": "string",
+                    "value": ""
+                  },
+                  "Items": {
+                    "type": "[]int",
+                    "isNull": true
+                  },
+                  "Dict": {
+                    "type": "map[string]int",
+                    "isNull": true
+                  },
+                  "PtrStr": {
+                    "type": "*string",
+                    "address": "[addr]",
+                    "value": ""
+                  },
+                  "PtrSlice": {
+                    "type": "*[]int",
+                    "isNull": true
+                  },
+                  "pad": {
+                    "type": "[3]int16",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                }
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
@@ -49,10 +49,16 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "len(x.Dict)",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={nil}"
+    "message": "len={error: nil pointer dereference}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_map.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_map",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_map",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_slice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_slice.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_slice",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=3"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_slice",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenPtrStruct_field_string.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_string",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenPtrStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenPtrStruct_field_string",
+          "location": {
+            "method": "main.lenPtrStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_isEmpty_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_isEmpty_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_isEmpty_cond",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_isEmpty_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_isEmpty_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_isEmpty_template",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty=false"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_isEmpty_template",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty=true"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_len_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 425
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 123
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenSlice_len_capture",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len": {
+                "type": "int",
+                "value": "5"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 425
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 124
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenSlice_len_capture",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len": {
+                "type": "int",
+                "value": "0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_len_eq_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_len_eq_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_len_eq_cond",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=match"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_len_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_len_template",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenSlice_len_template",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenSlice_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenSlice_nocond.json
@@ -1,0 +1,150 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 425
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 123
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenSlice_nocond",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "[]int",
+                "size": "5",
+                "elements": [
+                  {
+                    "type": "int",
+                    "value": "1"
+                  },
+                  {
+                    "type": "int",
+                    "value": "2"
+                  },
+                  {
+                    "type": "int",
+                    "value": "3"
+                  },
+                  {
+                    "type": "int",
+                    "value": "4"
+                  },
+                  {
+                    "type": "int",
+                    "value": "5"
+                  }
+                ]
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenSlice",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenSlice",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 425
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 124
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenSlice_nocond",
+          "location": {
+            "method": "main.lenSlice"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "[]int",
+                "isNull": true
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_eq_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_eq_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 121
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_eq_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len_eq_5": {
+                "type": "bool",
+                "value": "true"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 122
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_eq_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len_eq_5": {
+                "type": "bool",
+                "value": "false"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_eq_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_eq_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_eq_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "eq=true"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_eq_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "eq=false"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 121
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_isEmpty_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_isEmpty": {
+                "type": "bool",
+                "value": "false"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 122
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_isEmpty_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_isEmpty": {
+                "type": "bool",
+                "value": "true"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_isEmpty_cond",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_isEmpty_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_isEmpty_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty=false"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_isEmpty_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "empty=true"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_len_capture.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_len_capture.json
@@ -1,0 +1,118 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 121
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_len_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len": {
+                "type": "int",
+                "value": "5"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 122
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_len_capture",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "captureExpressions": {
+              "s_len": {
+                "type": "int",
+                "value": "0"
+              }
+            }
+          }
+        }
+      }
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_len_eq_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_len_eq_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_len_eq_cond",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=match"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_len_template.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_len_template.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_len_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenString_len_template",
+          "location": {
+            "method": "main.lenString"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenString_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenString_nocond.json
@@ -1,0 +1,128 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 121
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_nocond",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": "hello"
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenString",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenString",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 419
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 122
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenString_nocond",
+          "location": {
+            "method": "main.lenString"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "s": {
+                "type": "string",
+                "value": ""
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
@@ -172,7 +172,7 @@
           {
             "function": "main.lenStructFields",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 455
+            "lineNumber": 452
           },
           {
             "function": "main.main",
@@ -251,9 +251,14 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "@duration",
+          "message": "not available: maximum call count exceeded"
+        }
+      ]
     },
-    "timestamp": "[ts]",
-    "duration": "[duration]"
+    "timestamp": "[ts]"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStructFields_nocond.json
@@ -1,0 +1,259 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenStructFields",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 455
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 135
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenStructFields_nocond",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "main.lenFields",
+                "fields": {
+                  "S": {
+                    "type": "string",
+                    "value": "hello"
+                  },
+                  "Items": {
+                    "type": "[]int",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "1"
+                      },
+                      {
+                        "type": "int",
+                        "value": "2"
+                      },
+                      {
+                        "type": "int",
+                        "value": "3"
+                      }
+                    ]
+                  },
+                  "Dict": {
+                    "type": "map[string]int",
+                    "size": "2",
+                    "entries": [
+                      [
+                        {
+                          "type": "string",
+                          "value": "a"
+                        },
+                        {
+                          "type": "int",
+                          "value": "1"
+                        }
+                      ],
+                      [
+                        {
+                          "type": "string",
+                          "value": "b"
+                        },
+                        {
+                          "type": "int",
+                          "value": "2"
+                        }
+                      ]
+                    ]
+                  },
+                  "PtrStr": {
+                    "type": "*string",
+                    "address": "[addr]",
+                    "value": "hello"
+                  },
+                  "PtrSlice": {
+                    "type": "*[]int",
+                    "address": "[addr]",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int",
+                        "value": "1"
+                      },
+                      {
+                        "type": "int",
+                        "value": "2"
+                      },
+                      {
+                        "type": "int",
+                        "value": "3"
+                      }
+                    ]
+                  },
+                  "pad": {
+                    "type": "[3]int16",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                }
+              },
+              "tag": {
+                "type": "string",
+                "value": "match"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "stack": [
+          {
+            "function": "main.lenStructFields",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 455
+          },
+          {
+            "function": "main.main",
+            "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
+            "lineNumber": 139
+          },
+          {
+            "function": "runtime.main",
+            "fileName": "runtime/proc.go",
+            "lineNumber": "[lineNumber]"
+          },
+          {
+            "function": "runtime.goexit",
+            "fileName": "runtime/asm_[arch].s",
+            "lineNumber": "[lineNumber]"
+          }
+        ],
+        "probe": {
+          "id": "lenStructFields_nocond",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        },
+        "captures": {
+          "entry": {
+            "arguments": {
+              "x": {
+                "type": "main.lenFields",
+                "fields": {
+                  "S": {
+                    "type": "string",
+                    "value": ""
+                  },
+                  "Items": {
+                    "type": "[]int",
+                    "isNull": true
+                  },
+                  "Dict": {
+                    "type": "map[string]int",
+                    "isNull": true
+                  },
+                  "PtrStr": {
+                    "type": "*string",
+                    "address": "[addr]",
+                    "value": ""
+                  },
+                  "PtrSlice": {
+                    "type": "*[]int",
+                    "isNull": true
+                  },
+                  "pad": {
+                    "type": "[3]int16",
+                    "size": "3",
+                    "elements": [
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      },
+                      {
+                        "type": "int16",
+                        "value": "0"
+                      }
+                    ]
+                  }
+                }
+              },
+              "tag": {
+                "type": "string",
+                "value": "miss"
+              }
+            }
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
@@ -49,10 +49,16 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "len(x.Dict)",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={nil}"
+    "message": "len={error: nil pointer dereference}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_map",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_map",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_map.json
@@ -25,7 +25,7 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+    "message": "len=2"
   },
   {
     "service": "simple",
@@ -53,6 +53,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={error: len/isEmpty not supported on type \"map[string]int\" (map)}"
+    "message": "len={nil}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
@@ -49,10 +49,16 @@
           }
         }
       },
-      "type": "snapshot"
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "len(x.PtrSlice)",
+          "message": "nil pointer dereference"
+        }
+      ]
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={nil}"
+    "message": "len={error: nil pointer dereference}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
@@ -53,6 +53,6 @@
     },
     "timestamp": "[ts]",
     "duration": "[duration]",
-    "message": "len={unavailable}"
+    "message": "len={nil}"
   }
 ]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrslice.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_ptrslice",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=3"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_ptrslice",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len={unavailable}"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrstr.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_ptrstr.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_ptrstr",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_ptrstr",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_slice.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_slice.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_slice",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=3"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_slice",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_field_string.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_field_string.json
@@ -1,0 +1,58 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_string",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=5"
+  },
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_field_string",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "len=0"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
@@ -1,0 +1,36 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_isEmpty_map_cond",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot",
+      "evaluationErrors": [
+        {
+          "expr": "isEmpty(x.Dict)",
+          "message": "nil pointer encountered evaluating condition"
+        }
+      ]
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_map_cond.json
@@ -25,7 +25,7 @@
       "evaluationErrors": [
         {
           "expr": "isEmpty(x.Dict)",
-          "message": "nil pointer encountered evaluating condition"
+          "message": "nil pointer dereference"
         }
       ]
     },

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_slice_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_slice_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_isEmpty_slice_cond",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_string_cond.json
+++ b/pkg/dyninst/testdata/decoded/simple/lenStruct_isEmpty_string_cond.json
@@ -1,0 +1,30 @@
+[
+  {
+    "service": "simple",
+    "ddsource": "dd_debugger",
+    "logger": {
+      "name": "",
+      "method": "main.lenStructFields",
+      "version": 0,
+      "thread_id": "[goid]",
+      "thread_name": ""
+    },
+    "debugger": {
+      "snapshot": {
+        "id": "[id]",
+        "timestamp": "[ts]",
+        "language": "go",
+        "probe": {
+          "id": "lenStruct_isEmpty_string_cond",
+          "location": {
+            "method": "main.lenStructFields"
+          }
+        }
+      },
+      "type": "snapshot"
+    },
+    "timestamp": "[ts]",
+    "duration": "[duration]",
+    "message": "tag=miss"
+  }
+]

--- a/pkg/dyninst/testdata/decoded/simple/mapArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/mapArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.mapArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 166
+            "lineNumber": 205
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/noArgs.json
+++ b/pkg/dyninst/testdata/decoded/simple/noArgs.json
@@ -18,7 +18,7 @@
           {
             "function": "main.noArgs",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 200
+            "lineNumber": 239
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 128
+            "lineNumber": 167
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringArrayArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringArrayArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 148
+            "lineNumber": 187
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
+++ b/pkg/dyninst/testdata/decoded/simple/stringSliceArg.json
@@ -18,7 +18,7 @@
           {
             "function": "main.stringSliceArg",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 143
+            "lineNumber": 182
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
+++ b/pkg/dyninst/testdata/decoded/simple/usesMapsOfMapsThatDoNotAppearAsArguments.json
@@ -18,7 +18,7 @@
           {
             "function": "main.usesMapsOfMapsThatDoNotAppearAsArguments",
             "fileName": "github.com/DataDog/datadog-agent/pkg/dyninst/testprogs/progs/simple/main.go",
-            "lineNumber": 386
+            "lineNumber": 497
           },
           {
             "function": "main.main",

--- a/pkg/dyninst/testprogs/progs/simple/main.go
+++ b/pkg/dyninst/testprogs/progs/simple/main.go
@@ -115,6 +115,45 @@ func main() {
 	condSliceArg([]int{1, 2, 3}, "err")
 	condMapArg(map[string]int{"a": 1}, "err")
 	condStructDirect(condFields{I32: 42}, "err")
+
+	// len/isEmpty test functions: each called twice — once with a value that
+	// matches conditions, once with a different value.
+	lenString("hello", "match")
+	lenString("", "miss")
+	lenSlice([]int{1, 2, 3, 4, 5}, "match")
+	lenSlice(nil, "miss")
+	lenMap(map[string]int{"a": 1, "b": 2, "c": 3}, "match")
+	lenMap(nil, "miss")
+	str := "hello"
+	lenPtrString(&str, "match")
+	emptyStr := ""
+	lenPtrString(&emptyStr, "miss")
+
+	// len/isEmpty on struct fields (getmember + len)
+	sl := []int{1, 2, 3}
+	mp := map[string]int{"a": 1, "b": 2}
+	lenStructFields(lenFields{
+		S: "hello", Items: sl, Dict: mp,
+		PtrStr: &str, PtrSlice: &sl,
+	}, "match")
+	lenStructFields(lenFields{
+		S: "", Items: nil, Dict: nil,
+		PtrStr: &emptyStr, PtrSlice: nil,
+	}, "miss")
+
+	// len/isEmpty on pointer-to-struct fields
+	lenPtrStructFields(&lenFields{
+		S: "hello", Items: sl, Dict: mp,
+		PtrStr: &str, PtrSlice: &sl,
+	}, "match")
+	lenPtrStructFields(&lenFields{
+		S: "", Items: nil, Dict: nil,
+		PtrStr: &emptyStr, PtrSlice: nil,
+	}, "miss")
+
+	// len/isEmpty error cases: unsupported types
+	lenErrInt(42, "err")
+	lenErrStruct(condFields{I32: 1}, "err")
 }
 
 //go:noinline
@@ -362,6 +401,78 @@ func condMapArg(x map[string]int, tag string) {
 //
 //go:noinline
 func condStructDirect(x condFields, tag string) {
+	fmt.Println(x, tag)
+}
+
+// --- len/isEmpty test functions ---
+
+//go:noinline
+func sink(args ...any) {
+	// Prevent the compiler from optimizing away arguments.
+	_ = args
+}
+
+//go:noinline
+func lenString(s string, tag string) {
+	sink(s, tag)
+	fmt.Println(len(s), tag)
+}
+
+//go:noinline
+func lenSlice(s []int, tag string) {
+	sink(s, tag)
+	fmt.Println(len(s), tag)
+}
+
+//go:noinline
+func lenMap(m map[string]int, tag string) {
+	sink(m, tag)
+	fmt.Println(len(m), tag)
+}
+
+//go:noinline
+func lenPtrString(s *string, tag string) {
+	sink(s, tag)
+	fmt.Println(s, tag)
+}
+
+// lenFields is a struct with collection-typed fields for testing len/isEmpty
+// on field accesses (getmember + len), including pointer-to-collection fields.
+type lenFields struct {
+	S        string
+	Items    []int
+	Dict     map[string]int
+	PtrStr   *string
+	PtrSlice *[]int
+
+	pad [3]int16 // prevent this struct from being split to registers
+}
+
+//go:noinline
+func lenStructFields(x lenFields, tag string) {
+	sink(x, tag)
+	fmt.Println(x.S, x.Items, x.Dict, tag)
+}
+
+//go:noinline
+func lenPtrStructFields(x *lenFields, tag string) {
+	sink(x, tag)
+	fmt.Println(x.S, x.Items, x.Dict, tag)
+}
+
+// lenErrInt is a target for unsupported len on base type (int).
+//
+//go:noinline
+func lenErrInt(x int, tag string) {
+	sink(x, tag)
+	fmt.Println(x, tag)
+}
+
+// lenErrStruct is a target for unsupported len on a plain struct.
+//
+//go:noinline
+func lenErrStruct(x condFields, tag string) {
+	sink(x, tag)
 	fmt.Println(x, tag)
 }
 

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -1516,3 +1516,115 @@ probes:
     methodName: main.lenErrStruct
   sampling:
     snapshotsPerSecond: 10
+
+# ==========================================================================
+# eq() and isEmpty() as top-level expressions (template + capture)
+# ==========================================================================
+
+# --- isEmpty in template ---
+- id: lenString_isEmpty_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  template: "empty={isEmpty(s)}"
+  segments:
+    - str: "empty="
+    - json: {isEmpty: {ref: "s"}}
+      dsl: "isEmpty(s)"
+  sampling:
+    snapshotsPerSecond: 10
+
+- id: lenMap_isEmpty_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenMap
+  template: "empty={isEmpty(m)}"
+  segments:
+    - str: "empty="
+    - json: {isEmpty: {ref: "m"}}
+      dsl: "isEmpty(m)"
+  sampling:
+    snapshotsPerSecond: 10
+
+- id: lenSlice_isEmpty_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenSlice
+  template: "empty={isEmpty(s)}"
+  segments:
+    - str: "empty="
+    - json: {isEmpty: {ref: "s"}}
+      dsl: "isEmpty(s)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- eq in template ---
+- id: lenString_eq_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  template: "eq={len(s) == 5}"
+  segments:
+    - str: "eq="
+    - json: {eq: [{len: {ref: "s"}}, 5]}
+      dsl: "len(s) == 5"
+  sampling:
+    snapshotsPerSecond: 10
+
+- id: condString_eq_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condString
+  template: "eq={x == \"hello\"}"
+  segments:
+    - str: "eq="
+    - json: {eq: [{ref: "x"}, "hello"]}
+      dsl: "x == \"hello\""
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- isEmpty as capture expression ---
+- id: lenString_isEmpty_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  captureExpressions:
+    - name: "s_isEmpty"
+      expr:
+        dsl: "isEmpty(s)"
+        json: {isEmpty: {ref: "s"}}
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- eq as capture expression ---
+- id: lenString_eq_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  captureExpressions:
+    - name: "s_len_eq_5"
+      expr:
+        dsl: "len(s) == 5"
+        json: {eq: [{len: {ref: "s"}}, 5]}
+  sampling:
+    snapshotsPerSecond: 10
+
+- id: condString_eq_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.condString
+  captureExpressions:
+    - name: "x_eq_hello"
+      expr:
+        dsl: "x == \"hello\""
+        json: {eq: [{ref: "x"}, "hello"]}
+  sampling:
+    snapshotsPerSecond: 10

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -743,7 +743,7 @@ probes:
     methodName: main.condLine
     sourceFile: main.go
     lines:
-      - "343"
+      - "381"
   when:
     dsl: "n == 7"
     json: {eq: [{ref: "n"}, 7]}
@@ -768,7 +768,7 @@ probes:
     methodName: main.condLine
     sourceFile: main.go
     lines:
-      - "343"
+      - "381"
   sampling:
     snapshotsPerSecond: 10
 

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -999,3 +999,390 @@ probes:
     snapshotsPerSecond: 10
   tags:
     - "issue:ConditionExpressionUnresolvable"
+
+# ==========================================================================
+# len/isEmpty tests
+# ==========================================================================
+
+# --- lenString: len in template ---
+- id: lenString_len_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  template: "len={len(s)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "s"}}
+      dsl: "len(s)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenString: len as capture expression ---
+- id: lenString_len_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  captureExpressions:
+    - name: "s_len"
+      expr:
+        dsl: "len(s)"
+        json: {len: {ref: "s"}}
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenString: len inside eq condition ---
+- id: lenString_len_eq_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  when:
+    dsl: "len(s) == 5"
+    json: {eq: [{len: {ref: "s"}}, 5]}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenString: isEmpty as standalone condition ---
+- id: lenString_isEmpty_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenString
+  when:
+    dsl: "isEmpty(s)"
+    json: {isEmpty: {ref: "s"}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenString: unconditional control probe ---
+- id: lenString_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenString
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenSlice: len in template ---
+- id: lenSlice_len_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenSlice
+  template: "len={len(s)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "s"}}
+      dsl: "len(s)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenSlice: unconditional control probe ---
+- id: lenSlice_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenSlice
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenMap: len in template ---
+- id: lenMap_len_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenMap
+  template: "len={len(m)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "m"}}
+      dsl: "len(m)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenMap: unconditional control probe ---
+- id: lenMap_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenMap
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenPtrString: len with pointer auto-dereference ---
+- id: lenPtrString_len_template
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenPtrString
+  template: "len={len(s)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "s"}}
+      dsl: "len(s)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenPtrString: unconditional control probe ---
+- id: lenPtrString_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenPtrString
+  sampling:
+    snapshotsPerSecond: 10
+
+# ==========================================================================
+# len/isEmpty on struct fields (getmember + len)
+# ==========================================================================
+
+# len of struct string field: x.S
+- id: lenStruct_field_string
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  template: "len={len(x.S)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "S"]}}
+      dsl: "len(x.S)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of struct slice field: x.Items
+- id: lenStruct_field_slice
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  template: "len={len(x.Items)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "Items"]}}
+      dsl: "len(x.Items)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of struct map field: x.Dict
+- id: lenStruct_field_map
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  template: "len={len(x.Dict)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "Dict"]}}
+      dsl: "len(x.Dict)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# isEmpty of struct string field as condition
+- id: lenStruct_isEmpty_string_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  when:
+    dsl: "isEmpty(x.S)"
+    json: {isEmpty: {getmember: [{ref: "x"}, "S"]}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of struct pointer-to-string field: x.PtrStr (pointer auto-deref on leaf)
+- id: lenStruct_field_ptrstr
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  template: "len={len(x.PtrStr)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "PtrStr"]}}
+      dsl: "len(x.PtrStr)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of struct pointer-to-slice field: x.PtrSlice (pointer auto-deref on leaf)
+- id: lenStruct_field_ptrslice
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  template: "len={len(x.PtrSlice)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "PtrSlice"]}}
+      dsl: "len(x.PtrSlice)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# unconditional control probe for lenStructFields
+- id: lenStructFields_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenStructFields
+  sampling:
+    snapshotsPerSecond: 10
+
+# ==========================================================================
+# len/isEmpty on pointer-to-struct fields (deref struct ptr, then field, then len)
+# ==========================================================================
+
+# len of ptr-struct string field: x.S
+- id: lenPtrStruct_field_string
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenPtrStructFields
+  template: "len={len(x.S)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "S"]}}
+      dsl: "len(x.S)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of ptr-struct slice field: x.Items
+- id: lenPtrStruct_field_slice
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenPtrStructFields
+  template: "len={len(x.Items)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "Items"]}}
+      dsl: "len(x.Items)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# len of ptr-struct map field: x.Dict
+- id: lenPtrStruct_field_map
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenPtrStructFields
+  template: "len={len(x.Dict)}"
+  segments:
+    - str: "len="
+    - json: {len: {getmember: [{ref: "x"}, "Dict"]}}
+      dsl: "len(x.Dict)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# unconditional control probe for lenPtrStructFields
+- id: lenPtrStructFields_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenPtrStructFields
+  sampling:
+    snapshotsPerSecond: 10
+
+# ==========================================================================
+# len/isEmpty error cases: unsupported types
+# ==========================================================================
+
+# len on int (base type — should fail)
+- id: lenErr_int
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenErrInt
+  template: "len={len(x)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "x"}}
+      dsl: "len(x)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# isEmpty on int as condition (base type — should fail)
+- id: lenErr_int_isEmpty_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenErrInt
+  when:
+    dsl: "isEmpty(x)"
+    json: {isEmpty: {ref: "x"}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:ConditionExpressionUnresolvable"
+
+# len on struct (structure type — should fail)
+- id: lenErr_struct
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenErrStruct
+  template: "len={len(x)}"
+  segments:
+    - str: "len="
+    - json: {len: {ref: "x"}}
+      dsl: "len(x)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# isEmpty on struct as condition (structure type — should fail)
+- id: lenErr_struct_isEmpty_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenErrStruct
+  when:
+    dsl: "isEmpty(x)"
+    json: {isEmpty: {ref: "x"}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+  tags:
+    - "issue:ConditionExpressionUnresolvable"
+
+# unconditional control probe for lenErrInt
+- id: lenErrInt_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenErrInt
+  sampling:
+    snapshotsPerSecond: 10
+
+# unconditional control probe for lenErrStruct
+- id: lenErrStruct_nocond
+  type: LOG_PROBE
+  captureSnapshot: true
+  where:
+    methodName: main.lenErrStruct
+  sampling:
+    snapshotsPerSecond: 10

--- a/pkg/dyninst/testprogs/testdata/probes/simple.yaml
+++ b/pkg/dyninst/testprogs/testdata/probes/simple.yaml
@@ -1089,6 +1089,54 @@ probes:
   sampling:
     snapshotsPerSecond: 10
 
+# --- lenSlice: len as capture expression ---
+- id: lenSlice_len_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenSlice
+  captureExpressions:
+    - name: "s_len"
+      expr:
+        dsl: "len(s)"
+        json: {len: {ref: "s"}}
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenSlice: len inside eq condition ---
+- id: lenSlice_len_eq_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenSlice
+  when:
+    dsl: "len(s) == 5"
+    json: {eq: [{len: {ref: "s"}}, 5]}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenSlice: isEmpty as standalone condition ---
+- id: lenSlice_isEmpty_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenSlice
+  when:
+    dsl: "isEmpty(s)"
+    json: {isEmpty: {ref: "s"}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
 # --- lenSlice: unconditional control probe ---
 - id: lenSlice_nocond
   type: LOG_PROBE
@@ -1109,6 +1157,54 @@ probes:
     - str: "len="
     - json: {len: {ref: "m"}}
       dsl: "len(m)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenMap: len as capture expression ---
+- id: lenMap_len_capture
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenMap
+  captureExpressions:
+    - name: "m_len"
+      expr:
+        dsl: "len(m)"
+        json: {len: {ref: "m"}}
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenMap: len inside eq condition ---
+- id: lenMap_len_eq_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenMap
+  when:
+    dsl: "len(m) == 3"
+    json: {eq: [{len: {ref: "m"}}, 3]}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# --- lenMap: isEmpty as standalone condition ---
+- id: lenMap_isEmpty_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenMap
+  when:
+    dsl: "isEmpty(m)"
+    json: {isEmpty: {ref: "m"}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
   sampling:
     snapshotsPerSecond: 10
 
@@ -1187,6 +1283,40 @@ probes:
     - str: "len="
     - json: {len: {getmember: [{ref: "x"}, "Dict"]}}
       dsl: "len(x.Dict)"
+  sampling:
+    snapshotsPerSecond: 10
+
+# isEmpty of struct slice field as condition
+- id: lenStruct_isEmpty_slice_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  when:
+    dsl: "isEmpty(x.Items)"
+    json: {isEmpty: {getmember: [{ref: "x"}, "Items"]}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
+  sampling:
+    snapshotsPerSecond: 10
+
+# isEmpty of struct map field as condition
+- id: lenStruct_isEmpty_map_cond
+  type: LOG_PROBE
+  captureSnapshot: false
+  where:
+    methodName: main.lenStructFields
+  when:
+    dsl: "isEmpty(x.Dict)"
+    json: {isEmpty: {getmember: [{ref: "x"}, "Dict"]}}
+  template: "tag={tag}"
+  segments:
+    - str: "tag="
+    - json: {ref: "tag"}
+      dsl: "tag"
   sampling:
     snapshotsPerSecond: 10
 


### PR DESCRIPTION
### What does this PR do?

Add LenExpr and IsEmptyExpr to the expression language and wire them
through IR generation. len() reads the length field from Go string,
slice, and map headers (including through pointers). isEmpty() is
syntactic sugar for len(x) == 0, usable as a standalone probe condition.

Unsupported types (base types, structs) produce clear errors via the
existing issue reporting mechanism.

Also:
dyninst: distinguish nil pointer dereferences from other evaluation failures

Expand the presence bitset from 1 bit to 2 bits per expression. The first
bit indicates whether the expression was successfully captured, and the
second bit indicates whether a nil pointer dereference caused the failure.

This flows through the entire stack:
- eBPF stack machine sets the nil bit when a NULL pointer is encountered
  during EXPR_DEREFERENCE_PTR, and tracks condition_nil_deref separately
- Compiler emits NilBitIdx for dereference ops (sentinel 0xFFFFFFFF for
  condition expressions which use condition_eval_error instead)
- Decoder distinguishes nil from unavailable in both the human-readable
  format ("{nil}" vs "{unavailable}") and JSON notCapturedReason
- Condition evaluation errors now report "nil pointer encountered" when
  applicable

### Motivation

Folks use these functions.

### Describe how you validated your changes

Testing


### Additional Notes

Fixes [DEBUG-5369](https://datadoghq.atlassian.net/browse/DEBUG-5369).
Relates to [DEBUG-4255](https://datadoghq.atlassian.net/browse/DEBUG-4255).

[DEBUG-5369]: https://datadoghq.atlassian.net/browse/DEBUG-5369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ