### PR TITLE
[admission] Add per-pod annotation resource overrides for agent sidecar injection

### DIFF
--- a/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/agent_sidecar.go
@@ -336,6 +336,15 @@ func (w *Webhook) injectAgentSidecar(pod *corev1.Pod, namespace string, _ dynami
 			}
 			podUpdated = podUpdated || updated
 
+			// Apply per-pod annotation-based resource overrides (highest priority).
+			// Invalid annotations are logged and ignored, falling back to profile/default resources.
+			updated, err = applyAnnotationResourceOverrides(pod, &pod.Spec.Containers[i])
+			if err != nil {
+				log.Errorf("Failed to apply annotation resource overrides: %v", err)
+				return podUpdated, errors.New(metrics.InternalError)
+			}
+			podUpdated = podUpdated || updated
+
 			break
 		}
 	}

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/constants.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/constants.go
@@ -14,6 +14,14 @@ const (
 	providerFargate           = "fargate"
 )
 
+// Annotation keys for per-pod sidecar resource overrides
+const (
+	annotationSidecarCPURequest    = "agent.datadoghq.com/sidecar.cpu.request"
+	annotationSidecarCPULimit      = "agent.datadoghq.com/sidecar.cpu.limit"
+	annotationSidecarMemoryRequest = "agent.datadoghq.com/sidecar.memory.request"
+	annotationSidecarMemoryLimit   = "agent.datadoghq.com/sidecar.memory.limit"
+)
+
 const (
 	agentConfigVolumeName   = "agent-config"
 	agentOptionsVolumeName  = "agent-option"

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/overrides.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/overrides.go
@@ -9,8 +9,12 @@ package agentsidecar
 
 import (
 	"errors"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // withEnvOverrides applies the extraEnv overrides to the container. Returns a
@@ -53,6 +57,170 @@ func withResourceLimits(container *corev1.Container, resourceLimits corev1.Resou
 	}
 	container.Resources = resourceLimits
 	return nil
+}
+
+// parseAnnotationResourceOverrides parses per-pod resource override annotations
+// and returns the resulting ResourceRequirements. It returns nil if no resource
+// annotations are present. It returns an error if any annotation value is invalid
+// or if request > limit for any resource type.
+func parseAnnotationResourceOverrides(annotations map[string]string) (*corev1.ResourceRequirements, error) {
+	if annotations == nil {
+		return nil, nil
+	}
+
+	cpuReqStr, hasCPUReq := annotations[annotationSidecarCPURequest]
+	cpuLimStr, hasCPULim := annotations[annotationSidecarCPULimit]
+	memReqStr, hasMemReq := annotations[annotationSidecarMemoryRequest]
+	memLimStr, hasMemLim := annotations[annotationSidecarMemoryLimit]
+
+	// No resource annotations present
+	if !hasCPUReq && !hasCPULim && !hasMemReq && !hasMemLim {
+		return nil, nil
+	}
+
+	resources := &corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{},
+		Limits:   corev1.ResourceList{},
+	}
+
+	// Parse CPU annotations
+	if hasCPUReq || hasCPULim {
+		var cpuReq, cpuLim resource.Quantity
+		var err error
+
+		if hasCPUReq {
+			cpuReq, err = resource.ParseQuantity(cpuReqStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s annotation value %q: %s", annotationSidecarCPURequest, cpuReqStr, err)
+			}
+			if cpuReq.Cmp(resource.MustParse("0")) < 0 {
+				return nil, fmt.Errorf("negative %s annotation value %q", annotationSidecarCPURequest, cpuReqStr)
+			}
+		}
+		if hasCPULim {
+			cpuLim, err = resource.ParseQuantity(cpuLimStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s annotation value %q: %s", annotationSidecarCPULimit, cpuLimStr, err)
+			}
+			if cpuLim.Cmp(resource.MustParse("0")) < 0 {
+				return nil, fmt.Errorf("negative %s annotation value %q", annotationSidecarCPULimit, cpuLimStr)
+			}
+		}
+
+		// Fill missing side: limit-only → request=limit, request-only → limit=request
+		if hasCPULim && !hasCPUReq {
+			cpuReq = cpuLim
+		} else if hasCPUReq && !hasCPULim {
+			cpuLim = cpuReq
+		}
+
+		// Validate request <= limit
+		if cpuReq.Cmp(cpuLim) > 0 {
+			return nil, fmt.Errorf("CPU request (%s) exceeds limit (%s)", cpuReq.String(), cpuLim.String())
+		}
+
+		resources.Requests[corev1.ResourceCPU] = cpuReq
+		resources.Limits[corev1.ResourceCPU] = cpuLim
+	}
+
+	// Parse memory annotations
+	if hasMemReq || hasMemLim {
+		var memReq, memLim resource.Quantity
+		var err error
+
+		if hasMemReq {
+			memReq, err = resource.ParseQuantity(memReqStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s annotation value %q: %s", annotationSidecarMemoryRequest, memReqStr, err)
+			}
+			if memReq.Cmp(resource.MustParse("0")) < 0 {
+				return nil, fmt.Errorf("negative %s annotation value %q", annotationSidecarMemoryRequest, memReqStr)
+			}
+		}
+		if hasMemLim {
+			memLim, err = resource.ParseQuantity(memLimStr)
+			if err != nil {
+				return nil, fmt.Errorf("invalid %s annotation value %q: %s", annotationSidecarMemoryLimit, memLimStr, err)
+			}
+			if memLim.Cmp(resource.MustParse("0")) < 0 {
+				return nil, fmt.Errorf("negative %s annotation value %q", annotationSidecarMemoryLimit, memLimStr)
+			}
+		}
+
+		// Fill missing side: limit-only → request=limit, request-only → limit=request
+		if hasMemLim && !hasMemReq {
+			memReq = memLim
+		} else if hasMemReq && !hasMemLim {
+			memLim = memReq
+		}
+
+		// Validate request <= limit
+		if memReq.Cmp(memLim) > 0 {
+			return nil, fmt.Errorf("memory request (%s) exceeds limit (%s)", memReq.String(), memLim.String())
+		}
+
+		resources.Requests[corev1.ResourceMemory] = memReq
+		resources.Limits[corev1.ResourceMemory] = memLim
+	}
+
+	return resources, nil
+}
+
+// applyAnnotationResourceOverrides reads per-pod resource annotations and applies
+// them to the sidecar container. Returns true if the container was mutated.
+// If annotations are invalid, it logs a warning and returns false (no error),
+// allowing the caller to fall back to profile/default resources.
+func applyAnnotationResourceOverrides(pod *corev1.Pod, container *corev1.Container) (bool, error) {
+	if pod == nil {
+		return false, errors.New("can't apply annotation overrides to nil pod")
+	}
+	if container == nil {
+		return false, errors.New("can't apply annotation overrides to nil container")
+	}
+
+	resources, err := parseAnnotationResourceOverrides(pod.Annotations)
+	if err != nil {
+		log.Errorf("Invalid sidecar resource annotations on pod %s, ignoring annotations: %v", pod.Name, err)
+		return false, nil
+	}
+
+	if resources == nil {
+		return false, nil
+	}
+
+	// Deep-copy the existing resource maps before writing to avoid mutating
+	// shared profile state. withResourceLimits aliases container.Resources to
+	// the webhook-global profileOverrides maps, so in-place writes here would
+	// leak one pod's annotation overrides into subsequent pods and risk
+	// concurrent map writes.
+	newRequests := make(corev1.ResourceList)
+	for k, v := range container.Resources.Requests {
+		newRequests[k] = v
+	}
+	newLimits := make(corev1.ResourceList)
+	for k, v := range container.Resources.Limits {
+		newLimits[k] = v
+	}
+
+	// Merge annotation overrides into the copied maps.
+	// This allows overriding only CPU or only memory while keeping the other from profile/defaults.
+	if cpu, ok := resources.Requests[corev1.ResourceCPU]; ok {
+		newRequests[corev1.ResourceCPU] = cpu
+	}
+	if cpu, ok := resources.Limits[corev1.ResourceCPU]; ok {
+		newLimits[corev1.ResourceCPU] = cpu
+	}
+	if mem, ok := resources.Requests[corev1.ResourceMemory]; ok {
+		newRequests[corev1.ResourceMemory] = mem
+	}
+	if mem, ok := resources.Limits[corev1.ResourceMemory]; ok {
+		newLimits[corev1.ResourceMemory] = mem
+	}
+
+	container.Resources.Requests = newRequests
+	container.Resources.Limits = newLimits
+
+	return true, nil
 }
 
 // withSecurityContextOverrides applies the security context overrides to the container

--- a/pkg/clusteragent/admission/mutate/agent_sidecar/overrides_test.go
+++ b/pkg/clusteragent/admission/mutate/agent_sidecar/overrides_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
@@ -143,6 +144,361 @@ func TestWithResourceLimits(t *testing.T) {
 				assert.Equal(tt, test.containerAfterLimits, test.baseContainer)
 			}
 
+		})
+	}
+}
+
+func TestParseAnnotationResourceOverrides(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    *corev1.ResourceRequirements
+		expectError bool
+	}{
+		{
+			name:        "nil annotations",
+			annotations: nil,
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name:        "no resource annotations",
+			annotations: map[string]string{"some-other-annotation": "value"},
+			expected:    nil,
+			expectError: false,
+		},
+		{
+			name: "all four annotations set",
+			annotations: map[string]string{
+				annotationSidecarCPURequest:    "100m",
+				annotationSidecarCPULimit:      "500m",
+				annotationSidecarMemoryRequest: "256Mi",
+				annotationSidecarMemoryLimit:   "1Gi",
+			},
+			expected: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("256Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "memory limit only - request should equal limit",
+			annotations: map[string]string{
+				annotationSidecarMemoryLimit: "1Gi",
+			},
+			expected: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "cpu request only - limit should equal request",
+			annotations: map[string]string{
+				annotationSidecarCPURequest: "200m",
+			},
+			expected: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("200m"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU: resource.MustParse("200m"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "memory only - cpu untouched",
+			annotations: map[string]string{
+				annotationSidecarMemoryRequest: "512Mi",
+				annotationSidecarMemoryLimit:   "1Gi",
+			},
+			expected: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("512Mi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "cpu request exceeds limit - error",
+			annotations: map[string]string{
+				annotationSidecarCPURequest: "1",
+				annotationSidecarCPULimit:   "500m",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "memory request exceeds limit - error",
+			annotations: map[string]string{
+				annotationSidecarMemoryRequest: "2Gi",
+				annotationSidecarMemoryLimit:   "1Gi",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "invalid cpu value - error",
+			annotations: map[string]string{
+				annotationSidecarCPURequest: "abc",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "invalid memory value - error",
+			annotations: map[string]string{
+				annotationSidecarMemoryLimit: "not-a-quantity",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "negative cpu value - error",
+			annotations: map[string]string{annotationSidecarCPURequest: "-100m"},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name:        "negative memory value - error",
+			annotations: map[string]string{annotationSidecarMemoryLimit: "-256Mi"},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "request equals limit - valid",
+			annotations: map[string]string{
+				annotationSidecarCPURequest:    "500m",
+				annotationSidecarCPULimit:      "500m",
+				annotationSidecarMemoryRequest: "1Gi",
+				annotationSidecarMemoryLimit:   "1Gi",
+			},
+			expected: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("500m"),
+					corev1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			result, err := parseAnnotationResourceOverrides(test.annotations)
+
+			if test.expectError {
+				assert.Error(tt, err)
+				assert.Nil(tt, result)
+			} else {
+				assert.NoError(tt, err)
+				assert.Equal(tt, test.expected, result)
+			}
+		})
+	}
+}
+
+func TestApplyAnnotationResourceOverrides(t *testing.T) {
+	tests := []struct {
+		name                   string
+		pod                    *corev1.Pod
+		container              *corev1.Container
+		expectMutated          bool
+		expectError            bool
+		containerAfterOverride *corev1.Container
+	}{
+		{
+			name:        "nil pod",
+			pod:         nil,
+			container:   &corev1.Container{},
+			expectError: true,
+		},
+		{
+			name: "nil container",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			container:   nil,
+			expectError: true,
+		},
+		{
+			name: "no annotations - no mutation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectMutated: false,
+			expectError:   false,
+			containerAfterOverride: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "memory annotation overrides memory, cpu unchanged",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						annotationSidecarMemoryLimit: "1Gi",
+					},
+				},
+			},
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectMutated: true,
+			expectError:   false,
+			containerAfterOverride: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+		{
+			name: "invalid annotation - no mutation, no error (graceful fallback)",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						annotationSidecarMemoryRequest: "2Gi",
+						annotationSidecarMemoryLimit:   "1Gi",
+					},
+				},
+			},
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectMutated: false,
+			expectError:   false,
+			containerAfterOverride: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+		},
+		{
+			name: "all four annotations override everything",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+					Annotations: map[string]string{
+						annotationSidecarCPURequest:    "100m",
+						annotationSidecarCPULimit:      "1",
+						annotationSidecarMemoryRequest: "512Mi",
+						annotationSidecarMemoryLimit:   "2Gi",
+					},
+				},
+			},
+			container: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("200m"),
+						corev1.ResourceMemory: resource.MustParse("256Mi"),
+					},
+				},
+			},
+			expectMutated: true,
+			expectError:   false,
+			containerAfterOverride: &corev1.Container{
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(tt *testing.T) {
+			mutated, err := applyAnnotationResourceOverrides(test.pod, test.container)
+
+			if test.expectError {
+				assert.Error(tt, err)
+			} else {
+				assert.NoError(tt, err)
+				assert.Equal(tt, test.expectMutated, mutated)
+				assert.Equal(tt, test.containerAfterOverride, test.container)
+			}
 		})
 	}
 }

--- a/releasenotes/notes/admission-sidecar-annotation-resource-override-7cc6860270f7ee99.yaml
+++ b/releasenotes/notes/admission-sidecar-annotation-resource-override-7cc6860270f7ee99.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The admission controller's agent sidecar injection now supports per-pod
+    resource overrides via annotations: ``agent.datadoghq.com/sidecar.cpu.request``,
+    ``agent.datadoghq.com/sidecar.cpu.limit``,
+    ``agent.datadoghq.com/sidecar.memory.request``, and
+    ``agent.datadoghq.com/sidecar.memory.limit``.
+    These take priority over global profile defaults. Invalid or conflicting
+    values fall back to profile or hardcoded defaults with a warning log.


### PR DESCRIPTION
### What does this PR do?

Adds per-pod annotation-based resource overrides for the agent sidecar injection webhook. Users can now set resource requests/limits on individual pods via annotations:

- agent.datadoghq.com/sidecar.cpu.request: "200m"
- agent.datadoghq.com/sidecar.cpu.limit: "500m"
- agent.datadoghq.com/sidecar.memory.request: "256Mi"
- agent.datadoghq.com/sidecar.memory.limit: "1Gi"

Override priority (highest to lowest):
1. Pod annotations (per-pod)
2. Profile (global, via Operator)
3. Hardcoded defaults (256Mi / 200m)

Guard logic:
- Limit-only → request = limit
- Request-only → limit = request
- Request > limit → all annotations ignored + warning log + fallback to profile/defaults
- Invalid value (e.g. "abc") → all annotations ignored + warning log + fallback
- Partial override (e.g. memory-only) → only specified resource type is overridden, the other stays from profile/defaults

### Motivation

Current sidecar injection supports only a single global profile, so all sidecars share the same resources.

### Describe how you validated your changes

- Unit tests: 16 cases (parse + apply)
- Integration tests: 4 cases covering annotation > profile > default fallback flow
- go build, go vet clean

### Additional Notes
