### PR TITLE
dyninst: evaluate template expressions before snapshot vars

### DIFF
--- a/pkg/dyninst/decode/decoder_test.go
+++ b/pkg/dyninst/decode/decoder_test.go
@@ -270,10 +270,10 @@ func simpleStringArgEvent(t testing.TB, irProg *ir.Program) []byte {
 		(*byte)(unsafe.Pointer(&dataItem0)), unsafe.Sizeof(dataItem0))...,
 	)
 	item = append(item, 5) // bitset: bit 0 (expr 0 present) and bit 2 (expr 1 present)
-	// First expression (argument) at offset 1
+	// First expression (template_segment) at offset 1
 	item = binary.NativeEndian.AppendUint64(item, 0xdeadbeef)
 	item = binary.NativeEndian.AppendUint64(item, 16)
-	// Second expression (template_segment) at offset 17
+	// Second expression (argument) at offset 17
 	item = binary.NativeEndian.AppendUint64(item, 0xdeadbeef)
 	item = binary.NativeEndian.AppendUint64(item, 16)
 	item = append(item, 0, 0, 0, 0, 0, 0, 0) // padding
@@ -314,7 +314,7 @@ func simpleMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	)
 
 	require.NotNil(t, eventType)
-	// Expect two expressions: argument and template_segment
+	// Expect two expressions: template_segment and argument
 	require.GreaterOrEqual(t, len(eventType.Expressions), 2)
 	paramType := eventType.Expressions[0].Expression.Type
 	var ok bool
@@ -361,14 +361,14 @@ func simpleMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 
 	// Build root data item (presence bitset + pointers to header)
 	rootData := make([]byte, rootLen)
-	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
+	// Set presence bits for both expressions (bit 0 for template_segment, bit 1 for argument)
 	if eventType.PresenceBitsetSize > 0 {
 		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
-	// First expression (argument) at offset 1
+	// First expression (template_segment) at offset 1
 	ptrOff := int(eventType.Expressions[0].Offset)
 	binary.NativeEndian.PutUint64(rootData[ptrOff:ptrOff+8], headerAddr)
-	// Second expression (template_segment) at offset 9
+	// Second expression (argument) at offset 9
 	templatePtrOff := int(eventType.Expressions[1].Offset)
 	binary.NativeEndian.PutUint64(rootData[templatePtrOff:templatePtrOff+8], headerAddr)
 
@@ -1007,14 +1007,14 @@ func simpleBigMapArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	)
 
 	rootData := make([]byte, rootLen)
-	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
+	// Set presence bits for both expressions (bit 0 for template_segment, bit 1 for argument)
 	if eventType.PresenceBitsetSize > 0 {
 		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
-	// First expression (argument) at offset 1
+	// First expression (template_segment) at offset 1
 	ptrOff := int(eventType.Expressions[0].Offset)
 	binary.NativeEndian.PutUint64(rootData[ptrOff:ptrOff+8], headerAddr)
-	// Second expression (template_segment) at offset 9
+	// Second expression (argument) at offset 9
 	templatePtrOff := int(eventType.Expressions[1].Offset)
 	binary.NativeEndian.PutUint64(rootData[templatePtrOff:templatePtrOff+8], headerAddr)
 
@@ -1129,7 +1129,7 @@ func simplePointerChainArgEvent(t testing.TB, irProg *ir.Program) []byte {
 	eventType := events[0].Type
 	rootLen := int(eventType.GetByteSize())
 	rootData := make([]byte, rootLen)
-	// Set presence bits for both expressions (bit 0 for argument, bit 1 for template_segment)
+	// Set presence bits for both expressions (bit 0 for template_segment, bit 1 for argument)
 	if eventType.PresenceBitsetSize > 0 {
 		rootData[0] = 5 // presence bits: bit 0 (expr 0) and bit 2 (expr 1)
 	}
@@ -1155,10 +1155,10 @@ func simplePointerChainArgEvent(t testing.TB, irProg *ir.Program) []byte {
 		addr4 = uint64(0xa0000004)
 		addr5 = uint64(0xa0000005)
 	)
-	// First expression (argument) at offset 1: address of first pointer
+	// First expression (template_segment) at offset 1: address of first pointer
 	off := int(eventType.Expressions[0].Offset)
 	binary.NativeEndian.PutUint64(rootData[off:off+8], addr1)
-	// Second expression (template_segment) at offset 9: same address
+	// Second expression (argument) at offset 9: same address
 	templateOff := int(eventType.Expressions[1].Offset)
 	binary.NativeEndian.PutUint64(rootData[templateOff:templateOff+8], addr1)
 
@@ -1556,13 +1556,13 @@ func TestDecoderNilPointerCaptureExpression(t *testing.T) {
 	require.NoError(t, err)
 	input := simpleStringArgEvent(t, irProg)
 
-	// Flip bitset so expression 0 (the argument capture) has nil-deref
+	// Flip bitset so expression 1 (the argument capture) has nil-deref
 	// instead of present. Original bitset = 0b00000101 (bit 0 and bit 2 set).
-	// We want: expr 0 not-present + nil-deref (bit 0=0, bit 1=1),
-	//          expr 1 present (bit 2=1).
-	// Result: 0b00000110 = 6
+	// We want: expr 0 present (bit 0=1),
+	//          expr 1 not-present + nil-deref (bit 2=0, bit 3=1).
+	// Result: 0b00001001 = 9
 	bitsetOffset := int(unsafe.Sizeof(output.EventHeader{}) + unsafe.Sizeof(output.DataItemHeader{}))
-	input[bitsetOffset] = 6
+	input[bitsetOffset] = 9
 
 	buf, probe, err := decoder.Decode(Event{
 		EntryOrLine: output.Event(input),
@@ -1597,13 +1597,13 @@ func TestDecoderNilPointerTemplateExpression(t *testing.T) {
 	require.NoError(t, err)
 	input := simpleStringArgEvent(t, irProg)
 
-	// Flip bitset so expression 1 (the template segment) has nil-deref.
+	// Flip bitset so expression 0 (the template segment) has nil-deref.
 	// Original bitset = 0b00000101 (bit 0 and bit 2 set).
-	// We want: expr 0 present (bit 0=1),
-	//          expr 1 not-present + nil-deref (bit 2=0, bit 3=1).
-	// Result: 0b00001001 = 9
+	// We want: expr 0 not-present + nil-deref (bit 0=0, bit 1=1),
+	//          expr 1 present (bit 2=1).
+	// Result: 0b00000110 = 6
 	bitsetOffset := int(unsafe.Sizeof(output.EventHeader{}) + unsafe.Sizeof(output.DataItemHeader{}))
-	input[bitsetOffset] = 9
+	input[bitsetOffset] = 6
 
 	buf, probe, err := decoder.Decode(Event{
 		EntryOrLine: output.Event(input),

--- a/pkg/dyninst/irgen/irgen.go
+++ b/pkg/dyninst/irgen/irgen.go
@@ -884,6 +884,19 @@ func analyzeAllProbes(
 			}
 		}
 
+		// Put the template segments first, so we explore their values earlier
+		// than snapshot values. If we're going to run out of space, we may as
+		// well do it for data that shows up below the fold rather than in the
+		// message.
+		exprKindToInt := func(kind ir.RootExpressionKind) int {
+			if kind == ir.RootExpressionKindTemplateSegment {
+				return 0
+			}
+			return 1
+		}
+		slices.SortStableFunc(ap.expressions, func(a, b analyzedExpression) int {
+			return cmp.Compare(exprKindToInt(a.exprKind), exprKindToInt(b.exprKind))
+		})
 		analyzed = append(analyzed, ap)
 	}
 

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.23.11.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11218,7 +11218,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -11228,7 +11228,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -11260,7 +11260,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11270,7 +11270,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11302,7 +11302,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -11312,7 +11312,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -11344,7 +11344,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]struct {}
             Operations:
@@ -11354,7 +11354,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]struct {}
             Operations:
@@ -11370,7 +11370,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -11380,7 +11380,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -11396,7 +11396,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -11406,7 +11406,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -11422,7 +11422,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 186 ArrayType [2]map[string]int
             Operations:
@@ -11432,7 +11432,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 186 ArrayType [2]map[string]int
             Operations:
@@ -11448,7 +11448,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -11458,7 +11458,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -11474,7 +11474,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]main.nestedStruct
             Operations:
@@ -11484,7 +11484,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]main.nestedStruct
             Operations:
@@ -11500,7 +11500,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -11510,7 +11510,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -11542,7 +11542,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -11552,7 +11552,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -11571,7 +11571,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -11581,7 +11581,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -11597,7 +11597,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -11607,7 +11607,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -11623,7 +11623,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 238 GoChannelType chan bool
             Operations:
@@ -11633,7 +11633,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 238 GoChannelType chan bool
             Operations:
@@ -11649,16 +11649,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -11668,8 +11658,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -11677,9 +11667,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -11757,7 +11757,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 243 PointerType *main.t
             Operations:
@@ -11767,7 +11767,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 243 PointerType *main.t
             Operations:
@@ -11783,7 +11783,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 136 StructureType main.deepMap1
             Operations:
@@ -11793,7 +11793,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 136 StructureType main.deepMap1
             Operations:
@@ -11809,7 +11809,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 144 PointerType *main.deepMap7
             Operations:
@@ -11819,7 +11819,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 144 PointerType *main.deepMap7
             Operations:
@@ -11835,7 +11835,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 StructureType main.deepPtr1
             Operations:
@@ -11845,7 +11845,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 StructureType main.deepPtr1
             Operations:
@@ -11861,7 +11861,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 PointerType *main.deepPtr7
             Operations:
@@ -11871,7 +11871,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 PointerType *main.deepPtr7
             Operations:
@@ -11887,7 +11887,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 StructureType main.deepSlice1
             Operations:
@@ -11897,7 +11897,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 StructureType main.deepSlice1
             Operations:
@@ -11913,7 +11913,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 134 PointerType *main.deepSlice7
             Operations:
@@ -11923,7 +11923,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 134 PointerType *main.deepSlice7
             Operations:
@@ -11939,16 +11939,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -11958,8 +11948,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11967,9 +11957,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -11985,7 +11985,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -11995,7 +11995,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -12011,7 +12011,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -12021,7 +12021,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -12037,7 +12037,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -12047,7 +12047,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -12063,7 +12063,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 315 StructureType main.emptyStruct
             Operations:
@@ -12073,7 +12073,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 315 StructureType main.emptyStruct
             Operations:
@@ -12087,8 +12087,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12098,7 +12118,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12107,29 +12127,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12145,7 +12145,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12155,7 +12155,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12171,7 +12171,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -12181,7 +12181,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -12200,7 +12200,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -12210,7 +12210,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -12229,7 +12229,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12239,7 +12239,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12255,7 +12255,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12265,7 +12265,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12307,7 +12307,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12317,7 +12317,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12349,7 +12349,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12359,7 +12359,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12378,7 +12378,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12388,7 +12388,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12410,16 +12410,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12429,8 +12419,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12438,9 +12428,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12477,7 +12477,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12487,7 +12487,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12561,7 +12561,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12571,7 +12571,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12590,7 +12590,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12600,7 +12600,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12616,7 +12616,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12626,7 +12626,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12642,7 +12642,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12652,7 +12652,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12668,7 +12668,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -12678,7 +12678,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -12694,7 +12694,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -12704,7 +12704,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -12720,7 +12720,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -12730,7 +12730,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -12746,7 +12746,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -12756,7 +12756,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -12772,7 +12772,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -12782,7 +12782,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -12798,7 +12798,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoInterfaceType main.behavior
             Operations:
@@ -12808,7 +12808,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoInterfaceType main.behavior
             Operations:
@@ -12824,7 +12824,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -12834,7 +12834,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -12866,7 +12866,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -12876,7 +12876,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -12947,7 +12947,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12955,148 +12955,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13106,8 +13026,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13115,9 +13035,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13149,7 +13149,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
@@ -13159,7 +13159,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
@@ -13175,7 +13175,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13185,7 +13185,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13201,7 +13201,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
@@ -13211,7 +13211,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
@@ -13227,7 +13227,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 223 GoMapType map[struct {}]int
             Operations:
@@ -13237,7 +13237,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 223 GoMapType map[struct {}]int
             Operations:
@@ -13253,7 +13253,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 228 GoMapType map[int]struct {}
             Operations:
@@ -13263,7 +13263,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 228 GoMapType map[int]struct {}
             Operations:
@@ -13279,7 +13279,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 GoMapType map[int]int
             Operations:
@@ -13289,7 +13289,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 GoMapType map[int]int
             Operations:
@@ -13305,7 +13305,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
@@ -13315,7 +13315,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
@@ -13331,7 +13331,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
@@ -13341,7 +13341,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
@@ -13357,7 +13357,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13367,7 +13367,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13383,7 +13383,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13393,7 +13393,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13409,7 +13409,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
@@ -13419,7 +13419,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
@@ -13435,7 +13435,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13445,7 +13445,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13461,7 +13461,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -13471,7 +13471,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -13487,7 +13487,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string][]string
             Operations:
@@ -13497,7 +13497,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string][]string
             Operations:
@@ -13513,7 +13513,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 166 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13523,7 +13523,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 166 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13539,7 +13539,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[bool]main.node
             Operations:
@@ -13549,7 +13549,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[bool]main.node
             Operations:
@@ -13565,7 +13565,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13575,7 +13575,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13591,7 +13591,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13601,7 +13601,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13617,7 +13617,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13627,7 +13627,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13643,7 +13643,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13653,7 +13653,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13669,7 +13669,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13679,7 +13679,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13695,7 +13695,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13705,7 +13705,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13721,7 +13721,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13729,148 +13729,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13880,8 +13800,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13889,9 +13809,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13923,16 +13923,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 106 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 106 ArrayType [2]int
@@ -13942,8 +13932,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -13951,9 +13941,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -13995,16 +13995,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 245 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
@@ -14014,8 +14004,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -14023,9 +14013,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -14057,7 +14057,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14067,7 +14067,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14083,7 +14083,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14113,7 +14113,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14203,7 +14203,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14221,9 +14221,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14232,28 +14252,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14347,7 +14347,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14355,48 +14355,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -14406,17 +14376,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 15 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 15 BaseType uint
@@ -14426,8 +14386,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14435,9 +14395,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 15 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14453,7 +14453,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14463,7 +14463,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14479,7 +14479,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14489,7 +14489,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14521,7 +14521,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14531,7 +14531,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14547,7 +14547,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 312 PointerType *main.anotherStruct
             Operations:
@@ -14557,7 +14557,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 312 PointerType *main.anotherStruct
             Operations:
@@ -14620,16 +14620,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 5 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 5 PointerType *bool
@@ -14639,8 +14629,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -14648,9 +14638,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 5 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -14666,16 +14666,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -14685,8 +14675,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14694,9 +14684,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14712,16 +14712,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 14 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 14 BaseType int8
@@ -14731,17 +14721,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 259 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14751,8 +14731,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -14760,9 +14740,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 14 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 259 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -14778,7 +14778,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
@@ -14788,7 +14788,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
@@ -14804,7 +14804,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
@@ -14814,7 +14814,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
@@ -14830,7 +14830,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 242 PointerType *main.node
             Operations:
@@ -14840,7 +14840,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.node
             Operations:
@@ -14856,7 +14856,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 187 PointerType *map[string]int
             Operations:
@@ -14866,7 +14866,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 187 PointerType *map[string]int
             Operations:
@@ -14882,7 +14882,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
@@ -14892,7 +14892,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
@@ -14908,16 +14908,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
@@ -14927,8 +14917,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14936,9 +14926,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14980,7 +14980,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -14990,7 +14990,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15236,7 +15236,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15246,7 +15246,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15278,7 +15278,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15288,7 +15288,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15330,7 +15330,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15340,7 +15340,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15372,7 +15372,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15382,7 +15382,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15414,7 +15414,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15424,7 +15424,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15907,7 +15907,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -15917,7 +15917,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -15933,7 +15933,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15943,7 +15943,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15959,7 +15959,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -15969,7 +15969,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -15991,7 +15991,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 97 BaseType int16
             Operations:
@@ -16001,7 +16001,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 97 BaseType int16
             Operations:
@@ -16017,7 +16017,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16027,7 +16027,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16043,7 +16043,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16053,7 +16053,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16069,7 +16069,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 BaseType int8
             Operations:
@@ -16099,7 +16099,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 BaseType int8
             Operations:
@@ -16115,7 +16115,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16125,7 +16125,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16141,7 +16141,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16151,7 +16151,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16167,7 +16167,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -16177,7 +16177,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -16193,7 +16193,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -16203,7 +16203,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -16219,7 +16219,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16229,7 +16229,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16245,7 +16245,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -16255,7 +16255,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -16271,7 +16271,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16281,7 +16281,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16297,7 +16297,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -16307,7 +16307,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 BaseType uint
             Operations:
@@ -16323,7 +16323,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
@@ -16333,7 +16333,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
@@ -16349,7 +16349,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
@@ -16359,7 +16359,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
@@ -16375,7 +16375,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -16385,7 +16385,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -16401,7 +16401,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16411,7 +16411,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16463,7 +16463,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -16473,7 +16473,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -16525,7 +16525,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -16535,7 +16535,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -16551,7 +16551,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -16561,7 +16561,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -16577,7 +16577,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []string
             Operations:
@@ -16587,7 +16587,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 258 GoSliceHeaderType []string
             Operations:
@@ -16603,7 +16603,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 146 PointerType *main.stringType1
             Operations:
@@ -16613,7 +16613,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 146 PointerType *main.stringType1
             Operations:
@@ -16629,7 +16629,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 148 PointerType **main.stringType2
             Operations:
@@ -16639,7 +16639,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 148 PointerType **main.stringType2
             Operations:
@@ -16655,16 +16655,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -16674,8 +16664,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16683,9 +16673,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16701,7 +16701,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 StructureType main.structWithAny
             Operations:
@@ -16711,7 +16711,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 StructureType main.structWithAny
             Operations:
@@ -16727,7 +16727,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -16737,7 +16737,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -16779,7 +16779,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -16789,7 +16789,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -16808,7 +16808,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
@@ -16818,7 +16818,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
@@ -16834,7 +16834,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 160 StructureType main.structWithMap
             Operations:
@@ -16844,7 +16844,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 160 StructureType main.structWithMap
             Operations:
@@ -16876,7 +16876,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -16886,7 +16886,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -16908,16 +16908,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16927,17 +16917,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -16947,8 +16927,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -16956,9 +16936,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -16974,16 +16974,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -16993,17 +16983,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17013,8 +16993,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17022,9 +17002,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17056,7 +17056,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
@@ -17066,7 +17066,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
@@ -17127,7 +17127,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -17137,7 +17137,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -17195,16 +17195,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17214,17 +17204,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17234,8 +17214,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17243,9 +17223,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17261,7 +17261,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 BaseType main.typeAlias
             Operations:
@@ -17271,7 +17271,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 BaseType main.typeAlias
             Operations:
@@ -17287,7 +17287,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -17297,7 +17297,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -17313,7 +17313,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -17323,7 +17323,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -17339,7 +17339,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -17349,7 +17349,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -17365,7 +17365,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -17375,7 +17375,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -17391,7 +17391,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -17401,7 +17401,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -17417,7 +17417,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -17427,7 +17427,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -17443,7 +17443,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17453,7 +17453,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17469,7 +17469,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17479,7 +17479,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17495,7 +17495,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -17505,7 +17505,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -17521,7 +17521,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [100]uint
             Operations:
@@ -17531,7 +17531,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [100]uint
             Operations:
@@ -17547,7 +17547,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17557,7 +17557,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17573,7 +17573,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17583,7 +17583,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17599,16 +17599,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 248 ArrayType [0]int
@@ -17619,7 +17609,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -17627,9 +17617,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.24.3.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11523,7 +11523,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -11533,7 +11533,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -11565,7 +11565,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -11575,7 +11575,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -11607,7 +11607,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -11617,7 +11617,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -11649,7 +11649,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]struct {}
             Operations:
@@ -11659,7 +11659,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]struct {}
             Operations:
@@ -11675,7 +11675,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -11685,7 +11685,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -11701,7 +11701,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -11711,7 +11711,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -11727,7 +11727,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 189 ArrayType [2]map[string]int
             Operations:
@@ -11737,7 +11737,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 189 ArrayType [2]map[string]int
             Operations:
@@ -11753,7 +11753,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -11763,7 +11763,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -11779,7 +11779,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2]main.nestedStruct
             Operations:
@@ -11789,7 +11789,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2]main.nestedStruct
             Operations:
@@ -11805,7 +11805,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11815,7 +11815,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11847,7 +11847,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -11857,7 +11857,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -11876,7 +11876,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -11886,7 +11886,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -11902,7 +11902,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -11912,7 +11912,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -11928,7 +11928,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 241 GoChannelType chan bool
             Operations:
@@ -11938,7 +11938,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 241 GoChannelType chan bool
             Operations:
@@ -11954,16 +11954,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -11973,8 +11963,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -11982,9 +11972,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12062,7 +12062,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 PointerType *main.t
             Operations:
@@ -12072,7 +12072,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 PointerType *main.t
             Operations:
@@ -12088,7 +12088,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 StructureType main.deepMap1
             Operations:
@@ -12098,7 +12098,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 StructureType main.deepMap1
             Operations:
@@ -12114,7 +12114,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 147 PointerType *main.deepMap7
             Operations:
@@ -12124,7 +12124,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.deepMap7
             Operations:
@@ -12140,7 +12140,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 StructureType main.deepPtr1
             Operations:
@@ -12150,7 +12150,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 StructureType main.deepPtr1
             Operations:
@@ -12166,7 +12166,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 133 PointerType *main.deepPtr7
             Operations:
@@ -12176,7 +12176,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 133 PointerType *main.deepPtr7
             Operations:
@@ -12192,7 +12192,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 135 StructureType main.deepSlice1
             Operations:
@@ -12202,7 +12202,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 135 StructureType main.deepSlice1
             Operations:
@@ -12218,7 +12218,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 139 PointerType *main.deepSlice7
             Operations:
@@ -12228,7 +12228,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 139 PointerType *main.deepSlice7
             Operations:
@@ -12244,16 +12244,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -12263,8 +12253,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12272,9 +12262,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12290,7 +12290,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -12300,7 +12300,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -12316,7 +12316,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12326,7 +12326,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12342,7 +12342,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 319 PointerType *main.emptyStruct
             Operations:
@@ -12352,7 +12352,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 319 PointerType *main.emptyStruct
             Operations:
@@ -12368,7 +12368,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 318 StructureType main.emptyStruct
             Operations:
@@ -12378,7 +12378,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 318 StructureType main.emptyStruct
             Operations:
@@ -12392,8 +12392,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12403,7 +12423,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12412,29 +12432,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12450,7 +12450,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12460,7 +12460,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12476,7 +12476,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -12486,7 +12486,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -12505,7 +12505,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -12515,7 +12515,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -12534,7 +12534,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12544,7 +12544,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12560,7 +12560,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12570,7 +12570,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12612,7 +12612,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12622,7 +12622,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12654,7 +12654,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12664,7 +12664,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12683,7 +12683,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12693,7 +12693,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12715,16 +12715,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12734,8 +12724,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12743,9 +12733,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12782,7 +12782,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12792,7 +12792,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12866,7 +12866,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12876,7 +12876,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12895,7 +12895,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12905,7 +12905,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12921,7 +12921,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12931,7 +12931,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12947,7 +12947,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12957,7 +12957,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12973,7 +12973,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -12983,7 +12983,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -12999,7 +12999,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -13009,7 +13009,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -13025,7 +13025,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -13035,7 +13035,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -13051,7 +13051,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -13061,7 +13061,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -13077,7 +13077,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -13087,7 +13087,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -13103,7 +13103,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 160 GoInterfaceType main.behavior
             Operations:
@@ -13113,7 +13113,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 160 GoInterfaceType main.behavior
             Operations:
@@ -13129,7 +13129,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -13139,7 +13139,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -13171,7 +13171,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -13181,7 +13181,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -13252,7 +13252,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13260,148 +13260,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13411,8 +13331,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13420,9 +13340,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13454,7 +13454,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
@@ -13464,7 +13464,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
@@ -13480,7 +13480,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13490,7 +13490,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13506,7 +13506,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
@@ -13516,7 +13516,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
@@ -13532,7 +13532,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 226 GoMapType map[struct {}]int
             Operations:
@@ -13542,7 +13542,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 226 GoMapType map[struct {}]int
             Operations:
@@ -13558,7 +13558,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 231 GoMapType map[int]struct {}
             Operations:
@@ -13568,7 +13568,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 231 GoMapType map[int]struct {}
             Operations:
@@ -13584,7 +13584,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 164 GoMapType map[int]int
             Operations:
@@ -13594,7 +13594,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 164 GoMapType map[int]int
             Operations:
@@ -13610,7 +13610,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
@@ -13620,7 +13620,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
@@ -13636,7 +13636,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
@@ -13646,7 +13646,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
@@ -13662,7 +13662,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13672,7 +13672,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13688,7 +13688,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13698,7 +13698,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13714,7 +13714,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
@@ -13724,7 +13724,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
@@ -13740,7 +13740,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13750,7 +13750,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13766,7 +13766,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -13776,7 +13776,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -13792,7 +13792,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 179 GoMapType map[string][]string
             Operations:
@@ -13802,7 +13802,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 179 GoMapType map[string][]string
             Operations:
@@ -13818,7 +13818,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 169 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13828,7 +13828,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 169 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13844,7 +13844,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 196 GoMapType map[bool]main.node
             Operations:
@@ -13854,7 +13854,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 196 GoMapType map[bool]main.node
             Operations:
@@ -13870,7 +13870,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13880,7 +13880,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13896,7 +13896,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13906,7 +13906,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13922,7 +13922,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -13932,7 +13932,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -13948,7 +13948,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -13958,7 +13958,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -13974,7 +13974,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -13984,7 +13984,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14000,7 +14000,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14010,7 +14010,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14026,7 +14026,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14034,148 +14034,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14185,8 +14105,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14194,9 +14114,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14228,16 +14228,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 111 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]int
@@ -14247,8 +14237,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -14256,9 +14246,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -14300,16 +14300,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 248 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
@@ -14319,8 +14309,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -14328,9 +14318,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -14362,7 +14362,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14372,7 +14372,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14388,7 +14388,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14418,7 +14418,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14508,7 +14508,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14526,9 +14526,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14537,28 +14557,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14652,7 +14652,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14660,48 +14660,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 10 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14711,17 +14681,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 16 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 16 BaseType uint
@@ -14731,8 +14691,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14740,9 +14700,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 16 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14758,7 +14758,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14768,7 +14768,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14784,7 +14784,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14794,7 +14794,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14826,7 +14826,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14836,7 +14836,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14852,7 +14852,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 315 PointerType *main.anotherStruct
             Operations:
@@ -14862,7 +14862,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 315 PointerType *main.anotherStruct
             Operations:
@@ -14925,16 +14925,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 PointerType *bool
@@ -14944,8 +14934,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -14953,9 +14943,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -14971,16 +14971,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -14990,8 +14980,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14999,9 +14989,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15017,16 +15017,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 15 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 15 BaseType int8
@@ -15036,17 +15026,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 262 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15056,8 +15036,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -15065,9 +15045,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 262 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -15083,7 +15083,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
@@ -15093,7 +15093,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
@@ -15109,7 +15109,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
@@ -15119,7 +15119,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
@@ -15135,7 +15135,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 245 PointerType *main.node
             Operations:
@@ -15145,7 +15145,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 PointerType *main.node
             Operations:
@@ -15161,7 +15161,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 190 PointerType *map[string]int
             Operations:
@@ -15171,7 +15171,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 190 PointerType *map[string]int
             Operations:
@@ -15187,7 +15187,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
@@ -15197,7 +15197,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
@@ -15213,16 +15213,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
@@ -15232,8 +15222,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15241,9 +15231,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15285,7 +15285,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15295,7 +15295,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15541,7 +15541,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15551,7 +15551,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15583,7 +15583,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15593,7 +15593,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15635,7 +15635,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15645,7 +15645,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15677,7 +15677,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15687,7 +15687,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15719,7 +15719,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15729,7 +15729,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -16212,7 +16212,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -16222,7 +16222,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -16238,7 +16238,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16248,7 +16248,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16264,7 +16264,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16274,7 +16274,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16296,7 +16296,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 BaseType int16
             Operations:
@@ -16306,7 +16306,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 BaseType int16
             Operations:
@@ -16322,7 +16322,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16332,7 +16332,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16348,7 +16348,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16358,7 +16358,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16374,7 +16374,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -16404,7 +16404,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -16420,7 +16420,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16430,7 +16430,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16446,7 +16446,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16456,7 +16456,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16472,7 +16472,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16482,7 +16482,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16498,7 +16498,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16508,7 +16508,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16524,7 +16524,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16534,7 +16534,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16550,7 +16550,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16560,7 +16560,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16576,7 +16576,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16586,7 +16586,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16602,7 +16602,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -16612,7 +16612,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 BaseType uint
             Operations:
@@ -16628,7 +16628,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
@@ -16638,7 +16638,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
@@ -16654,7 +16654,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
@@ -16664,7 +16664,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
@@ -16680,7 +16680,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -16690,7 +16690,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -16706,7 +16706,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16716,7 +16716,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16768,7 +16768,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -16778,7 +16778,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -16830,7 +16830,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -16840,7 +16840,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -16856,7 +16856,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -16866,7 +16866,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -16882,7 +16882,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 261 GoSliceHeaderType []string
             Operations:
@@ -16892,7 +16892,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 261 GoSliceHeaderType []string
             Operations:
@@ -16908,7 +16908,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 PointerType *main.stringType1
             Operations:
@@ -16918,7 +16918,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 PointerType *main.stringType1
             Operations:
@@ -16934,7 +16934,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 151 PointerType **main.stringType2
             Operations:
@@ -16944,7 +16944,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 151 PointerType **main.stringType2
             Operations:
@@ -16960,16 +16960,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -16979,8 +16969,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16988,9 +16978,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17006,7 +17006,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 162 StructureType main.structWithAny
             Operations:
@@ -17016,7 +17016,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 162 StructureType main.structWithAny
             Operations:
@@ -17032,7 +17032,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -17042,7 +17042,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -17084,7 +17084,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -17094,7 +17094,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -17113,7 +17113,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
@@ -17123,7 +17123,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
@@ -17139,7 +17139,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 StructureType main.structWithMap
             Operations:
@@ -17149,7 +17149,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 StructureType main.structWithMap
             Operations:
@@ -17181,7 +17181,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -17191,7 +17191,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -17213,16 +17213,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17232,17 +17222,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17252,8 +17232,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17261,9 +17241,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17279,16 +17279,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17298,17 +17288,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17318,8 +17298,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17327,9 +17307,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17361,7 +17361,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
@@ -17371,7 +17371,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
@@ -17432,7 +17432,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -17442,7 +17442,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -17500,16 +17500,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17519,17 +17509,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17539,8 +17519,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17548,9 +17528,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17566,7 +17566,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 BaseType main.typeAlias
             Operations:
@@ -17576,7 +17576,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 BaseType main.typeAlias
             Operations:
@@ -17592,7 +17592,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -17602,7 +17602,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -17618,7 +17618,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -17628,7 +17628,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -17644,7 +17644,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17654,7 +17654,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17670,7 +17670,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -17680,7 +17680,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -17696,7 +17696,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -17706,7 +17706,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -17722,7 +17722,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -17732,7 +17732,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -17748,7 +17748,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17758,7 +17758,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17774,7 +17774,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17784,7 +17784,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17800,7 +17800,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -17810,7 +17810,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -17826,7 +17826,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [100]uint
             Operations:
@@ -17836,7 +17836,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [100]uint
             Operations:
@@ -17852,7 +17852,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17862,7 +17862,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17878,7 +17878,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17888,7 +17888,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17904,16 +17904,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 251 ArrayType [0]int
@@ -17924,7 +17914,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17932,9 +17922,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.25.0.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11580,7 +11580,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -11590,7 +11590,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -11622,7 +11622,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -11632,7 +11632,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -11664,7 +11664,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11674,7 +11674,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11706,7 +11706,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [2]struct {}
             Operations:
@@ -11716,7 +11716,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [2]struct {}
             Operations:
@@ -11732,7 +11732,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -11742,7 +11742,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -11758,7 +11758,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -11768,7 +11768,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -11784,7 +11784,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 ArrayType [2]map[string]int
             Operations:
@@ -11794,7 +11794,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 ArrayType [2]map[string]int
             Operations:
@@ -11810,7 +11810,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -11820,7 +11820,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -11836,7 +11836,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]main.nestedStruct
             Operations:
@@ -11846,7 +11846,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]main.nestedStruct
             Operations:
@@ -11862,7 +11862,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11872,7 +11872,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11904,7 +11904,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -11914,7 +11914,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -11933,7 +11933,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -11943,7 +11943,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -11959,7 +11959,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -11969,7 +11969,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -11985,7 +11985,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 243 GoChannelType chan bool
             Operations:
@@ -11995,7 +11995,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 243 GoChannelType chan bool
             Operations:
@@ -12011,16 +12011,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -12030,8 +12020,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12039,9 +12029,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12119,7 +12119,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 248 PointerType *main.t
             Operations:
@@ -12129,7 +12129,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 PointerType *main.t
             Operations:
@@ -12145,7 +12145,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 143 StructureType main.deepMap1
             Operations:
@@ -12155,7 +12155,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 143 StructureType main.deepMap1
             Operations:
@@ -12171,7 +12171,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 PointerType *main.deepMap7
             Operations:
@@ -12181,7 +12181,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 PointerType *main.deepMap7
             Operations:
@@ -12197,7 +12197,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 StructureType main.deepPtr1
             Operations:
@@ -12207,7 +12207,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 StructureType main.deepPtr1
             Operations:
@@ -12223,7 +12223,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 135 PointerType *main.deepPtr7
             Operations:
@@ -12233,7 +12233,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 135 PointerType *main.deepPtr7
             Operations:
@@ -12249,7 +12249,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 137 StructureType main.deepSlice1
             Operations:
@@ -12259,7 +12259,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 137 StructureType main.deepSlice1
             Operations:
@@ -12275,7 +12275,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 PointerType *main.deepSlice7
             Operations:
@@ -12285,7 +12285,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 PointerType *main.deepSlice7
             Operations:
@@ -12301,16 +12301,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -12320,8 +12310,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12329,9 +12319,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12347,7 +12347,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -12357,7 +12357,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -12373,7 +12373,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12383,7 +12383,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12399,7 +12399,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 321 PointerType *main.emptyStruct
             Operations:
@@ -12409,7 +12409,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 321 PointerType *main.emptyStruct
             Operations:
@@ -12425,7 +12425,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 320 StructureType main.emptyStruct
             Operations:
@@ -12435,7 +12435,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 320 StructureType main.emptyStruct
             Operations:
@@ -12449,8 +12449,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 13 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12460,7 +12480,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12469,29 +12489,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 13 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12507,7 +12507,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12517,7 +12517,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 GoInterfaceType error
             Operations:
@@ -12533,7 +12533,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -12543,7 +12543,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -12562,7 +12562,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -12572,7 +12572,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -12591,7 +12591,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12601,7 +12601,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12617,7 +12617,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12627,7 +12627,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12669,7 +12669,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12679,7 +12679,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12711,7 +12711,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12721,7 +12721,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12740,7 +12740,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12750,7 +12750,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12772,16 +12772,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12791,8 +12781,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12800,9 +12790,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12839,7 +12839,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12849,7 +12849,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12923,7 +12923,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12933,7 +12933,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12952,7 +12952,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12962,7 +12962,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12978,7 +12978,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12988,7 +12988,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13004,7 +13004,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -13014,7 +13014,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -13030,7 +13030,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -13040,7 +13040,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -13056,7 +13056,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -13066,7 +13066,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -13082,7 +13082,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -13092,7 +13092,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -13108,7 +13108,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -13118,7 +13118,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -13134,7 +13134,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -13144,7 +13144,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -13160,7 +13160,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 162 GoInterfaceType main.behavior
             Operations:
@@ -13170,7 +13170,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 162 GoInterfaceType main.behavior
             Operations:
@@ -13186,7 +13186,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -13196,7 +13196,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -13228,7 +13228,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -13238,7 +13238,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -13309,7 +13309,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13317,148 +13317,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13468,8 +13388,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13477,9 +13397,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13511,7 +13511,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
@@ -13521,7 +13521,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
@@ -13537,7 +13537,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13547,7 +13547,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13563,7 +13563,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
@@ -13573,7 +13573,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
@@ -13589,7 +13589,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 228 GoMapType map[struct {}]int
             Operations:
@@ -13599,7 +13599,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 228 GoMapType map[struct {}]int
             Operations:
@@ -13615,7 +13615,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 233 GoMapType map[int]struct {}
             Operations:
@@ -13625,7 +13625,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 233 GoMapType map[int]struct {}
             Operations:
@@ -13641,7 +13641,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 166 GoMapType map[int]int
             Operations:
@@ -13651,7 +13651,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 166 GoMapType map[int]int
             Operations:
@@ -13667,7 +13667,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
@@ -13677,7 +13677,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
@@ -13693,7 +13693,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
@@ -13703,7 +13703,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
@@ -13719,7 +13719,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13729,7 +13729,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13745,7 +13745,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13755,7 +13755,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13771,7 +13771,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
@@ -13781,7 +13781,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
@@ -13797,7 +13797,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13807,7 +13807,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13823,7 +13823,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -13833,7 +13833,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -13849,7 +13849,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 181 GoMapType map[string][]string
             Operations:
@@ -13859,7 +13859,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 181 GoMapType map[string][]string
             Operations:
@@ -13875,7 +13875,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13885,7 +13885,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13901,7 +13901,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[bool]main.node
             Operations:
@@ -13911,7 +13911,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[bool]main.node
             Operations:
@@ -13927,7 +13927,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13937,7 +13937,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13953,7 +13953,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13963,7 +13963,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -13979,7 +13979,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -13989,7 +13989,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14005,7 +14005,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14015,7 +14015,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14031,7 +14031,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14041,7 +14041,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14057,7 +14057,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14067,7 +14067,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14083,7 +14083,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14091,148 +14091,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14242,8 +14162,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14251,9 +14171,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14285,16 +14285,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 113 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int
@@ -14304,8 +14294,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -14313,9 +14303,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -14357,16 +14357,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 250 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
@@ -14376,8 +14366,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -14385,9 +14375,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -14419,7 +14419,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14429,7 +14429,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14445,7 +14445,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14475,7 +14475,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14565,7 +14565,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14583,9 +14583,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14594,28 +14614,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14709,7 +14709,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14717,48 +14717,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 10 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14768,17 +14738,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 17 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 17 BaseType uint
@@ -14788,8 +14748,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14797,9 +14757,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 17 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14815,7 +14815,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14825,7 +14825,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14841,7 +14841,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14851,7 +14851,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14883,7 +14883,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14893,7 +14893,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14909,7 +14909,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 317 PointerType *main.anotherStruct
             Operations:
@@ -14919,7 +14919,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 317 PointerType *main.anotherStruct
             Operations:
@@ -14982,16 +14982,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 PointerType *bool
@@ -15001,8 +14991,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -15010,9 +15000,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -15028,16 +15028,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -15047,8 +15037,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15056,9 +15046,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15074,16 +15074,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 16 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 16 BaseType int8
@@ -15093,17 +15083,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 264 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15113,8 +15093,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -15122,9 +15102,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 264 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -15140,7 +15140,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
@@ -15150,7 +15150,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
@@ -15166,7 +15166,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
@@ -15176,7 +15176,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
@@ -15192,7 +15192,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 247 PointerType *main.node
             Operations:
@@ -15202,7 +15202,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 247 PointerType *main.node
             Operations:
@@ -15218,7 +15218,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 192 PointerType *map[string]int
             Operations:
@@ -15228,7 +15228,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 192 PointerType *map[string]int
             Operations:
@@ -15244,7 +15244,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
@@ -15254,7 +15254,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
@@ -15270,16 +15270,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
@@ -15289,8 +15279,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15298,9 +15288,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15342,7 +15342,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -15352,7 +15352,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -15598,7 +15598,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15608,7 +15608,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15640,7 +15640,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15650,7 +15650,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15692,7 +15692,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15702,7 +15702,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15734,7 +15734,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15744,7 +15744,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15776,7 +15776,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -15786,7 +15786,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -16269,7 +16269,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -16279,7 +16279,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -16295,7 +16295,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16305,7 +16305,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16321,7 +16321,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16331,7 +16331,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16353,7 +16353,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 BaseType int16
             Operations:
@@ -16363,7 +16363,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 BaseType int16
             Operations:
@@ -16379,7 +16379,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16389,7 +16389,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16405,7 +16405,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16415,7 +16415,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16431,7 +16431,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -16461,7 +16461,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -16477,7 +16477,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16487,7 +16487,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16503,7 +16503,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16513,7 +16513,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16529,7 +16529,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16539,7 +16539,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16555,7 +16555,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16565,7 +16565,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16581,7 +16581,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16591,7 +16591,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16607,7 +16607,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16617,7 +16617,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16633,7 +16633,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16643,7 +16643,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16659,7 +16659,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -16669,7 +16669,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 17 BaseType uint
             Operations:
@@ -16685,7 +16685,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
@@ -16695,7 +16695,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
@@ -16711,7 +16711,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
@@ -16721,7 +16721,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
@@ -16737,7 +16737,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -16747,7 +16747,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -16763,7 +16763,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16773,7 +16773,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16825,7 +16825,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -16835,7 +16835,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -16887,7 +16887,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -16897,7 +16897,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -16913,7 +16913,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -16923,7 +16923,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -16939,7 +16939,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []string
             Operations:
@@ -16949,7 +16949,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []string
             Operations:
@@ -16965,7 +16965,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 151 PointerType *main.stringType1
             Operations:
@@ -16975,7 +16975,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 151 PointerType *main.stringType1
             Operations:
@@ -16991,7 +16991,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 153 PointerType **main.stringType2
             Operations:
@@ -17001,7 +17001,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 153 PointerType **main.stringType2
             Operations:
@@ -17017,16 +17017,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -17036,8 +17026,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17045,9 +17035,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17063,7 +17063,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 164 StructureType main.structWithAny
             Operations:
@@ -17073,7 +17073,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 164 StructureType main.structWithAny
             Operations:
@@ -17089,7 +17089,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -17099,7 +17099,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -17141,7 +17141,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -17151,7 +17151,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -17170,7 +17170,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
@@ -17180,7 +17180,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
@@ -17196,7 +17196,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 165 StructureType main.structWithMap
             Operations:
@@ -17206,7 +17206,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 165 StructureType main.structWithMap
             Operations:
@@ -17238,7 +17238,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -17248,7 +17248,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -17270,16 +17270,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17289,17 +17279,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17309,8 +17289,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17318,9 +17298,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17336,16 +17336,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17355,17 +17345,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17375,8 +17355,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17384,9 +17364,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17418,7 +17418,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
@@ -17428,7 +17428,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
@@ -17489,7 +17489,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -17499,7 +17499,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -17557,16 +17557,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17576,17 +17566,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17596,8 +17576,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17605,9 +17585,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17623,7 +17623,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 127 BaseType main.typeAlias
             Operations:
@@ -17633,7 +17633,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 127 BaseType main.typeAlias
             Operations:
@@ -17649,7 +17649,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -17659,7 +17659,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -17675,7 +17675,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -17685,7 +17685,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -17701,7 +17701,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17711,7 +17711,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17727,7 +17727,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -17737,7 +17737,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -17753,7 +17753,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -17763,7 +17763,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -17779,7 +17779,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -17789,7 +17789,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -17805,7 +17805,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17815,7 +17815,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17831,7 +17831,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17841,7 +17841,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17857,7 +17857,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -17867,7 +17867,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 VoidPointerType unsafe.Pointer
             Operations:
@@ -17883,7 +17883,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 ArrayType [100]uint
             Operations:
@@ -17893,7 +17893,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 ArrayType [100]uint
             Operations:
@@ -17909,7 +17909,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17919,7 +17919,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17935,7 +17935,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17945,7 +17945,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17961,16 +17961,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 253 ArrayType [0]int
@@ -17981,7 +17971,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17989,9 +17979,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=amd64,toolchain=go1.26rc1.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -263,7 +263,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -284,7 +284,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -305,7 +305,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -532,7 +532,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -561,12 +561,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -590,7 +590,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -611,7 +611,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -632,7 +632,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -653,7 +653,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -674,7 +674,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -695,7 +695,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -716,7 +716,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -737,7 +737,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -763,12 +763,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -790,7 +790,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -811,7 +811,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -831,7 +831,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -852,7 +852,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -886,12 +886,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -916,7 +916,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -941,7 +941,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -966,7 +966,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -991,7 +991,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1015,7 +1015,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1040,7 +1040,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1070,12 +1070,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1100,7 +1100,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1269,7 +1269,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1303,7 +1303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1324,7 +1324,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1348,7 +1348,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1374,7 +1374,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1395,7 +1395,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1416,7 +1416,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1437,7 +1437,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1458,7 +1458,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1479,7 +1479,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1500,7 +1500,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1524,7 +1524,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1545,7 +1545,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1657,47 +1657,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1718,7 +1718,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1739,7 +1739,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1760,7 +1760,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1781,7 +1781,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1802,7 +1802,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1823,7 +1823,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1844,7 +1844,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1865,7 +1865,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1888,7 +1888,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1911,7 +1911,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1932,7 +1932,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1953,7 +1953,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1974,7 +1974,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1995,7 +1995,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2016,7 +2016,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2037,7 +2037,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2058,7 +2058,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2079,7 +2079,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2100,7 +2100,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2123,7 +2123,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2144,7 +2144,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2166,7 +2166,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2216,47 +2216,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2285,12 +2285,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2319,12 +2319,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2348,7 +2348,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2383,27 +2383,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2427,7 +2427,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2458,12 +2458,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2484,7 +2484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2588,12 +2588,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2614,7 +2614,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2640,12 +2640,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2674,17 +2674,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2705,7 +2705,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2726,7 +2726,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2747,7 +2747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2768,7 +2768,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2801,7 +2801,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2839,12 +2839,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -2993,7 +2993,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3017,7 +3017,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3041,7 +3041,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3065,7 +3065,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3094,7 +3094,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3295,7 +3295,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3333,31 +3333,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3378,7 +3378,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3399,7 +3399,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3454,7 +3454,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3476,7 +3476,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3497,7 +3497,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3518,7 +3518,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3547,15 +3547,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3576,7 +3576,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3597,7 +3597,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3618,7 +3618,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3639,7 +3639,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3660,7 +3660,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3681,7 +3681,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3702,7 +3702,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3723,7 +3723,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3744,7 +3744,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3765,7 +3765,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3789,7 +3789,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3813,7 +3813,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3834,7 +3834,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3855,7 +3855,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3876,7 +3876,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3897,7 +3897,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3918,7 +3918,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3939,7 +3939,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3965,12 +3965,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -3991,7 +3991,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4015,7 +4015,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4036,7 +4036,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4056,7 +4056,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4082,7 +4082,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4113,17 +4113,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4152,17 +4152,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4266,17 +4266,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4297,7 +4297,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4357,7 +4357,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4417,7 +4417,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4438,7 +4438,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4459,7 +4459,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4480,7 +4480,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4501,7 +4501,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4522,7 +4522,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4543,7 +4543,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4564,7 +4564,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4585,7 +4585,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4606,7 +4606,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4627,7 +4627,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4648,7 +4648,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4669,7 +4669,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4722,12 +4722,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11567,7 +11567,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 169 PointerType *interface {}
             Operations:
@@ -11577,7 +11577,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 169 PointerType *interface {}
             Operations:
@@ -11609,7 +11609,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -11619,7 +11619,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -11651,7 +11651,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -11661,7 +11661,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -11693,7 +11693,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 ArrayType [2]struct {}
             Operations:
@@ -11703,7 +11703,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 ArrayType [2]struct {}
             Operations:
@@ -11719,7 +11719,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 127 ArrayType [2][2][2]int
             Operations:
@@ -11729,7 +11729,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 127 ArrayType [2][2][2]int
             Operations:
@@ -11745,7 +11745,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 ArrayType [2][2]int
             Operations:
@@ -11755,7 +11755,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 ArrayType [2][2]int
             Operations:
@@ -11771,7 +11771,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 197 ArrayType [2]map[string]int
             Operations:
@@ -11781,7 +11781,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 197 ArrayType [2]map[string]int
             Operations:
@@ -11797,7 +11797,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -11807,7 +11807,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -11823,7 +11823,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 ArrayType [2]main.nestedStruct
             Operations:
@@ -11833,7 +11833,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 ArrayType [2]main.nestedStruct
             Operations:
@@ -11849,7 +11849,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11859,7 +11859,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -11891,7 +11891,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 134 StructureType main.bigStruct
             Operations:
@@ -11901,7 +11901,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 134 StructureType main.bigStruct
             Operations:
@@ -11917,7 +11917,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2]bool
             Operations:
@@ -11927,7 +11927,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]bool
             Operations:
@@ -11943,7 +11943,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -11953,7 +11953,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -11969,7 +11969,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 249 GoChannelType chan bool
             Operations:
@@ -11979,7 +11979,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 GoChannelType chan bool
             Operations:
@@ -11995,16 +11995,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -12014,8 +12004,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12023,9 +12013,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12103,7 +12103,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 254 PointerType *main.t
             Operations:
@@ -12113,7 +12113,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 254 PointerType *main.t
             Operations:
@@ -12129,7 +12129,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 StructureType main.deepMap1
             Operations:
@@ -12139,7 +12139,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 StructureType main.deepMap1
             Operations:
@@ -12155,7 +12155,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 PointerType *main.deepMap7
             Operations:
@@ -12165,7 +12165,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 PointerType *main.deepMap7
             Operations:
@@ -12181,7 +12181,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 138 StructureType main.deepPtr1
             Operations:
@@ -12191,7 +12191,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 138 StructureType main.deepPtr1
             Operations:
@@ -12207,7 +12207,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 PointerType *main.deepPtr7
             Operations:
@@ -12217,7 +12217,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 PointerType *main.deepPtr7
             Operations:
@@ -12233,7 +12233,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 143 StructureType main.deepSlice1
             Operations:
@@ -12243,7 +12243,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 143 StructureType main.deepSlice1
             Operations:
@@ -12259,7 +12259,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 147 PointerType *main.deepSlice7
             Operations:
@@ -12269,7 +12269,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.deepSlice7
             Operations:
@@ -12285,16 +12285,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -12304,8 +12294,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12313,9 +12303,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12331,7 +12331,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -12341,7 +12341,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -12357,7 +12357,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12367,7 +12367,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12383,7 +12383,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 327 PointerType *main.emptyStruct
             Operations:
@@ -12393,7 +12393,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 327 PointerType *main.emptyStruct
             Operations:
@@ -12409,7 +12409,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 326 StructureType main.emptyStruct
             Operations:
@@ -12419,7 +12419,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 326 StructureType main.emptyStruct
             Operations:
@@ -12433,8 +12433,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12444,7 +12464,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12453,29 +12473,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12491,7 +12491,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12501,7 +12501,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12517,7 +12517,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 165 PointerType *main.esotericHeap
             Operations:
@@ -12527,7 +12527,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 165 PointerType *main.esotericHeap
             Operations:
@@ -12546,7 +12546,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 StructureType main.esotericStack
             Operations:
@@ -12556,7 +12556,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 StructureType main.esotericStack
             Operations:
@@ -12575,7 +12575,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12585,7 +12585,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12601,7 +12601,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12611,7 +12611,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12653,7 +12653,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12663,7 +12663,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12695,7 +12695,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12705,7 +12705,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12724,7 +12724,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12734,7 +12734,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12756,16 +12756,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12775,8 +12765,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12784,9 +12774,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12823,7 +12823,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12833,7 +12833,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12907,7 +12907,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12917,7 +12917,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12936,7 +12936,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12946,7 +12946,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12962,7 +12962,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12972,7 +12972,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12988,7 +12988,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12998,7 +12998,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -13014,7 +13014,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 ArrayType [2]int16
             Operations:
@@ -13024,7 +13024,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2]int16
             Operations:
@@ -13040,7 +13040,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -13050,7 +13050,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -13066,7 +13066,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]int64
             Operations:
@@ -13076,7 +13076,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]int64
             Operations:
@@ -13092,7 +13092,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2]int8
             Operations:
@@ -13102,7 +13102,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2]int8
             Operations:
@@ -13118,7 +13118,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]int
             Operations:
@@ -13128,7 +13128,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]int
             Operations:
@@ -13144,7 +13144,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 168 GoInterfaceType main.behavior
             Operations:
@@ -13154,7 +13154,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 168 GoInterfaceType main.behavior
             Operations:
@@ -13170,7 +13170,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -13180,7 +13180,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -13212,7 +13212,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 StructureType main.node
             Operations:
@@ -13222,7 +13222,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 StructureType main.node
             Operations:
@@ -13313,7 +13313,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13321,148 +13321,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13472,8 +13392,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13481,9 +13401,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13515,7 +13515,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
@@ -13525,7 +13525,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
@@ -13541,7 +13541,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13551,7 +13551,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13567,7 +13567,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
@@ -13577,7 +13577,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
@@ -13593,7 +13593,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 234 GoMapType map[struct {}]int
             Operations:
@@ -13603,7 +13603,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 234 GoMapType map[struct {}]int
             Operations:
@@ -13619,7 +13619,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 239 GoMapType map[int]struct {}
             Operations:
@@ -13629,7 +13629,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 239 GoMapType map[int]struct {}
             Operations:
@@ -13645,7 +13645,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 172 GoMapType map[int]int
             Operations:
@@ -13655,7 +13655,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[int]int
             Operations:
@@ -13671,7 +13671,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
@@ -13681,7 +13681,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
@@ -13697,7 +13697,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
@@ -13707,7 +13707,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
@@ -13723,7 +13723,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13733,7 +13733,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13749,7 +13749,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13759,7 +13759,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13775,7 +13775,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
@@ -13785,7 +13785,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
@@ -13801,7 +13801,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13811,7 +13811,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13827,7 +13827,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -13837,7 +13837,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -13853,7 +13853,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 187 GoMapType map[string][]string
             Operations:
@@ -13863,7 +13863,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]string
             Operations:
@@ -13879,7 +13879,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 177 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13889,7 +13889,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13905,7 +13905,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 204 GoMapType map[bool]main.node
             Operations:
@@ -13915,7 +13915,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[bool]main.node
             Operations:
@@ -13931,7 +13931,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13941,7 +13941,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13957,7 +13957,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13967,7 +13967,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -13983,7 +13983,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -13993,7 +13993,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14009,7 +14009,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14019,7 +14019,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14035,7 +14035,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14045,7 +14045,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14061,7 +14061,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14071,7 +14071,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14087,7 +14087,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14095,148 +14095,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14246,8 +14166,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14255,9 +14175,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14289,16 +14289,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 119 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]int
@@ -14308,8 +14298,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -14317,9 +14307,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 119 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -14361,16 +14361,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 256 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
@@ -14380,8 +14370,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -14389,9 +14379,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 256 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -14423,7 +14423,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14433,7 +14433,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14449,7 +14449,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14479,7 +14479,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14569,7 +14569,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14587,9 +14587,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14598,28 +14618,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14713,7 +14713,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14721,48 +14721,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 10 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 10 BaseType int32
@@ -14772,17 +14742,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 14 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 14 BaseType uint
@@ -14792,8 +14752,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14801,9 +14761,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 10 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 14 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14819,7 +14819,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14829,7 +14829,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14845,7 +14845,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14855,7 +14855,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14887,7 +14887,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14897,7 +14897,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14913,7 +14913,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 323 PointerType *main.anotherStruct
             Operations:
@@ -14923,7 +14923,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 323 PointerType *main.anotherStruct
             Operations:
@@ -14986,16 +14986,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 PointerType *bool
@@ -15005,8 +14995,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -15014,9 +15004,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -15032,16 +15032,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -15051,8 +15041,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15060,9 +15050,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15078,16 +15078,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 20 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 20 BaseType int8
@@ -15097,17 +15087,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 270 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15117,8 +15097,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -15126,9 +15106,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 20 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 270 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -15144,7 +15144,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
@@ -15154,7 +15154,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
@@ -15170,7 +15170,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
@@ -15180,7 +15180,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
@@ -15196,7 +15196,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 253 PointerType *main.node
             Operations:
@@ -15206,7 +15206,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 253 PointerType *main.node
             Operations:
@@ -15222,7 +15222,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 PointerType *map[string]int
             Operations:
@@ -15232,7 +15232,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 PointerType *map[string]int
             Operations:
@@ -15248,7 +15248,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
@@ -15258,7 +15258,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
@@ -15274,16 +15274,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
@@ -15293,8 +15283,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15302,9 +15292,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15346,7 +15346,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -15356,7 +15356,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -15602,7 +15602,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15612,7 +15612,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15644,7 +15644,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15654,7 +15654,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15696,7 +15696,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15706,7 +15706,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15738,7 +15738,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15748,7 +15748,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15780,7 +15780,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -15790,7 +15790,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -16273,7 +16273,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -16283,7 +16283,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -16299,7 +16299,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16309,7 +16309,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16325,7 +16325,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16335,7 +16335,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16357,7 +16357,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 BaseType int16
             Operations:
@@ -16367,7 +16367,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 BaseType int16
             Operations:
@@ -16383,7 +16383,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16393,7 +16393,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16409,7 +16409,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16419,7 +16419,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int64
             Operations:
@@ -16435,7 +16435,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 20 BaseType int8
             Operations:
@@ -16465,7 +16465,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 20 BaseType int8
             Operations:
@@ -16481,7 +16481,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16491,7 +16491,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16507,7 +16507,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16517,7 +16517,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType int32
             Operations:
@@ -16533,7 +16533,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16543,7 +16543,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16559,7 +16559,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16569,7 +16569,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16585,7 +16585,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16595,7 +16595,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16611,7 +16611,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16621,7 +16621,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16637,7 +16637,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16647,7 +16647,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16663,7 +16663,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -16673,7 +16673,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 BaseType uint
             Operations:
@@ -16689,7 +16689,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
@@ -16699,7 +16699,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
@@ -16715,7 +16715,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
@@ -16725,7 +16725,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
@@ -16741,7 +16741,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -16751,7 +16751,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -16767,7 +16767,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16777,7 +16777,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16829,7 +16829,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -16839,7 +16839,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -16891,7 +16891,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -16901,7 +16901,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -16917,7 +16917,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 101 PointerType *string
             Operations:
@@ -16927,7 +16927,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 101 PointerType *string
             Operations:
@@ -16943,7 +16943,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 269 GoSliceHeaderType []string
             Operations:
@@ -16953,7 +16953,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 269 GoSliceHeaderType []string
             Operations:
@@ -16969,7 +16969,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.stringType1
             Operations:
@@ -16979,7 +16979,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 PointerType *main.stringType1
             Operations:
@@ -16995,7 +16995,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 PointerType **main.stringType2
             Operations:
@@ -17005,7 +17005,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 PointerType **main.stringType2
             Operations:
@@ -17021,16 +17021,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -17040,8 +17030,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17049,9 +17039,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17067,7 +17067,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 170 StructureType main.structWithAny
             Operations:
@@ -17077,7 +17077,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 170 StructureType main.structWithAny
             Operations:
@@ -17093,7 +17093,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 262 StructureType main.structWithArray
             Operations:
@@ -17103,7 +17103,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 262 StructureType main.structWithArray
             Operations:
@@ -17145,7 +17145,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
@@ -17155,7 +17155,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
@@ -17171,7 +17171,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
@@ -17181,7 +17181,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
@@ -17197,7 +17197,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 StructureType main.structWithMap
             Operations:
@@ -17207,7 +17207,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 StructureType main.structWithMap
             Operations:
@@ -17239,7 +17239,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 322 StructureType main.aStruct
             Operations:
@@ -17249,7 +17249,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 322 StructureType main.aStruct
             Operations:
@@ -17265,16 +17265,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17284,17 +17274,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17304,8 +17284,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17313,9 +17293,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17331,16 +17331,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17350,17 +17340,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17370,8 +17350,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17379,9 +17359,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17413,7 +17413,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
@@ -17423,7 +17423,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
@@ -17484,7 +17484,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 274 StructureType main.threeStringStruct
             Operations:
@@ -17494,7 +17494,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 274 StructureType main.threeStringStruct
             Operations:
@@ -17546,16 +17546,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17565,17 +17555,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17585,8 +17565,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17594,9 +17574,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17612,7 +17612,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 133 BaseType main.typeAlias
             Operations:
@@ -17622,7 +17622,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 133 BaseType main.typeAlias
             Operations:
@@ -17638,7 +17638,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [2]uint16
             Operations:
@@ -17648,7 +17648,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [2]uint16
             Operations:
@@ -17664,7 +17664,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 ArrayType [2]uint32
             Operations:
@@ -17674,7 +17674,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 ArrayType [2]uint32
             Operations:
@@ -17690,7 +17690,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 58 ArrayType [2]uint64
             Operations:
@@ -17700,7 +17700,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 58 ArrayType [2]uint64
             Operations:
@@ -17716,7 +17716,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -17726,7 +17726,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -17742,7 +17742,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 123 ArrayType [2]uint
             Operations:
@@ -17752,7 +17752,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 123 ArrayType [2]uint
             Operations:
@@ -17768,7 +17768,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 PointerType *uint
             Operations:
@@ -17778,7 +17778,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 PointerType *uint
             Operations:
@@ -17794,7 +17794,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17804,7 +17804,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17820,7 +17820,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17830,7 +17830,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17846,7 +17846,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
@@ -17856,7 +17856,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
@@ -17872,7 +17872,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 ArrayType [100]uint
             Operations:
@@ -17882,7 +17882,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 ArrayType [100]uint
             Operations:
@@ -17898,7 +17898,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17908,7 +17908,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17924,7 +17924,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17934,7 +17934,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17950,16 +17950,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 259 ArrayType [0]int
@@ -17970,7 +17960,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17978,9 +17968,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.23.11.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11456,7 +11456,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -11466,7 +11466,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 158 PointerType *interface {}
             Operations:
@@ -11498,7 +11498,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11508,7 +11508,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -11540,7 +11540,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -11550,7 +11550,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -11582,7 +11582,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]struct {}
             Operations:
@@ -11592,7 +11592,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]struct {}
             Operations:
@@ -11608,7 +11608,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -11618,7 +11618,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2][2][2]int
             Operations:
@@ -11634,7 +11634,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -11644,7 +11644,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2][2]int
             Operations:
@@ -11660,7 +11660,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 186 ArrayType [2]map[string]int
             Operations:
@@ -11670,7 +11670,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 186 ArrayType [2]map[string]int
             Operations:
@@ -11686,7 +11686,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -11696,7 +11696,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -11712,7 +11712,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]main.nestedStruct
             Operations:
@@ -11722,7 +11722,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]main.nestedStruct
             Operations:
@@ -11738,7 +11738,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -11748,7 +11748,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -11780,7 +11780,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -11790,7 +11790,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 StructureType main.bigStruct
             Operations:
@@ -11809,7 +11809,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -11819,7 +11819,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 105 ArrayType [2]bool
             Operations:
@@ -11835,7 +11835,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -11845,7 +11845,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -11861,7 +11861,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 238 GoChannelType chan bool
             Operations:
@@ -11871,7 +11871,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 238 GoChannelType chan bool
             Operations:
@@ -11887,16 +11887,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -11906,8 +11896,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -11915,9 +11905,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -11995,7 +11995,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 243 PointerType *main.t
             Operations:
@@ -12005,7 +12005,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 243 PointerType *main.t
             Operations:
@@ -12021,7 +12021,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 136 StructureType main.deepMap1
             Operations:
@@ -12031,7 +12031,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 136 StructureType main.deepMap1
             Operations:
@@ -12047,7 +12047,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 144 PointerType *main.deepMap7
             Operations:
@@ -12057,7 +12057,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 144 PointerType *main.deepMap7
             Operations:
@@ -12073,7 +12073,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 StructureType main.deepPtr1
             Operations:
@@ -12083,7 +12083,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 StructureType main.deepPtr1
             Operations:
@@ -12099,7 +12099,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 PointerType *main.deepPtr7
             Operations:
@@ -12109,7 +12109,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 PointerType *main.deepPtr7
             Operations:
@@ -12125,7 +12125,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 StructureType main.deepSlice1
             Operations:
@@ -12135,7 +12135,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 StructureType main.deepSlice1
             Operations:
@@ -12151,7 +12151,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 134 PointerType *main.deepSlice7
             Operations:
@@ -12161,7 +12161,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 134 PointerType *main.deepSlice7
             Operations:
@@ -12177,16 +12177,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -12196,8 +12186,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12205,9 +12195,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12223,7 +12223,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -12233,7 +12233,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -12249,7 +12249,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -12259,7 +12259,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -12275,7 +12275,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -12285,7 +12285,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 316 PointerType *main.emptyStruct
             Operations:
@@ -12301,7 +12301,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 315 StructureType main.emptyStruct
             Operations:
@@ -12311,7 +12311,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 315 StructureType main.emptyStruct
             Operations:
@@ -12325,8 +12325,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 18 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12336,7 +12356,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 9 BaseType int
@@ -12345,29 +12365,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 18 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12383,7 +12383,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12393,7 +12393,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 18 GoInterfaceType error
             Operations:
@@ -12409,7 +12409,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -12419,7 +12419,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 154 PointerType *main.esotericHeap
             Operations:
@@ -12438,7 +12438,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -12448,7 +12448,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 150 StructureType main.esotericStack
             Operations:
@@ -12467,7 +12467,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12477,7 +12477,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12493,7 +12493,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12503,7 +12503,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12545,7 +12545,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12555,7 +12555,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12587,7 +12587,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12597,7 +12597,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12616,7 +12616,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12626,7 +12626,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12648,16 +12648,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -12667,8 +12657,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12676,9 +12666,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12715,7 +12715,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12725,7 +12725,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12799,7 +12799,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12809,7 +12809,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12828,7 +12828,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12838,7 +12838,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12854,7 +12854,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12864,7 +12864,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -12880,7 +12880,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12890,7 +12890,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -12906,7 +12906,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -12916,7 +12916,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int16
             Operations:
@@ -12932,7 +12932,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -12942,7 +12942,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -12958,7 +12958,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -12968,7 +12968,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]int64
             Operations:
@@ -12984,7 +12984,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -12994,7 +12994,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]int8
             Operations:
@@ -13010,7 +13010,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -13020,7 +13020,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 106 ArrayType [2]int
             Operations:
@@ -13036,7 +13036,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoInterfaceType main.behavior
             Operations:
@@ -13046,7 +13046,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoInterfaceType main.behavior
             Operations:
@@ -13062,7 +13062,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -13072,7 +13072,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -13104,7 +13104,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -13114,7 +13114,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 241 StructureType main.node
             Operations:
@@ -13185,7 +13185,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13193,148 +13193,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -13344,8 +13264,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13353,9 +13273,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13387,7 +13387,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
@@ -13397,7 +13397,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 181 GoMapType map[[4]string][2]int
             Operations:
@@ -13413,7 +13413,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13423,7 +13423,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13439,7 +13439,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
@@ -13449,7 +13449,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 233 GoMapType map[struct {}]struct {}
             Operations:
@@ -13465,7 +13465,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 223 GoMapType map[struct {}]int
             Operations:
@@ -13475,7 +13475,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 223 GoMapType map[struct {}]int
             Operations:
@@ -13491,7 +13491,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 228 GoMapType map[int]struct {}
             Operations:
@@ -13501,7 +13501,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 228 GoMapType map[int]struct {}
             Operations:
@@ -13517,7 +13517,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 GoMapType map[int]int
             Operations:
@@ -13527,7 +13527,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 GoMapType map[int]int
             Operations:
@@ -13543,7 +13543,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
@@ -13553,7 +13553,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 218 GoMapType map[[4]int][4]int
             Operations:
@@ -13569,7 +13569,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
@@ -13579,7 +13579,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 213 GoMapType map[[4]int]uint8
             Operations:
@@ -13595,7 +13595,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13605,7 +13605,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13621,7 +13621,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13631,7 +13631,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 188 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13647,7 +13647,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
@@ -13657,7 +13657,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8][4]int
             Operations:
@@ -13673,7 +13673,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13683,7 +13683,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13699,7 +13699,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -13709,7 +13709,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -13725,7 +13725,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string][]string
             Operations:
@@ -13735,7 +13735,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string][]string
             Operations:
@@ -13751,7 +13751,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 166 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13761,7 +13761,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 166 GoMapType map[string]main.nestedStruct
             Operations:
@@ -13777,7 +13777,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[bool]main.node
             Operations:
@@ -13787,7 +13787,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[bool]main.node
             Operations:
@@ -13803,7 +13803,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13813,7 +13813,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13829,7 +13829,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13839,7 +13839,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[uint8]uint8
             Operations:
@@ -13855,7 +13855,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13865,7 +13865,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13881,7 +13881,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13891,7 +13891,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[int]uint8
             Operations:
@@ -13907,7 +13907,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13917,7 +13917,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13933,7 +13933,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13943,7 +13943,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -13959,7 +13959,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -13967,148 +13967,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 9 BaseType int
@@ -14118,8 +14038,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14127,9 +14047,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14161,16 +14161,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 106 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 106 ArrayType [2]int
@@ -14180,8 +14170,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -14189,9 +14179,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 106 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 ArrayType [3]int
             Operations:
@@ -14233,16 +14233,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 245 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
@@ -14252,8 +14242,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -14261,9 +14251,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 245 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 StructureType main.largeStruct
             Operations:
@@ -14295,7 +14295,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14305,7 +14305,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14321,7 +14321,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14351,7 +14351,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14441,7 +14441,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14459,9 +14459,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 9 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14470,28 +14490,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 9 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14585,7 +14585,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14593,48 +14593,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 13 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 13 BaseType int32
@@ -14644,17 +14614,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 12 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 12 BaseType uint
@@ -14664,8 +14624,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14673,9 +14633,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 13 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 12 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -14691,7 +14691,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14701,7 +14701,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14717,7 +14717,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14727,7 +14727,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14759,7 +14759,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14769,7 +14769,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14785,7 +14785,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 312 PointerType *main.anotherStruct
             Operations:
@@ -14795,7 +14795,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 312 PointerType *main.anotherStruct
             Operations:
@@ -14858,16 +14858,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 5 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 5 PointerType *bool
@@ -14877,8 +14867,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -14886,9 +14876,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 5 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -14904,16 +14904,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -14923,8 +14913,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14932,9 +14922,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -14950,16 +14950,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 15 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 15 BaseType int8
@@ -14969,17 +14959,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 259 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 259 GoSliceHeaderType []bool
@@ -14989,8 +14969,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -14998,9 +14978,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 15 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 259 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -15016,7 +15016,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
@@ -15026,7 +15026,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 260 GoSliceHeaderType []uint16
             Operations:
@@ -15042,7 +15042,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
@@ -15052,7 +15052,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 265 PointerType *main.oneStringStruct
             Operations:
@@ -15068,7 +15068,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 242 PointerType *main.node
             Operations:
@@ -15078,7 +15078,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.node
             Operations:
@@ -15094,7 +15094,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 187 PointerType *map[string]int
             Operations:
@@ -15104,7 +15104,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 187 PointerType *map[string]int
             Operations:
@@ -15120,7 +15120,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
@@ -15130,7 +15130,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 239 PointerType *main.structWithTwoValues
             Operations:
@@ -15146,16 +15146,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 152 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
@@ -15165,8 +15155,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15174,9 +15164,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 152 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15218,7 +15218,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15228,7 +15228,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15474,7 +15474,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15484,7 +15484,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15516,7 +15516,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15526,7 +15526,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15568,7 +15568,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15578,7 +15578,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15610,7 +15610,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15620,7 +15620,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -15652,7 +15652,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -15662,7 +15662,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 152 GoEmptyInterfaceType interface {}
             Operations:
@@ -16145,7 +16145,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -16155,7 +16155,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 103 ArrayType [2]int32
             Operations:
@@ -16171,7 +16171,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16181,7 +16181,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16197,7 +16197,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16207,7 +16207,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16229,7 +16229,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 89 BaseType int16
             Operations:
@@ -16239,7 +16239,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 89 BaseType int16
             Operations:
@@ -16255,7 +16255,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -16265,7 +16265,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -16281,7 +16281,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 BaseType int64
             Operations:
@@ -16291,7 +16291,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 BaseType int64
             Operations:
@@ -16307,7 +16307,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -16337,7 +16337,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 BaseType int8
             Operations:
@@ -16353,7 +16353,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16363,7 +16363,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16379,7 +16379,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -16389,7 +16389,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int32
             Operations:
@@ -16405,7 +16405,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -16415,7 +16415,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -16431,7 +16431,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -16441,7 +16441,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType uint16
             Operations:
@@ -16457,7 +16457,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16467,7 +16467,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16483,7 +16483,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -16493,7 +16493,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint64
             Operations:
@@ -16509,7 +16509,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16519,7 +16519,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16535,7 +16535,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -16545,7 +16545,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType uint
             Operations:
@@ -16561,7 +16561,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
@@ -16571,7 +16571,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 261 GoSliceHeaderType []struct {}
             Operations:
@@ -16587,7 +16587,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
@@ -16597,7 +16597,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 253 GoSliceHeaderType [][]uint
             Operations:
@@ -16613,7 +16613,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -16623,7 +16623,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]int
             Operations:
@@ -16639,7 +16639,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16649,7 +16649,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16701,7 +16701,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -16711,7 +16711,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 156 ArrayType [5]int
             Operations:
@@ -16763,7 +16763,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -16773,7 +16773,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 ArrayType [2]string
             Operations:
@@ -16789,7 +16789,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -16799,7 +16799,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 88 PointerType *string
             Operations:
@@ -16815,7 +16815,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []string
             Operations:
@@ -16825,7 +16825,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 258 GoSliceHeaderType []string
             Operations:
@@ -16841,7 +16841,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 146 PointerType *main.stringType1
             Operations:
@@ -16851,7 +16851,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 146 PointerType *main.stringType1
             Operations:
@@ -16867,7 +16867,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 148 PointerType **main.stringType2
             Operations:
@@ -16877,7 +16877,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 148 PointerType **main.stringType2
             Operations:
@@ -16893,16 +16893,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []main.structWithNoStrings
@@ -16912,8 +16902,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16921,9 +16911,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -16939,7 +16939,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 StructureType main.structWithAny
             Operations:
@@ -16949,7 +16949,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 StructureType main.structWithAny
             Operations:
@@ -16965,7 +16965,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -16975,7 +16975,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 StructureType main.structWithArray
             Operations:
@@ -17017,7 +17017,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -17027,7 +17027,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 280 StructureType main.structWithCyclicMaps
             Operations:
@@ -17046,7 +17046,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
@@ -17056,7 +17056,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 267 StructureType main.structWithCyclicSlices
             Operations:
@@ -17072,7 +17072,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 160 StructureType main.structWithMap
             Operations:
@@ -17082,7 +17082,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 160 StructureType main.structWithMap
             Operations:
@@ -17114,7 +17114,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -17124,7 +17124,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 311 StructureType main.aStruct
             Operations:
@@ -17146,16 +17146,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17165,17 +17155,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 252 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
@@ -17185,8 +17165,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17194,9 +17174,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 252 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17212,16 +17212,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17231,17 +17221,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17251,8 +17231,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17260,9 +17240,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17294,7 +17294,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
@@ -17304,7 +17304,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 PointerType *main.threeStringStruct
             Operations:
@@ -17365,7 +17365,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -17375,7 +17375,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 StructureType main.threeStringStruct
             Operations:
@@ -17433,16 +17433,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17452,17 +17442,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 11 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
@@ -17472,8 +17452,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17481,9 +17461,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 11 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17499,7 +17499,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 BaseType main.typeAlias
             Operations:
@@ -17509,7 +17509,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 BaseType main.typeAlias
             Operations:
@@ -17525,7 +17525,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -17535,7 +17535,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]uint16
             Operations:
@@ -17551,7 +17551,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -17561,7 +17561,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]uint32
             Operations:
@@ -17577,7 +17577,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -17587,7 +17587,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 52 ArrayType [2]uint64
             Operations:
@@ -17603,7 +17603,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -17613,7 +17613,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 ArrayType [2]uint8
             Operations:
@@ -17629,7 +17629,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -17639,7 +17639,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]uint
             Operations:
@@ -17655,7 +17655,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -17665,7 +17665,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 100 PointerType *uint
             Operations:
@@ -17681,7 +17681,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17691,7 +17691,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17707,7 +17707,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17717,7 +17717,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 GoStringHeaderType string
             Operations:
@@ -17733,7 +17733,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -17743,7 +17743,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 19 VoidPointerType unsafe.Pointer
             Operations:
@@ -17759,7 +17759,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [100]uint
             Operations:
@@ -17769,7 +17769,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [100]uint
             Operations:
@@ -17785,7 +17785,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17795,7 +17795,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17811,7 +17811,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17821,7 +17821,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 GoSliceHeaderType []uint
             Operations:
@@ -17837,16 +17837,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 248 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 248 ArrayType [0]int
@@ -17857,7 +17847,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 BaseType int
             Operations:
@@ -17865,9 +17855,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 248 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.24.3.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11761,7 +11761,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -11771,7 +11771,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 PointerType *interface {}
             Operations:
@@ -11803,7 +11803,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -11813,7 +11813,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -11845,7 +11845,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -11855,7 +11855,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -11887,7 +11887,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]struct {}
             Operations:
@@ -11897,7 +11897,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]struct {}
             Operations:
@@ -11913,7 +11913,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -11923,7 +11923,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2][2][2]int
             Operations:
@@ -11939,7 +11939,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -11949,7 +11949,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2][2]int
             Operations:
@@ -11965,7 +11965,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 189 ArrayType [2]map[string]int
             Operations:
@@ -11975,7 +11975,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 189 ArrayType [2]map[string]int
             Operations:
@@ -11991,7 +11991,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -12001,7 +12001,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -12017,7 +12017,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2]main.nestedStruct
             Operations:
@@ -12027,7 +12027,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2]main.nestedStruct
             Operations:
@@ -12043,7 +12043,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12053,7 +12053,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12085,7 +12085,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -12095,7 +12095,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 StructureType main.bigStruct
             Operations:
@@ -12114,7 +12114,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -12124,7 +12124,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]bool
             Operations:
@@ -12140,7 +12140,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -12150,7 +12150,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -12166,7 +12166,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 241 GoChannelType chan bool
             Operations:
@@ -12176,7 +12176,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 241 GoChannelType chan bool
             Operations:
@@ -12192,16 +12192,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -12211,8 +12201,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12220,9 +12210,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12300,7 +12300,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 PointerType *main.t
             Operations:
@@ -12310,7 +12310,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 PointerType *main.t
             Operations:
@@ -12326,7 +12326,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 StructureType main.deepMap1
             Operations:
@@ -12336,7 +12336,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 StructureType main.deepMap1
             Operations:
@@ -12352,7 +12352,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 147 PointerType *main.deepMap7
             Operations:
@@ -12362,7 +12362,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.deepMap7
             Operations:
@@ -12378,7 +12378,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 StructureType main.deepPtr1
             Operations:
@@ -12388,7 +12388,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 StructureType main.deepPtr1
             Operations:
@@ -12404,7 +12404,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 133 PointerType *main.deepPtr7
             Operations:
@@ -12414,7 +12414,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 133 PointerType *main.deepPtr7
             Operations:
@@ -12430,7 +12430,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 135 StructureType main.deepSlice1
             Operations:
@@ -12440,7 +12440,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 135 StructureType main.deepSlice1
             Operations:
@@ -12456,7 +12456,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 139 PointerType *main.deepSlice7
             Operations:
@@ -12466,7 +12466,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 139 PointerType *main.deepSlice7
             Operations:
@@ -12482,16 +12482,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -12501,8 +12491,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12510,9 +12500,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12528,7 +12528,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -12538,7 +12538,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -12554,7 +12554,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12564,7 +12564,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12580,7 +12580,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 319 PointerType *main.emptyStruct
             Operations:
@@ -12590,7 +12590,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 319 PointerType *main.emptyStruct
             Operations:
@@ -12606,7 +12606,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 318 StructureType main.emptyStruct
             Operations:
@@ -12616,7 +12616,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 318 StructureType main.emptyStruct
             Operations:
@@ -12630,8 +12630,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12641,7 +12661,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12650,29 +12670,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12688,7 +12688,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12698,7 +12698,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12714,7 +12714,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -12724,7 +12724,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 PointerType *main.esotericHeap
             Operations:
@@ -12743,7 +12743,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -12753,7 +12753,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 153 StructureType main.esotericStack
             Operations:
@@ -12772,7 +12772,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12782,7 +12782,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12798,7 +12798,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12808,7 +12808,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -12850,7 +12850,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12860,7 +12860,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12892,7 +12892,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12902,7 +12902,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12921,7 +12921,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12931,7 +12931,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12953,16 +12953,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -12972,8 +12962,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12981,9 +12971,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13020,7 +13020,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13030,7 +13030,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13104,7 +13104,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13114,7 +13114,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13133,7 +13133,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13143,7 +13143,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13159,7 +13159,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13169,7 +13169,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13185,7 +13185,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -13195,7 +13195,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -13211,7 +13211,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -13221,7 +13221,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int16
             Operations:
@@ -13237,7 +13237,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -13247,7 +13247,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -13263,7 +13263,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -13273,7 +13273,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int64
             Operations:
@@ -13289,7 +13289,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -13299,7 +13299,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]int8
             Operations:
@@ -13315,7 +13315,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -13325,7 +13325,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]int
             Operations:
@@ -13341,7 +13341,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 160 GoInterfaceType main.behavior
             Operations:
@@ -13351,7 +13351,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 160 GoInterfaceType main.behavior
             Operations:
@@ -13367,7 +13367,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -13377,7 +13377,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -13409,7 +13409,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -13419,7 +13419,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 StructureType main.node
             Operations:
@@ -13490,7 +13490,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13498,148 +13498,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13649,8 +13569,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13658,9 +13578,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13692,7 +13692,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
@@ -13702,7 +13702,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 184 GoMapType map[[4]string][2]int
             Operations:
@@ -13718,7 +13718,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13728,7 +13728,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13744,7 +13744,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
@@ -13754,7 +13754,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 236 GoMapType map[struct {}]struct {}
             Operations:
@@ -13770,7 +13770,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 226 GoMapType map[struct {}]int
             Operations:
@@ -13780,7 +13780,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 226 GoMapType map[struct {}]int
             Operations:
@@ -13796,7 +13796,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 231 GoMapType map[int]struct {}
             Operations:
@@ -13806,7 +13806,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 231 GoMapType map[int]struct {}
             Operations:
@@ -13822,7 +13822,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 164 GoMapType map[int]int
             Operations:
@@ -13832,7 +13832,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 164 GoMapType map[int]int
             Operations:
@@ -13848,7 +13848,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
@@ -13858,7 +13858,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 221 GoMapType map[[4]int][4]int
             Operations:
@@ -13874,7 +13874,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
@@ -13884,7 +13884,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 216 GoMapType map[[4]int]uint8
             Operations:
@@ -13900,7 +13900,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13910,7 +13910,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13926,7 +13926,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13936,7 +13936,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13952,7 +13952,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
@@ -13962,7 +13962,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 211 GoMapType map[uint8][4]int
             Operations:
@@ -13978,7 +13978,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -13988,7 +13988,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -14004,7 +14004,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -14014,7 +14014,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -14030,7 +14030,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 179 GoMapType map[string][]string
             Operations:
@@ -14040,7 +14040,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 179 GoMapType map[string][]string
             Operations:
@@ -14056,7 +14056,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 169 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14066,7 +14066,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 169 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14082,7 +14082,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 196 GoMapType map[bool]main.node
             Operations:
@@ -14092,7 +14092,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 196 GoMapType map[bool]main.node
             Operations:
@@ -14108,7 +14108,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -14118,7 +14118,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -14134,7 +14134,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -14144,7 +14144,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 206 GoMapType map[uint8]uint8
             Operations:
@@ -14160,7 +14160,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -14170,7 +14170,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -14186,7 +14186,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -14196,7 +14196,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 201 GoMapType map[int]uint8
             Operations:
@@ -14212,7 +14212,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14222,7 +14222,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14238,7 +14238,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14248,7 +14248,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14264,7 +14264,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14272,148 +14272,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14423,8 +14343,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14432,9 +14352,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14466,16 +14466,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 111 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]int
@@ -14485,8 +14475,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -14494,9 +14484,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 111 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 ArrayType [3]int
             Operations:
@@ -14538,16 +14538,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 248 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
@@ -14557,8 +14547,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -14566,9 +14556,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 248 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 StructureType main.largeStruct
             Operations:
@@ -14600,7 +14600,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14610,7 +14610,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14626,7 +14626,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14656,7 +14656,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14746,7 +14746,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14764,9 +14764,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14775,28 +14795,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14890,7 +14890,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14898,48 +14898,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -14949,17 +14919,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 10 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -14969,8 +14929,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14978,9 +14938,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14996,7 +14996,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15006,7 +15006,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15022,7 +15022,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15032,7 +15032,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15064,7 +15064,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15074,7 +15074,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15090,7 +15090,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 315 PointerType *main.anotherStruct
             Operations:
@@ -15100,7 +15100,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 315 PointerType *main.anotherStruct
             Operations:
@@ -15163,16 +15163,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 PointerType *bool
@@ -15182,8 +15172,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15191,9 +15181,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15209,16 +15209,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -15228,8 +15218,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15237,9 +15227,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15255,16 +15255,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 16 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 16 BaseType int8
@@ -15274,17 +15264,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 262 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 262 GoSliceHeaderType []bool
@@ -15294,8 +15274,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15303,9 +15283,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 16 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 262 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15321,7 +15321,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
@@ -15331,7 +15331,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint16
             Operations:
@@ -15347,7 +15347,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
@@ -15357,7 +15357,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 268 PointerType *main.oneStringStruct
             Operations:
@@ -15373,7 +15373,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 245 PointerType *main.node
             Operations:
@@ -15383,7 +15383,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 245 PointerType *main.node
             Operations:
@@ -15399,7 +15399,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 190 PointerType *map[string]int
             Operations:
@@ -15409,7 +15409,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 190 PointerType *map[string]int
             Operations:
@@ -15425,7 +15425,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
@@ -15435,7 +15435,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 242 PointerType *main.structWithTwoValues
             Operations:
@@ -15451,16 +15451,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 155 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
@@ -15470,8 +15460,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15479,9 +15469,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 155 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15523,7 +15523,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15533,7 +15533,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15779,7 +15779,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15789,7 +15789,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15821,7 +15821,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15831,7 +15831,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15873,7 +15873,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15883,7 +15883,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15915,7 +15915,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15925,7 +15925,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15957,7 +15957,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -15967,7 +15967,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 GoEmptyInterfaceType interface {}
             Operations:
@@ -16450,7 +16450,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -16460,7 +16460,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 108 ArrayType [2]int32
             Operations:
@@ -16476,7 +16476,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16486,7 +16486,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16502,7 +16502,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16512,7 +16512,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16534,7 +16534,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 94 BaseType int16
             Operations:
@@ -16544,7 +16544,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 94 BaseType int16
             Operations:
@@ -16560,7 +16560,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16570,7 +16570,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16586,7 +16586,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16596,7 +16596,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16612,7 +16612,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -16642,7 +16642,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 BaseType int8
             Operations:
@@ -16658,7 +16658,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16668,7 +16668,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16684,7 +16684,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16694,7 +16694,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16710,7 +16710,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16720,7 +16720,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16736,7 +16736,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16746,7 +16746,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16762,7 +16762,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16772,7 +16772,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16788,7 +16788,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16798,7 +16798,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16814,7 +16814,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16824,7 +16824,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16840,7 +16840,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -16850,7 +16850,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -16866,7 +16866,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
@@ -16876,7 +16876,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType []struct {}
             Operations:
@@ -16892,7 +16892,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
@@ -16902,7 +16902,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 GoSliceHeaderType [][]uint
             Operations:
@@ -16918,7 +16918,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -16928,7 +16928,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 174 GoMapType map[string]int
             Operations:
@@ -16944,7 +16944,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16954,7 +16954,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17006,7 +17006,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -17016,7 +17016,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 ArrayType [5]int
             Operations:
@@ -17068,7 +17068,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -17078,7 +17078,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]string
             Operations:
@@ -17094,7 +17094,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -17104,7 +17104,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 93 PointerType *string
             Operations:
@@ -17120,7 +17120,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 261 GoSliceHeaderType []string
             Operations:
@@ -17130,7 +17130,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 261 GoSliceHeaderType []string
             Operations:
@@ -17146,7 +17146,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 PointerType *main.stringType1
             Operations:
@@ -17156,7 +17156,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 PointerType *main.stringType1
             Operations:
@@ -17172,7 +17172,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 151 PointerType **main.stringType2
             Operations:
@@ -17182,7 +17182,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 151 PointerType **main.stringType2
             Operations:
@@ -17198,16 +17198,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 258 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType []main.structWithNoStrings
@@ -17217,8 +17207,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17226,9 +17216,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 258 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17244,7 +17244,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 162 StructureType main.structWithAny
             Operations:
@@ -17254,7 +17254,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 162 StructureType main.structWithAny
             Operations:
@@ -17270,7 +17270,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -17280,7 +17280,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 254 StructureType main.structWithArray
             Operations:
@@ -17322,7 +17322,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -17332,7 +17332,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 283 StructureType main.structWithCyclicMaps
             Operations:
@@ -17351,7 +17351,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
@@ -17361,7 +17361,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 270 StructureType main.structWithCyclicSlices
             Operations:
@@ -17377,7 +17377,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 StructureType main.structWithMap
             Operations:
@@ -17387,7 +17387,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 StructureType main.structWithMap
             Operations:
@@ -17419,7 +17419,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -17429,7 +17429,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 314 StructureType main.aStruct
             Operations:
@@ -17451,16 +17451,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17470,17 +17460,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 255 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
@@ -17490,8 +17470,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17499,9 +17479,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 255 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17517,16 +17517,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17536,17 +17526,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17556,8 +17536,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17565,9 +17545,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17599,7 +17599,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
@@ -17609,7 +17609,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 267 PointerType *main.threeStringStruct
             Operations:
@@ -17670,7 +17670,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -17680,7 +17680,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 266 StructureType main.threeStringStruct
             Operations:
@@ -17738,16 +17738,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17757,17 +17747,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17777,8 +17757,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17786,9 +17766,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17804,7 +17804,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 BaseType main.typeAlias
             Operations:
@@ -17814,7 +17814,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 BaseType main.typeAlias
             Operations:
@@ -17830,7 +17830,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -17840,7 +17840,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]uint16
             Operations:
@@ -17856,7 +17856,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -17866,7 +17866,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint32
             Operations:
@@ -17882,7 +17882,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17892,7 +17892,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17908,7 +17908,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -17918,7 +17918,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 ArrayType [2]uint8
             Operations:
@@ -17934,7 +17934,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -17944,7 +17944,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint
             Operations:
@@ -17960,7 +17960,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -17970,7 +17970,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 105 PointerType *uint
             Operations:
@@ -17986,7 +17986,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -17996,7 +17996,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -18012,7 +18012,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18022,7 +18022,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18038,7 +18038,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -18048,7 +18048,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -18064,7 +18064,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [100]uint
             Operations:
@@ -18074,7 +18074,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [100]uint
             Operations:
@@ -18090,7 +18090,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -18100,7 +18100,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -18116,7 +18116,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -18126,7 +18126,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 255 GoSliceHeaderType []uint
             Operations:
@@ -18142,16 +18142,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 251 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 251 ArrayType [0]int
@@ -18162,7 +18152,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -18170,9 +18160,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 251 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.25.0.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -267,7 +267,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -288,7 +288,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -309,7 +309,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -540,7 +540,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -569,12 +569,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -598,7 +598,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -619,7 +619,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -640,7 +640,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -661,7 +661,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -682,7 +682,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -703,7 +703,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -724,7 +724,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -745,7 +745,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -771,12 +771,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -798,7 +798,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -819,7 +819,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -839,7 +839,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -860,7 +860,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -894,12 +894,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 3
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 5
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -924,7 +924,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -949,7 +949,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -974,7 +974,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -999,7 +999,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1023,7 +1023,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1048,7 +1048,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1078,12 +1078,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1108,7 +1108,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1277,7 +1277,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1311,7 +1311,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1332,7 +1332,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1356,7 +1356,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1382,7 +1382,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1403,7 +1403,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1424,7 +1424,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1445,7 +1445,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1466,7 +1466,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1487,7 +1487,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1508,7 +1508,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1532,7 +1532,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1553,7 +1553,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1665,47 +1665,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1726,7 +1726,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1747,7 +1747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1768,7 +1768,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1789,7 +1789,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1810,7 +1810,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1831,7 +1831,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1852,7 +1852,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1873,7 +1873,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1896,7 +1896,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1919,7 +1919,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1940,7 +1940,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1961,7 +1961,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1982,7 +1982,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -2003,7 +2003,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2024,7 +2024,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2045,7 +2045,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2066,7 +2066,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2087,7 +2087,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2108,7 +2108,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2131,7 +2131,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2152,7 +2152,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2174,7 +2174,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2224,47 +2224,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2293,12 +2293,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2327,12 +2327,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2356,7 +2356,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2391,27 +2391,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2435,7 +2435,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2466,12 +2466,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2492,7 +2492,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2596,12 +2596,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2622,7 +2622,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2648,12 +2648,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2682,17 +2682,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2713,7 +2713,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2734,7 +2734,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2755,7 +2755,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2776,7 +2776,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2809,7 +2809,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2847,12 +2847,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -3001,7 +3001,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3025,7 +3025,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3049,7 +3049,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3073,7 +3073,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3102,7 +3102,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3303,7 +3303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3341,31 +3341,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3386,7 +3386,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3407,7 +3407,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3462,7 +3462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3484,7 +3484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3505,7 +3505,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3526,7 +3526,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3555,15 +3555,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3584,7 +3584,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3605,7 +3605,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3626,7 +3626,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3647,7 +3647,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3668,7 +3668,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3689,7 +3689,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3710,7 +3710,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3731,7 +3731,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3752,7 +3752,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3773,7 +3773,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3797,7 +3797,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3821,7 +3821,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3842,7 +3842,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3863,7 +3863,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3884,7 +3884,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3905,7 +3905,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3926,7 +3926,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3951,7 +3951,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3977,12 +3977,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -4003,7 +4003,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4027,7 +4027,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4052,7 +4052,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4072,7 +4072,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4098,7 +4098,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4129,17 +4129,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4168,17 +4168,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4282,17 +4282,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4317,7 +4317,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4381,7 +4381,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4441,7 +4441,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4462,7 +4462,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4483,7 +4483,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4504,7 +4504,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4525,7 +4525,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4546,7 +4546,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4567,7 +4567,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4588,7 +4588,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4609,7 +4609,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4630,7 +4630,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4651,7 +4651,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4672,7 +4672,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4693,7 +4693,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4746,12 +4746,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11854,7 +11854,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -11864,7 +11864,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 PointerType *interface {}
             Operations:
@@ -11896,7 +11896,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -11906,7 +11906,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -11938,7 +11938,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11948,7 +11948,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -11980,7 +11980,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [2]struct {}
             Operations:
@@ -11990,7 +11990,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [2]struct {}
             Operations:
@@ -12006,7 +12006,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -12016,7 +12016,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2][2][2]int
             Operations:
@@ -12032,7 +12032,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -12042,7 +12042,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2][2]int
             Operations:
@@ -12058,7 +12058,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 191 ArrayType [2]map[string]int
             Operations:
@@ -12068,7 +12068,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 191 ArrayType [2]map[string]int
             Operations:
@@ -12084,7 +12084,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -12094,7 +12094,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -12110,7 +12110,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]main.nestedStruct
             Operations:
@@ -12120,7 +12120,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]main.nestedStruct
             Operations:
@@ -12136,7 +12136,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12146,7 +12146,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12178,7 +12178,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -12188,7 +12188,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 StructureType main.bigStruct
             Operations:
@@ -12207,7 +12207,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -12217,7 +12217,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 ArrayType [2]bool
             Operations:
@@ -12233,7 +12233,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -12243,7 +12243,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -12259,7 +12259,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 243 GoChannelType chan bool
             Operations:
@@ -12269,7 +12269,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 243 GoChannelType chan bool
             Operations:
@@ -12285,16 +12285,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -12304,8 +12294,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12313,9 +12303,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12393,7 +12393,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 248 PointerType *main.t
             Operations:
@@ -12403,7 +12403,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 248 PointerType *main.t
             Operations:
@@ -12419,7 +12419,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 143 StructureType main.deepMap1
             Operations:
@@ -12429,7 +12429,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 143 StructureType main.deepMap1
             Operations:
@@ -12445,7 +12445,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 PointerType *main.deepMap7
             Operations:
@@ -12455,7 +12455,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 PointerType *main.deepMap7
             Operations:
@@ -12471,7 +12471,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 StructureType main.deepPtr1
             Operations:
@@ -12481,7 +12481,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 StructureType main.deepPtr1
             Operations:
@@ -12497,7 +12497,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 135 PointerType *main.deepPtr7
             Operations:
@@ -12507,7 +12507,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 135 PointerType *main.deepPtr7
             Operations:
@@ -12523,7 +12523,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 137 StructureType main.deepSlice1
             Operations:
@@ -12533,7 +12533,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 137 StructureType main.deepSlice1
             Operations:
@@ -12549,7 +12549,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 PointerType *main.deepSlice7
             Operations:
@@ -12559,7 +12559,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 PointerType *main.deepSlice7
             Operations:
@@ -12575,16 +12575,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -12594,8 +12584,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12603,9 +12593,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12621,7 +12621,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -12631,7 +12631,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -12647,7 +12647,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12657,7 +12657,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12673,7 +12673,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 321 PointerType *main.emptyStruct
             Operations:
@@ -12683,7 +12683,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 321 PointerType *main.emptyStruct
             Operations:
@@ -12699,7 +12699,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 320 StructureType main.emptyStruct
             Operations:
@@ -12709,7 +12709,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 320 StructureType main.emptyStruct
             Operations:
@@ -12723,8 +12723,28 @@ Types:
       ByteSize: 59
       PresenceBitsetSize: 2
       Expressions:
-        - Name: shouldErr
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 14 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: shouldErr
+          Offset: 26
           Kind: local
           Expression:
             Type: 4 BaseType bool
@@ -12734,7 +12754,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: ~r0
-          Offset: 3
+          Offset: 27
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12744,7 +12764,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 11
+          Offset: 35
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12753,29 +12773,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 19
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 27
-          Kind: local
-          Expression:
-            Type: 14 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 43
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12791,7 +12791,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12801,7 +12801,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 14 GoInterfaceType error
             Operations:
@@ -12817,7 +12817,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -12827,7 +12827,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 PointerType *main.esotericHeap
             Operations:
@@ -12846,7 +12846,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -12856,7 +12856,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 StructureType main.esotericStack
             Operations:
@@ -12875,7 +12875,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12885,7 +12885,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12901,7 +12901,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12911,7 +12911,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -12953,7 +12953,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12963,7 +12963,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12995,7 +12995,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13005,7 +13005,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13024,7 +13024,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13034,7 +13034,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13056,16 +13056,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13075,8 +13065,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13084,9 +13074,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13123,7 +13123,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13133,7 +13133,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13207,7 +13207,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13217,7 +13217,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13236,7 +13236,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13246,7 +13246,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13262,7 +13262,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13272,7 +13272,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13288,7 +13288,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -13298,7 +13298,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -13314,7 +13314,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -13324,7 +13324,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]int16
             Operations:
@@ -13340,7 +13340,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -13350,7 +13350,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -13366,7 +13366,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -13376,7 +13376,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int64
             Operations:
@@ -13392,7 +13392,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -13402,7 +13402,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 ArrayType [2]int8
             Operations:
@@ -13418,7 +13418,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -13428,7 +13428,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 113 ArrayType [2]int
             Operations:
@@ -13444,7 +13444,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 162 GoInterfaceType main.behavior
             Operations:
@@ -13454,7 +13454,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 162 GoInterfaceType main.behavior
             Operations:
@@ -13470,7 +13470,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -13480,7 +13480,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -13512,7 +13512,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -13522,7 +13522,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 246 StructureType main.node
             Operations:
@@ -13593,7 +13593,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13601,148 +13601,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13752,8 +13672,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13761,9 +13681,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13795,7 +13795,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
@@ -13805,7 +13805,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 186 GoMapType map[[4]string][2]int
             Operations:
@@ -13821,7 +13821,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13831,7 +13831,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13847,7 +13847,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
@@ -13857,7 +13857,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 238 GoMapType map[struct {}]struct {}
             Operations:
@@ -13873,7 +13873,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 228 GoMapType map[struct {}]int
             Operations:
@@ -13883,7 +13883,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 228 GoMapType map[struct {}]int
             Operations:
@@ -13899,7 +13899,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 233 GoMapType map[int]struct {}
             Operations:
@@ -13909,7 +13909,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 233 GoMapType map[int]struct {}
             Operations:
@@ -13925,7 +13925,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 166 GoMapType map[int]int
             Operations:
@@ -13935,7 +13935,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 166 GoMapType map[int]int
             Operations:
@@ -13951,7 +13951,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
@@ -13961,7 +13961,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 223 GoMapType map[[4]int][4]int
             Operations:
@@ -13977,7 +13977,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
@@ -13987,7 +13987,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 218 GoMapType map[[4]int]uint8
             Operations:
@@ -14003,7 +14003,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14013,7 +14013,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14029,7 +14029,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14039,7 +14039,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 193 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14055,7 +14055,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
@@ -14065,7 +14065,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 213 GoMapType map[uint8][4]int
             Operations:
@@ -14081,7 +14081,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14091,7 +14091,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14107,7 +14107,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -14117,7 +14117,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -14133,7 +14133,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 181 GoMapType map[string][]string
             Operations:
@@ -14143,7 +14143,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 181 GoMapType map[string][]string
             Operations:
@@ -14159,7 +14159,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14169,7 +14169,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14185,7 +14185,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 GoMapType map[bool]main.node
             Operations:
@@ -14195,7 +14195,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 GoMapType map[bool]main.node
             Operations:
@@ -14211,7 +14211,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14221,7 +14221,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14237,7 +14237,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14247,7 +14247,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 208 GoMapType map[uint8]uint8
             Operations:
@@ -14263,7 +14263,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14273,7 +14273,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14289,7 +14289,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14299,7 +14299,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 203 GoMapType map[int]uint8
             Operations:
@@ -14315,7 +14315,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14325,7 +14325,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14341,7 +14341,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14351,7 +14351,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14367,7 +14367,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14375,148 +14375,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14526,8 +14446,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14535,9 +14455,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14569,16 +14569,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 113 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 113 ArrayType [2]int
@@ -14588,8 +14578,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -14597,9 +14587,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 113 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 251 ArrayType [3]int
             Operations:
@@ -14641,16 +14641,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 250 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
@@ -14660,8 +14650,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -14669,9 +14659,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 250 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 StructureType main.largeStruct
             Operations:
@@ -14703,7 +14703,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14713,7 +14713,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14729,7 +14729,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14759,7 +14759,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14849,7 +14849,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14867,9 +14867,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14878,28 +14898,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14993,7 +14993,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15001,48 +15001,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -15052,17 +15022,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 10 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 10 BaseType uint
@@ -15072,8 +15032,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -15081,9 +15041,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 10 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -15099,7 +15099,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15109,7 +15109,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15125,7 +15125,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15135,7 +15135,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15167,7 +15167,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15177,7 +15177,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15193,7 +15193,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 317 PointerType *main.anotherStruct
             Operations:
@@ -15203,7 +15203,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 317 PointerType *main.anotherStruct
             Operations:
@@ -15266,16 +15266,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 11 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 PointerType *bool
@@ -15285,8 +15275,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15294,9 +15284,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 11 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15312,16 +15312,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -15331,8 +15321,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15340,9 +15330,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15358,16 +15358,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 17 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 17 BaseType int8
@@ -15377,17 +15367,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 264 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType []bool
@@ -15397,8 +15377,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15406,9 +15386,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 17 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 264 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -15424,7 +15424,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
@@ -15434,7 +15434,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 265 GoSliceHeaderType []uint16
             Operations:
@@ -15450,7 +15450,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
@@ -15460,7 +15460,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 270 PointerType *main.oneStringStruct
             Operations:
@@ -15476,7 +15476,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 247 PointerType *main.node
             Operations:
@@ -15486,7 +15486,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 247 PointerType *main.node
             Operations:
@@ -15502,7 +15502,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 192 PointerType *map[string]int
             Operations:
@@ -15512,7 +15512,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 192 PointerType *map[string]int
             Operations:
@@ -15528,7 +15528,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
@@ -15538,7 +15538,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 PointerType *main.structWithTwoValues
             Operations:
@@ -15554,16 +15554,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 157 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
@@ -15573,8 +15563,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15582,9 +15572,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 157 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15626,7 +15626,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -15636,7 +15636,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -15882,7 +15882,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15892,7 +15892,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15924,7 +15924,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15934,7 +15934,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15976,7 +15976,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15986,7 +15986,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16018,7 +16018,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16028,7 +16028,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16060,7 +16060,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -16070,7 +16070,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 GoEmptyInterfaceType interface {}
             Operations:
@@ -16553,7 +16553,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -16563,7 +16563,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 110 ArrayType [2]int32
             Operations:
@@ -16579,7 +16579,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16589,7 +16589,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16605,7 +16605,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16615,7 +16615,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16637,7 +16637,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 96 BaseType int16
             Operations:
@@ -16647,7 +16647,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 96 BaseType int16
             Operations:
@@ -16663,7 +16663,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16673,7 +16673,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16689,7 +16689,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16699,7 +16699,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16715,7 +16715,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 17 BaseType int8
             Operations:
@@ -16745,7 +16745,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 17 BaseType int8
             Operations:
@@ -16761,7 +16761,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16771,7 +16771,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16787,7 +16787,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16797,7 +16797,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16813,7 +16813,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16823,7 +16823,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16839,7 +16839,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16849,7 +16849,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16865,7 +16865,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16875,7 +16875,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16891,7 +16891,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16901,7 +16901,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16917,7 +16917,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16927,7 +16927,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16943,7 +16943,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -16953,7 +16953,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 BaseType uint
             Operations:
@@ -16969,7 +16969,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
@@ -16979,7 +16979,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 266 GoSliceHeaderType []struct {}
             Operations:
@@ -16995,7 +16995,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
@@ -17005,7 +17005,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 258 GoSliceHeaderType [][]uint
             Operations:
@@ -17021,7 +17021,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -17031,7 +17031,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 176 GoMapType map[string]int
             Operations:
@@ -17047,7 +17047,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17057,7 +17057,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17109,7 +17109,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -17119,7 +17119,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 ArrayType [5]int
             Operations:
@@ -17171,7 +17171,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -17181,7 +17181,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 ArrayType [2]string
             Operations:
@@ -17197,7 +17197,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -17207,7 +17207,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 95 PointerType *string
             Operations:
@@ -17223,7 +17223,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []string
             Operations:
@@ -17233,7 +17233,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []string
             Operations:
@@ -17249,7 +17249,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 151 PointerType *main.stringType1
             Operations:
@@ -17259,7 +17259,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 151 PointerType *main.stringType1
             Operations:
@@ -17275,7 +17275,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 153 PointerType **main.stringType2
             Operations:
@@ -17285,7 +17285,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 153 PointerType **main.stringType2
             Operations:
@@ -17301,16 +17301,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 260 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 260 GoSliceHeaderType []main.structWithNoStrings
@@ -17320,8 +17310,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17329,9 +17319,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 260 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17347,7 +17347,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 164 StructureType main.structWithAny
             Operations:
@@ -17357,7 +17357,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 164 StructureType main.structWithAny
             Operations:
@@ -17373,7 +17373,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -17383,7 +17383,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.structWithArray
             Operations:
@@ -17425,7 +17425,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -17435,7 +17435,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 285 StructureType main.structWithCyclicMaps
             Operations:
@@ -17454,7 +17454,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
@@ -17464,7 +17464,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 272 StructureType main.structWithCyclicSlices
             Operations:
@@ -17480,7 +17480,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 165 StructureType main.structWithMap
             Operations:
@@ -17490,7 +17490,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 165 StructureType main.structWithMap
             Operations:
@@ -17522,7 +17522,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -17532,7 +17532,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 316 StructureType main.aStruct
             Operations:
@@ -17554,16 +17554,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17573,17 +17563,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 257 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
@@ -17593,8 +17573,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17602,9 +17582,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 257 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -17620,16 +17620,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17639,17 +17629,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17659,8 +17639,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17668,9 +17648,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17702,7 +17702,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
@@ -17712,7 +17712,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 269 PointerType *main.threeStringStruct
             Operations:
@@ -17773,7 +17773,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -17783,7 +17783,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 268 StructureType main.threeStringStruct
             Operations:
@@ -17841,16 +17841,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17860,17 +17850,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17880,8 +17860,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17889,9 +17869,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17907,7 +17907,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 127 BaseType main.typeAlias
             Operations:
@@ -17917,7 +17917,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 127 BaseType main.typeAlias
             Operations:
@@ -17933,7 +17933,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -17943,7 +17943,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]uint16
             Operations:
@@ -17959,7 +17959,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -17969,7 +17969,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]uint32
             Operations:
@@ -17985,7 +17985,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -17995,7 +17995,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 54 ArrayType [2]uint64
             Operations:
@@ -18011,7 +18011,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -18021,7 +18021,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 ArrayType [2]uint8
             Operations:
@@ -18037,7 +18037,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -18047,7 +18047,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]uint
             Operations:
@@ -18063,7 +18063,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -18073,7 +18073,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 107 PointerType *uint
             Operations:
@@ -18089,7 +18089,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18099,7 +18099,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18115,7 +18115,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18125,7 +18125,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18141,7 +18141,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -18151,7 +18151,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 VoidPointerType unsafe.Pointer
             Operations:
@@ -18167,7 +18167,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 ArrayType [100]uint
             Operations:
@@ -18177,7 +18177,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 ArrayType [100]uint
             Operations:
@@ -18193,7 +18193,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18203,7 +18203,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18219,7 +18219,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18229,7 +18229,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 GoSliceHeaderType []uint
             Operations:
@@ -18245,16 +18245,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 253 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 253 ArrayType [0]int
@@ -18265,7 +18255,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -18273,9 +18263,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 253 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/sample.arch=arm64,toolchain=go1.26rc1.yaml
@@ -43,7 +43,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAnyPtr
       version: 0
       type: LOG_PROBE
@@ -68,7 +68,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -92,7 +92,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -113,7 +113,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArrays
       version: 0
       type: LOG_PROBE
@@ -134,7 +134,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfArraysOfArrays
       version: 0
       type: LOG_PROBE
@@ -155,7 +155,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfMaps
       version: 0
       type: LOG_PROBE
@@ -176,7 +176,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStrings
       version: 0
       type: LOG_PROBE
@@ -197,7 +197,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testArrayOfStructs
       version: 0
       type: LOG_PROBE
@@ -217,7 +217,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testAtomicAdd
       version: 0
       type: LOG_PROBE
@@ -242,7 +242,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBigStruct
       version: 0
       type: LOG_PROBE
@@ -263,7 +263,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testBoolArray
       version: 0
       type: LOG_PROBE
@@ -284,7 +284,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testByteArray
       version: 0
       type: LOG_PROBE
@@ -305,7 +305,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCaptureExprGetmember
       version: 0
       type: LOG_PROBE
@@ -532,7 +532,7 @@ Probes:
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testCombinedByte
       version: 0
       type: LOG_PROBE
@@ -561,12 +561,12 @@ Probes:
             - JSON: {Ref: w}
               DSL: w
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - Error: failed to resolve reference "y"
               DSL: y
@@ -590,7 +590,7 @@ Probes:
             - JSON: {Ref: t}
               DSL: t
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap1
       version: 0
       type: LOG_PROBE
@@ -611,7 +611,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepMap7
       version: 0
       type: LOG_PROBE
@@ -632,7 +632,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr1
       version: 0
       type: LOG_PROBE
@@ -653,7 +653,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepPtr7
       version: 0
       type: LOG_PROBE
@@ -674,7 +674,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice1
       version: 0
       type: LOG_PROBE
@@ -695,7 +695,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testDeepSlice7
       version: 0
       type: LOG_PROBE
@@ -716,7 +716,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySlice
       version: 0
       type: LOG_PROBE
@@ -737,7 +737,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptySliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -763,12 +763,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testEmptyString
       version: 0
       type: LOG_PROBE
@@ -790,7 +790,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStruct
       version: 0
       type: LOG_PROBE
@@ -811,7 +811,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEmptyStructPointer
       version: 0
       type: LOG_PROBE
@@ -831,7 +831,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testError
       version: 0
       type: LOG_PROBE
@@ -852,7 +852,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testErrorAtLine
       version: 0
       type: LOG_PROBE
@@ -886,12 +886,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 2
+              EventExpressionIndex: 0
             - ', err='
             - JSON: {Ref: err}
               DSL: err
               EventKind: Line
-              EventExpressionIndex: 4
+              EventExpressionIndex: 1
     - id: testEsotericHeap
       version: 0
       type: LOG_PROBE
@@ -916,7 +916,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testEsotericStack
       version: 0
       type: LOG_PROBE
@@ -941,7 +941,7 @@ Probes:
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFrameless
       version: 0
       type: LOG_PROBE
@@ -966,7 +966,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArray
       version: 0
       type: LOG_PROBE
@@ -991,7 +991,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testFramelessArrayLine
       version: 0
       type: LOG_PROBE
@@ -1015,7 +1015,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBA
       version: 0
       type: LOG_PROBE
@@ -1040,7 +1040,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBB
       version: 0
       type: LOG_PROBE
@@ -1070,12 +1070,12 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testInlinedBBA
       version: 0
       type: LOG_PROBE
@@ -1100,7 +1100,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedBBB
       version: 0
       type: LOG_PROBE
@@ -1269,7 +1269,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedPrintLine
       version: 0
       type: LOG_PROBE
@@ -1303,7 +1303,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSq
       version: 0
       type: LOG_PROBE
@@ -1324,7 +1324,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSqLine
       version: 0
       type: LOG_PROBE
@@ -1348,7 +1348,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Line
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInlinedSumArray
       version: 0
       type: LOG_PROBE
@@ -1374,7 +1374,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt16Array
       version: 0
       type: LOG_PROBE
@@ -1395,7 +1395,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt32Array
       version: 0
       type: LOG_PROBE
@@ -1416,7 +1416,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt64Array
       version: 0
       type: LOG_PROBE
@@ -1437,7 +1437,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInt8Array
       version: 0
       type: LOG_PROBE
@@ -1458,7 +1458,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testIntArray
       version: 0
       type: LOG_PROBE
@@ -1479,7 +1479,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testInterface
       version: 0
       type: LOG_PROBE
@@ -1500,7 +1500,7 @@ Probes:
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLargeArgAndReturn
       version: 0
       type: LOG_PROBE
@@ -1524,7 +1524,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLinkedList
       version: 0
       type: LOG_PROBE
@@ -1545,7 +1545,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testLongFunctionWithChangingStateLineA
       version: 0
       type: LOG_PROBE
@@ -1657,47 +1657,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMapArrayToArray
       version: 0
       type: LOG_PROBE
@@ -1718,7 +1718,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmbeddedMaps
       version: 0
       type: LOG_PROBE
@@ -1739,7 +1739,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKey
       version: 0
       type: LOG_PROBE
@@ -1760,7 +1760,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -1781,7 +1781,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapEmptyValue
       version: 0
       type: LOG_PROBE
@@ -1802,7 +1802,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapIntToInt
       version: 0
       type: LOG_PROBE
@@ -1823,7 +1823,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1844,7 +1844,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapLargeKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1865,7 +1865,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassive
       version: 0
       type: LOG_PROBE
@@ -1888,7 +1888,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapMassiveWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -1911,7 +1911,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeyLargeValue
       version: 0
       type: LOG_PROBE
@@ -1932,7 +1932,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapSmallKeySmallValue
       version: 0
       type: LOG_PROBE
@@ -1953,7 +1953,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToInt
       version: 0
       type: LOG_PROBE
@@ -1974,7 +1974,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToSlice
       version: 0
       type: LOG_PROBE
@@ -1995,7 +1995,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapStringToStruct
       version: 0
       type: LOG_PROBE
@@ -2016,7 +2016,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithLinkedList
       version: 0
       type: LOG_PROBE
@@ -2037,7 +2037,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValue
       version: 0
       type: LOG_PROBE
@@ -2058,7 +2058,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallKeyAndValueMassive
       version: 0
       type: LOG_PROBE
@@ -2079,7 +2079,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValue
       version: 0
       type: LOG_PROBE
@@ -2100,7 +2100,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMapWithSmallValueMassive
       version: 0
       type: LOG_PROBE
@@ -2123,7 +2123,7 @@ Probes:
             - JSON: {Ref: redactMyEntries}
               DSL: redactMyEntries
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveString
       version: 0
       type: LOG_PROBE
@@ -2144,7 +2144,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMassiveStringWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -2166,7 +2166,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMixedArgsStackReturn
       version: 0
       type: LOG_PROBE
@@ -2216,47 +2216,47 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
             - ', '
             - JSON: {Ref: f}
               DSL: f
               EventKind: Entry
-              EventExpressionIndex: 11
+              EventExpressionIndex: 5
             - ', '
             - JSON: {Ref: g}
               DSL: g
               EventKind: Entry
-              EventExpressionIndex: 13
+              EventExpressionIndex: 6
             - ', '
             - JSON: {Ref: h}
               DSL: h
               EventKind: Entry
-              EventExpressionIndex: 15
+              EventExpressionIndex: 7
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 17
+              EventExpressionIndex: 8
     - id: testMultipleArrayArgs
       version: 0
       type: LOG_PROBE
@@ -2285,12 +2285,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleLargeArgs
       version: 0
       type: LOG_PROBE
@@ -2319,12 +2319,12 @@ Probes:
             - JSON: {Ref: s1}
               DSL: s1
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s2}
               DSL: s2
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testMultipleNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2348,7 +2348,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testMultipleSimpleParams
       version: 0
       type: LOG_PROBE
@@ -2383,27 +2383,27 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
             - ', '
             - JSON: {Ref: d}
               DSL: d
               EventKind: Entry
-              EventExpressionIndex: 7
+              EventExpressionIndex: 3
             - ', '
             - JSON: {Ref: e}
               DSL: e
               EventKind: Entry
-              EventExpressionIndex: 9
+              EventExpressionIndex: 4
     - id: testNamedReturn
       version: 0
       type: LOG_PROBE
@@ -2427,7 +2427,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNamedReturnWithTemplate
       version: 0
       type: LOG_PROBE
@@ -2458,12 +2458,12 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' * 2 = result '
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer
       version: 0
       type: LOG_PROBE
@@ -2484,7 +2484,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNestedPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -2588,12 +2588,12 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSlice
       version: 0
       type: LOG_PROBE
@@ -2614,7 +2614,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testNilSliceOfStructs
       version: 0
       type: LOG_PROBE
@@ -2640,12 +2640,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testNilSliceWithOtherParams
       version: 0
       type: LOG_PROBE
@@ -2674,17 +2674,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testOneStringInStructPointer
       version: 0
       type: LOG_PROBE
@@ -2705,7 +2705,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerLoop
       version: 0
       type: LOG_PROBE
@@ -2726,7 +2726,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToMap
       version: 0
       type: LOG_PROBE
@@ -2747,7 +2747,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testPointerToSimpleStruct
       version: 0
       type: LOG_PROBE
@@ -2768,7 +2768,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAny
       version: 0
       type: LOG_PROBE
@@ -2801,7 +2801,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsAnyAndError
       version: 0
       type: LOG_PROBE
@@ -2839,12 +2839,12 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testReturnsArray
       version: 0
       type: LOG_PROBE
@@ -2993,7 +2993,7 @@ Probes:
             - JSON: {Ref: failed}
               DSL: failed
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInt
       version: 0
       type: LOG_PROBE
@@ -3017,7 +3017,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntAndFloat
       version: 0
       type: LOG_PROBE
@@ -3041,7 +3041,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsIntPointer
       version: 0
       type: LOG_PROBE
@@ -3065,7 +3065,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsInterface
       version: 0
       type: LOG_PROBE
@@ -3094,7 +3094,7 @@ Probes:
             - JSON: {Ref: v}
               DSL: v
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testReturnsLargeStruct
       version: 0
       type: LOG_PROBE
@@ -3295,7 +3295,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSegmentsForParamsAndReturnsOutOfOrder
       version: 0
       type: LOG_PROBE
@@ -3333,31 +3333,31 @@ Probes:
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 4
+              EventExpressionIndex: 2
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
+              EventExpressionIndex: 0
+            - JSON: {Ref: i}
+              DSL: i
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: i}
-              DSL: i
-              EventKind: Entry
-              EventExpressionIndex: 3
             - JSON: {Ref: result2}
               DSL: result2
               EventKind: Return
-              EventExpressionIndex: 5
+              EventExpressionIndex: 3
             - JSON: {Ref: result}
               DSL: result
               EventKind: Return
-              EventExpressionIndex: 2
+              EventExpressionIndex: 1
     - id: testSingleBool
       version: 0
       type: LOG_PROBE
@@ -3378,7 +3378,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleByte
       version: 0
       type: LOG_PROBE
@@ -3399,7 +3399,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleFloat32
       version: 0
       type: LOG_PROBE
@@ -3454,7 +3454,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt16
       version: 0
       type: LOG_PROBE
@@ -3476,7 +3476,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt32
       version: 0
       type: LOG_PROBE
@@ -3497,7 +3497,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt64
       version: 0
       type: LOG_PROBE
@@ -3518,7 +3518,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleInt8
       version: 0
       type: LOG_PROBE
@@ -3547,15 +3547,15 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
+              EventExpressionIndex: 0
+            - JSON: {Ref: x}
+              DSL: x
+              EventKind: Entry
               EventExpressionIndex: 1
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
               EventExpressionIndex: 2
-            - JSON: {Ref: x}
-              DSL: x
-              EventKind: Entry
-              EventExpressionIndex: 3
     - id: testSingleRune
       version: 0
       type: LOG_PROBE
@@ -3576,7 +3576,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleString
       version: 0
       type: LOG_PROBE
@@ -3597,7 +3597,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint
       version: 0
       type: LOG_PROBE
@@ -3618,7 +3618,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint16
       version: 0
       type: LOG_PROBE
@@ -3639,7 +3639,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint32
       version: 0
       type: LOG_PROBE
@@ -3660,7 +3660,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint64
       version: 0
       type: LOG_PROBE
@@ -3681,7 +3681,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSingleUint8
       version: 0
       type: LOG_PROBE
@@ -3702,7 +3702,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceEmptyStructs
       version: 0
       type: LOG_PROBE
@@ -3723,7 +3723,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSliceOfSlices
       version: 0
       type: LOG_PROBE
@@ -3744,7 +3744,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSmallMap
       version: 0
       type: LOG_PROBE
@@ -3765,7 +3765,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testSomeNamedReturn
       version: 0
       type: LOG_PROBE
@@ -3789,7 +3789,7 @@ Probes:
             - JSON: {Ref: i}
               DSL: i
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStackArgRegReturns
       version: 0
       type: LOG_PROBE
@@ -3813,7 +3813,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringArray
       version: 0
       type: LOG_PROBE
@@ -3834,7 +3834,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringPointer
       version: 0
       type: LOG_PROBE
@@ -3855,7 +3855,7 @@ Probes:
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringSlice
       version: 0
       type: LOG_PROBE
@@ -3876,7 +3876,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType1
       version: 0
       type: LOG_PROBE
@@ -3897,7 +3897,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStringType2
       version: 0
       type: LOG_PROBE
@@ -3918,7 +3918,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStruct
       version: 0
       type: LOG_PROBE
@@ -3939,7 +3939,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructSlice
       version: 0
       type: LOG_PROBE
@@ -3965,12 +3965,12 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
     - id: testStructWithAny
       version: 0
       type: LOG_PROBE
@@ -3991,7 +3991,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithArrayArg
       version: 0
       type: LOG_PROBE
@@ -4015,7 +4015,7 @@ Probes:
             - JSON: {Ref: arg}
               DSL: arg
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicMaps
       version: 0
       type: LOG_PROBE
@@ -4036,7 +4036,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithCyclicSlices
       version: 0
       type: LOG_PROBE
@@ -4056,7 +4056,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testStructWithMap
       version: 0
       type: LOG_PROBE
@@ -4082,7 +4082,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ' '
             - '@duration'
     - id: testSubslices
@@ -4113,17 +4113,17 @@ Probes:
             - JSON: {Ref: as}
               DSL: as
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: bs}
               DSL: bs
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: cs}
               DSL: cs
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testSubstrings
       version: 0
       type: LOG_PROBE
@@ -4152,17 +4152,17 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: c}
               DSL: c
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testTemplateWithNonexistantVariableName
       version: 0
       type: LOG_PROBE
@@ -4266,17 +4266,17 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: y}
               DSL: y
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
             - ', '
             - JSON: {Ref: z}
               DSL: z
               EventKind: Entry
-              EventExpressionIndex: 5
+              EventExpressionIndex: 2
     - id: testThreeStringsInStruct
       version: 0
       type: LOG_PROBE
@@ -4297,7 +4297,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructExpr
       version: 0
       type: LOG_PROBE
@@ -4357,7 +4357,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testThreeStringsInStructPointer_expression_with_dots
       version: 0
       type: LOG_PROBE
@@ -4417,7 +4417,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint16Array
       version: 0
       type: LOG_PROBE
@@ -4438,7 +4438,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint32Array
       version: 0
       type: LOG_PROBE
@@ -4459,7 +4459,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint64Array
       version: 0
       type: LOG_PROBE
@@ -4480,7 +4480,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUint8Array
       version: 0
       type: LOG_PROBE
@@ -4501,7 +4501,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintArray
       version: 0
       type: LOG_PROBE
@@ -4522,7 +4522,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintPointer
       version: 0
       type: LOG_PROBE
@@ -4543,7 +4543,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUintSlice
       version: 0
       type: LOG_PROBE
@@ -4564,7 +4564,7 @@ Probes:
             - JSON: {Ref: u}
               DSL: u
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnitializedString
       version: 0
       type: LOG_PROBE
@@ -4585,7 +4585,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testUnsafePointer
       version: 0
       type: LOG_PROBE
@@ -4606,7 +4606,7 @@ Probes:
             - JSON: {Ref: x}
               DSL: x
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeArray
       version: 0
       type: LOG_PROBE
@@ -4627,7 +4627,7 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSlice
       version: 0
       type: LOG_PROBE
@@ -4648,7 +4648,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testVeryLargeSliceWithSizeLimit
       version: 0
       type: LOG_PROBE
@@ -4669,7 +4669,7 @@ Probes:
             - JSON: {Ref: xs}
               DSL: xs
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: testWhollyInlinedSubroutine
       version: 0
       type: LOG_PROBE
@@ -4722,12 +4722,12 @@ Probes:
             - JSON: {Ref: a}
               DSL: a
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
             - ', '
             - JSON: {Ref: b}
               DSL: b
               EventKind: Entry
-              EventExpressionIndex: 3
+              EventExpressionIndex: 1
 Subprograms:
     - ID: 1
       Name: main.testByteArray
@@ -11827,7 +11827,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 169 PointerType *interface {}
             Operations:
@@ -11837,7 +11837,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 169 PointerType *interface {}
             Operations:
@@ -11869,7 +11869,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -11879,7 +11879,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -11911,7 +11911,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -11921,7 +11921,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -11953,7 +11953,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 ArrayType [2]struct {}
             Operations:
@@ -11963,7 +11963,7 @@ Types:
                   ByteSize: 0
         - Name: a
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 ArrayType [2]struct {}
             Operations:
@@ -11979,7 +11979,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 127 ArrayType [2][2][2]int
             Operations:
@@ -11989,7 +11989,7 @@ Types:
                   ByteSize: 64
         - Name: b
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 127 ArrayType [2][2][2]int
             Operations:
@@ -12005,7 +12005,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 126 ArrayType [2][2]int
             Operations:
@@ -12015,7 +12015,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 126 ArrayType [2][2]int
             Operations:
@@ -12031,7 +12031,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 197 ArrayType [2]map[string]int
             Operations:
@@ -12041,7 +12041,7 @@ Types:
                   ByteSize: 16
         - Name: m
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 197 ArrayType [2]map[string]int
             Operations:
@@ -12057,7 +12057,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -12067,7 +12067,7 @@ Types:
                   ByteSize: 32
         - Name: a
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -12083,7 +12083,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 128 ArrayType [2]main.nestedStruct
             Operations:
@@ -12093,7 +12093,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 128 ArrayType [2]main.nestedStruct
             Operations:
@@ -12109,7 +12109,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12119,7 +12119,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -12151,7 +12151,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 134 StructureType main.bigStruct
             Operations:
@@ -12161,7 +12161,7 @@ Types:
                   ByteSize: 48
         - Name: b
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 134 StructureType main.bigStruct
             Operations:
@@ -12177,7 +12177,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 118 ArrayType [2]bool
             Operations:
@@ -12187,7 +12187,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 118 ArrayType [2]bool
             Operations:
@@ -12203,7 +12203,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -12213,7 +12213,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -12229,7 +12229,7 @@ Types:
       Expressions:
         - Name: c
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 249 GoChannelType chan bool
             Operations:
@@ -12239,7 +12239,7 @@ Types:
                   ByteSize: 0
         - Name: c
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 249 GoChannelType chan bool
             Operations:
@@ -12255,16 +12255,6 @@ Types:
       Expressions:
         - Name: w
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 84, index: 0, name: w}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: w
-          Offset: 2
           Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
@@ -12274,8 +12264,8 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: x
-          Offset: 3
-          Kind: argument
+          Offset: 2
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12283,9 +12273,19 @@ Types:
                   Variable: {subprogram: 84, index: 1, name: x}
                   Offset: 0
                   ByteSize: 1
+        - Name: w
+          Offset: 3
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 84, index: 0, name: w}
+                  Offset: 0
+                  ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -12363,7 +12363,7 @@ Types:
       Expressions:
         - Name: t
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 254 PointerType *main.t
             Operations:
@@ -12373,7 +12373,7 @@ Types:
                   ByteSize: 8
         - Name: t
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 254 PointerType *main.t
             Operations:
@@ -12389,7 +12389,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 149 StructureType main.deepMap1
             Operations:
@@ -12399,7 +12399,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 149 StructureType main.deepMap1
             Operations:
@@ -12415,7 +12415,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 155 PointerType *main.deepMap7
             Operations:
@@ -12425,7 +12425,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 155 PointerType *main.deepMap7
             Operations:
@@ -12441,7 +12441,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 138 StructureType main.deepPtr1
             Operations:
@@ -12451,7 +12451,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 138 StructureType main.deepPtr1
             Operations:
@@ -12467,7 +12467,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 141 PointerType *main.deepPtr7
             Operations:
@@ -12477,7 +12477,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 141 PointerType *main.deepPtr7
             Operations:
@@ -12493,7 +12493,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 143 StructureType main.deepSlice1
             Operations:
@@ -12503,7 +12503,7 @@ Types:
                   ByteSize: 24
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 143 StructureType main.deepSlice1
             Operations:
@@ -12519,7 +12519,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 147 PointerType *main.deepSlice7
             Operations:
@@ -12529,7 +12529,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 147 PointerType *main.deepSlice7
             Operations:
@@ -12545,16 +12545,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 135, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -12564,8 +12554,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12573,9 +12563,19 @@ Types:
                   Variable: {subprogram: 135, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 135, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12591,7 +12591,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -12601,7 +12601,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -12617,7 +12617,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12627,7 +12627,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -12643,7 +12643,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 327 PointerType *main.emptyStruct
             Operations:
@@ -12653,7 +12653,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 327 PointerType *main.emptyStruct
             Operations:
@@ -12669,7 +12669,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 326 StructureType main.emptyStruct
             Operations:
@@ -12679,7 +12679,7 @@ Types:
                   ByteSize: 0
         - Name: e
           Offset: 1
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 326 StructureType main.emptyStruct
             Operations:
@@ -12693,8 +12693,28 @@ Types:
       ByteSize: 58
       PresenceBitsetSize: 2
       Expressions:
-        - Name: ~r0
+        - Name: x
           Offset: 2
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 2, name: x}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: err
+          Offset: 10
+          Kind: template_segment
+          Expression:
+            Type: 15 GoInterfaceType error
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 38, index: 3, name: err}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: ~r0
+          Offset: 26
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12704,7 +12724,7 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: x
-          Offset: 10
+          Offset: 34
           Kind: local
           Expression:
             Type: 7 BaseType int
@@ -12713,29 +12733,9 @@ Types:
                   Variable: {subprogram: 38, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
-        - Name: x
-          Offset: 18
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 2, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: err
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 15 GoInterfaceType error
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 38, index: 3, name: err}
-                  Offset: 0
-                  ByteSize: 16
         - Name: err
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12751,7 +12751,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12761,7 +12761,7 @@ Types:
                   ByteSize: 16
         - Name: e
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 15 GoInterfaceType error
             Operations:
@@ -12777,7 +12777,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 165 PointerType *main.esotericHeap
             Operations:
@@ -12787,7 +12787,7 @@ Types:
                   ByteSize: 8
         - Name: e
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 165 PointerType *main.esotericHeap
             Operations:
@@ -12806,7 +12806,7 @@ Types:
       Expressions:
         - Name: e
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 161 StructureType main.esotericStack
             Operations:
@@ -12816,7 +12816,7 @@ Types:
                   ByteSize: 64
         - Name: e
           Offset: 65
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 161 StructureType main.esotericStack
             Operations:
@@ -12835,7 +12835,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12845,7 +12845,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12861,7 +12861,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12871,7 +12871,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -12913,7 +12913,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12923,7 +12923,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12955,7 +12955,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12965,7 +12965,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12984,7 +12984,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -12994,7 +12994,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13016,16 +13016,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 51, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: x
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13035,8 +13025,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: y
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13044,9 +13034,19 @@ Types:
                   Variable: {subprogram: 51, index: 1, name: y}
                   Offset: 0
                   ByteSize: 8
+        - Name: x
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 51, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 8
         - Name: y
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13083,7 +13083,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13093,7 +13093,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13167,7 +13167,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13177,7 +13177,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13196,7 +13196,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13206,7 +13206,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13222,7 +13222,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13232,7 +13232,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13248,7 +13248,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -13258,7 +13258,7 @@ Types:
                   ByteSize: 40
         - Name: a
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -13274,7 +13274,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 ArrayType [2]int16
             Operations:
@@ -13284,7 +13284,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 ArrayType [2]int16
             Operations:
@@ -13300,7 +13300,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -13310,7 +13310,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -13326,7 +13326,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 122 ArrayType [2]int64
             Operations:
@@ -13336,7 +13336,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 122 ArrayType [2]int64
             Operations:
@@ -13352,7 +13352,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 120 ArrayType [2]int8
             Operations:
@@ -13362,7 +13362,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 120 ArrayType [2]int8
             Operations:
@@ -13378,7 +13378,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]int
             Operations:
@@ -13388,7 +13388,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 119 ArrayType [2]int
             Operations:
@@ -13404,7 +13404,7 @@ Types:
       Expressions:
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 168 GoInterfaceType main.behavior
             Operations:
@@ -13414,7 +13414,7 @@ Types:
                   ByteSize: 16
         - Name: b
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 168 GoInterfaceType main.behavior
             Operations:
@@ -13430,7 +13430,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -13440,7 +13440,7 @@ Types:
                   ByteSize: 80
         - Name: arg
           Offset: 81
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -13472,7 +13472,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 252 StructureType main.node
             Operations:
@@ -13482,7 +13482,7 @@ Types:
                   ByteSize: 16
         - Name: a
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 252 StructureType main.node
             Operations:
@@ -13573,7 +13573,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13581,148 +13581,68 @@ Types:
                   Variable: {subprogram: 125, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 0, name: a}
+                  Variable: {subprogram: 125, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 1, name: b}
+                  Variable: {subprogram: 125, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 2, name: c}
+                  Variable: {subprogram: 125, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
+                  Variable: {subprogram: 125, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 125, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -13732,8 +13652,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: i
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13741,9 +13661,89 @@ Types:
                   Variable: {subprogram: 125, index: 8, name: i}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 77
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 125, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: i
           Offset: 141
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -13775,7 +13775,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
@@ -13785,7 +13785,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 192 GoMapType map[[4]string][2]int
             Operations:
@@ -13801,7 +13801,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13811,7 +13811,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13827,7 +13827,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
@@ -13837,7 +13837,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 244 GoMapType map[struct {}]struct {}
             Operations:
@@ -13853,7 +13853,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 234 GoMapType map[struct {}]int
             Operations:
@@ -13863,7 +13863,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 234 GoMapType map[struct {}]int
             Operations:
@@ -13879,7 +13879,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 239 GoMapType map[int]struct {}
             Operations:
@@ -13889,7 +13889,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 239 GoMapType map[int]struct {}
             Operations:
@@ -13905,7 +13905,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 172 GoMapType map[int]int
             Operations:
@@ -13915,7 +13915,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 172 GoMapType map[int]int
             Operations:
@@ -13931,7 +13931,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
@@ -13941,7 +13941,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 229 GoMapType map[[4]int][4]int
             Operations:
@@ -13957,7 +13957,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
@@ -13967,7 +13967,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 224 GoMapType map[[4]int]uint8
             Operations:
@@ -13983,7 +13983,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -13993,7 +13993,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14009,7 +14009,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14019,7 +14019,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 199 GoMapType map[string][]main.structWithMap
             Operations:
@@ -14035,7 +14035,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
@@ -14045,7 +14045,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 219 GoMapType map[uint8][4]int
             Operations:
@@ -14061,7 +14061,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14071,7 +14071,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14087,7 +14087,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -14097,7 +14097,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -14113,7 +14113,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 187 GoMapType map[string][]string
             Operations:
@@ -14123,7 +14123,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 187 GoMapType map[string][]string
             Operations:
@@ -14139,7 +14139,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 177 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14149,7 +14149,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 177 GoMapType map[string]main.nestedStruct
             Operations:
@@ -14165,7 +14165,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 204 GoMapType map[bool]main.node
             Operations:
@@ -14175,7 +14175,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 204 GoMapType map[bool]main.node
             Operations:
@@ -14191,7 +14191,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14201,7 +14201,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14217,7 +14217,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14227,7 +14227,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 214 GoMapType map[uint8]uint8
             Operations:
@@ -14243,7 +14243,7 @@ Types:
       Expressions:
         - Name: redactMyEntries
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14253,7 +14253,7 @@ Types:
                   ByteSize: 8
         - Name: redactMyEntries
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14269,7 +14269,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14279,7 +14279,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 209 GoMapType map[int]uint8
             Operations:
@@ -14295,7 +14295,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14305,7 +14305,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14321,7 +14321,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14331,7 +14331,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14347,7 +14347,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 5
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14355,148 +14355,68 @@ Types:
                   Variable: {subprogram: 126, index: 0, name: a}
                   Offset: 0
                   ByteSize: 8
-        - Name: a
+        - Name: b
           Offset: 13
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 0, name: a}
+                  Variable: {subprogram: 126, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: c
           Offset: 21
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 2, name: c}
                   Offset: 0
                   ByteSize: 8
-        - Name: b
+        - Name: d
           Offset: 29
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 1, name: b}
+                  Variable: {subprogram: 126, index: 3, name: d}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: e
           Offset: 37
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 4, name: e}
                   Offset: 0
                   ByteSize: 8
-        - Name: c
+        - Name: f
           Offset: 45
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 2, name: c}
+                  Variable: {subprogram: 126, index: 5, name: f}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: g
           Offset: 53
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
+                  Variable: {subprogram: 126, index: 6, name: g}
                   Offset: 0
                   ByteSize: 8
-        - Name: d
+        - Name: h
           Offset: 61
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 69
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: e
-          Offset: 77
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 4, name: e}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 85
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: f
-          Offset: 93
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 5, name: f}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 101
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: g
-          Offset: 109
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 6, name: g}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 117
-          Kind: argument
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 126, index: 7, name: h}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: h
-          Offset: 125
           Kind: template_segment
           Expression:
             Type: 7 BaseType int
@@ -14506,8 +14426,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: s
-          Offset: 133
-          Kind: argument
+          Offset: 69
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14515,9 +14435,89 @@ Types:
                   Variable: {subprogram: 126, index: 8, name: s}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 85
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: b
+          Offset: 93
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: c
+          Offset: 101
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: d
+          Offset: 109
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: e
+          Offset: 117
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 4, name: e}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: f
+          Offset: 125
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 5, name: f}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: g
+          Offset: 133
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 6, name: g}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: h
+          Offset: 141
+          Kind: argument
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 126, index: 7, name: h}
+                  Offset: 0
+                  ByteSize: 8
         - Name: s
           Offset: 149
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -14549,16 +14549,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 119 ArrayType [2]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 128, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 119 ArrayType [2]int
@@ -14568,8 +14558,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -14577,9 +14567,19 @@ Types:
                   Variable: {subprogram: 128, index: 1, name: b}
                   Offset: 0
                   ByteSize: 24
+        - Name: a
+          Offset: 41
+          Kind: argument
+          Expression:
+            Type: 119 ArrayType [2]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 128, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
         - Name: b
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 257 ArrayType [3]int
             Operations:
@@ -14621,16 +14621,6 @@ Types:
       Expressions:
         - Name: s1
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 256 StructureType main.largeStruct
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 124, index: 0, name: s1}
-                  Offset: 0
-                  ByteSize: 80
-        - Name: s1
-          Offset: 81
           Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
@@ -14640,8 +14630,8 @@ Types:
                   Offset: 0
                   ByteSize: 80
         - Name: s2
-          Offset: 161
-          Kind: argument
+          Offset: 81
+          Kind: template_segment
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -14649,9 +14639,19 @@ Types:
                   Variable: {subprogram: 124, index: 1, name: s2}
                   Offset: 0
                   ByteSize: 80
+        - Name: s1
+          Offset: 161
+          Kind: argument
+          Expression:
+            Type: 256 StructureType main.largeStruct
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 124, index: 0, name: s1}
+                  Offset: 0
+                  ByteSize: 80
         - Name: s2
           Offset: 241
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 256 StructureType main.largeStruct
             Operations:
@@ -14683,7 +14683,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14693,7 +14693,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14709,7 +14709,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14739,7 +14739,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14829,7 +14829,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 2
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14847,9 +14847,29 @@ Types:
                   Variable: {subprogram: 105, index: 1, name: result}
                   Offset: 0
                   ByteSize: 8
-        - Name: result
+        - Name: result2
           Offset: 18
           Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result2
+          Offset: 26
+          Kind: template_segment
+          Expression:
+            Type: 7 BaseType int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 105, index: 2, name: result2}
+                  Offset: 0
+                  ByteSize: 8
+        - Name: result
+          Offset: 34
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14858,28 +14878,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: result2
-          Offset: 26
-          Kind: local
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
-          Offset: 34
-          Kind: template_segment
-          Expression:
-            Type: 7 BaseType int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 105, index: 2, name: result2}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: result2
           Offset: 42
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -14973,7 +14973,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 3
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -14981,48 +14981,18 @@ Types:
                   Variable: {subprogram: 86, index: 0, name: a}
                   Offset: 0
                   ByteSize: 1
-        - Name: a
+        - Name: b
           Offset: 4
           Kind: template_segment
           Expression:
-            Type: 4 BaseType bool
+            Type: 3 BaseType uint8
             Operations:
                 - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 0, name: a}
+                  Variable: {subprogram: 86, index: 1, name: b}
                   Offset: 0
                   ByteSize: 1
-        - Name: b
+        - Name: c
           Offset: 5
-          Kind: argument
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: b
-          Offset: 6
-          Kind: template_segment
-          Expression:
-            Type: 3 BaseType uint8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: c
-          Offset: 7
-          Kind: argument
-          Expression:
-            Type: 12 BaseType int32
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 2, name: c}
-                  Offset: 0
-                  ByteSize: 4
-        - Name: c
-          Offset: 11
           Kind: template_segment
           Expression:
             Type: 12 BaseType int32
@@ -15032,17 +15002,7 @@ Types:
                   Offset: 0
                   ByteSize: 4
         - Name: d
-          Offset: 15
-          Kind: argument
-          Expression:
-            Type: 11 BaseType uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 86, index: 3, name: d}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: d
-          Offset: 23
+          Offset: 9
           Kind: template_segment
           Expression:
             Type: 11 BaseType uint
@@ -15052,8 +15012,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: e
-          Offset: 31
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -15061,9 +15021,49 @@ Types:
                   Variable: {subprogram: 86, index: 4, name: e}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 4 BaseType bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: b
+          Offset: 34
+          Kind: argument
+          Expression:
+            Type: 3 BaseType uint8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: c
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 12 BaseType int32
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 2, name: c}
+                  Offset: 0
+                  ByteSize: 4
+        - Name: d
+          Offset: 39
+          Kind: argument
+          Expression:
+            Type: 11 BaseType uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 86, index: 3, name: d}
+                  Offset: 0
+                  ByteSize: 8
         - Name: e
           Offset: 47
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -15079,7 +15079,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15089,7 +15089,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15105,7 +15105,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15115,7 +15115,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15147,7 +15147,7 @@ Types:
       Expressions:
         - Name: result
           Offset: 1
-          Kind: local
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15157,7 +15157,7 @@ Types:
                   ByteSize: 8
         - Name: result
           Offset: 9
-          Kind: template_segment
+          Kind: local
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15173,7 +15173,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 323 PointerType *main.anotherStruct
             Operations:
@@ -15183,7 +15183,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 323 PointerType *main.anotherStruct
             Operations:
@@ -15246,16 +15246,6 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 10 PointerType *bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 95, index: 0, name: z}
-                  Offset: 0
-                  ByteSize: 8
-        - Name: z
-          Offset: 9
           Kind: template_segment
           Expression:
             Type: 10 PointerType *bool
@@ -15265,8 +15255,8 @@ Types:
                   Offset: 0
                   ByteSize: 8
         - Name: a
-          Offset: 17
-          Kind: argument
+          Offset: 9
+          Kind: template_segment
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -15274,9 +15264,19 @@ Types:
                   Variable: {subprogram: 95, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: z
+          Offset: 17
+          Kind: argument
+          Expression:
+            Type: 10 PointerType *bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 95, index: 0, name: z}
+                  Offset: 0
+                  ByteSize: 8
         - Name: a
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -15292,16 +15292,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 136, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -15311,8 +15301,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15320,9 +15310,19 @@ Types:
                   Variable: {subprogram: 136, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 136, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15338,16 +15338,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 19 BaseType int8
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 1
-        - Name: a
-          Offset: 3
           Kind: template_segment
           Expression:
             Type: 19 BaseType int8
@@ -15357,17 +15347,7 @@ Types:
                   Offset: 0
                   ByteSize: 1
         - Name: s
-          Offset: 4
-          Kind: argument
-          Expression:
-            Type: 270 GoSliceHeaderType []bool
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 138, index: 1, name: s}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: s
-          Offset: 28
+          Offset: 3
           Kind: template_segment
           Expression:
             Type: 270 GoSliceHeaderType []bool
@@ -15377,8 +15357,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: x
-          Offset: 52
-          Kind: argument
+          Offset: 27
+          Kind: template_segment
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -15386,9 +15366,29 @@ Types:
                   Variable: {subprogram: 138, index: 2, name: x}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 35
+          Kind: argument
+          Expression:
+            Type: 19 BaseType int8
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 1
+        - Name: s
+          Offset: 36
+          Kind: argument
+          Expression:
+            Type: 270 GoSliceHeaderType []bool
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 138, index: 1, name: s}
+                  Offset: 0
+                  ByteSize: 24
         - Name: x
           Offset: 60
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -15404,7 +15404,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
@@ -15414,7 +15414,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 271 GoSliceHeaderType []uint16
             Operations:
@@ -15430,7 +15430,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
@@ -15440,7 +15440,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 276 PointerType *main.oneStringStruct
             Operations:
@@ -15456,7 +15456,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 253 PointerType *main.node
             Operations:
@@ -15466,7 +15466,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 253 PointerType *main.node
             Operations:
@@ -15482,7 +15482,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 198 PointerType *map[string]int
             Operations:
@@ -15492,7 +15492,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 198 PointerType *map[string]int
             Operations:
@@ -15508,7 +15508,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
@@ -15518,7 +15518,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 250 PointerType *main.structWithTwoValues
             Operations:
@@ -15534,16 +15534,6 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 163 GoEmptyInterfaceType interface {}
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 101, index: 0, name: v}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: v
-          Offset: 17
           Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
@@ -15553,8 +15543,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: failed
-          Offset: 33
-          Kind: argument
+          Offset: 17
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15562,9 +15552,19 @@ Types:
                   Variable: {subprogram: 101, index: 1, name: failed}
                   Offset: 0
                   ByteSize: 1
+        - Name: v
+          Offset: 18
+          Kind: argument
+          Expression:
+            Type: 163 GoEmptyInterfaceType interface {}
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 101, index: 0, name: v}
+                  Offset: 0
+                  ByteSize: 16
         - Name: failed
           Offset: 34
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15606,7 +15606,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -15616,7 +15616,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -15862,7 +15862,7 @@ Types:
       Expressions:
         - Name: failed
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15872,7 +15872,7 @@ Types:
                   ByteSize: 1
         - Name: failed
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -15904,7 +15904,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15914,7 +15914,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15956,7 +15956,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15966,7 +15966,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -15998,7 +15998,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16008,7 +16008,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16040,7 +16040,7 @@ Types:
       Expressions:
         - Name: v
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -16050,7 +16050,7 @@ Types:
                   ByteSize: 16
         - Name: v
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 163 GoEmptyInterfaceType interface {}
             Operations:
@@ -16533,7 +16533,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -16543,7 +16543,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 ArrayType [2]int32
             Operations:
@@ -16559,7 +16559,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16569,7 +16569,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 4 BaseType bool
             Operations:
@@ -16585,7 +16585,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16595,7 +16595,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16617,7 +16617,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 102 BaseType int16
             Operations:
@@ -16627,7 +16627,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 102 BaseType int16
             Operations:
@@ -16643,7 +16643,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16653,7 +16653,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16669,7 +16669,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16679,7 +16679,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 13 BaseType int64
             Operations:
@@ -16695,7 +16695,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 19 BaseType int8
             Operations:
@@ -16725,7 +16725,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 4
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 19 BaseType int8
             Operations:
@@ -16741,7 +16741,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16751,7 +16751,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -16767,7 +16767,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16777,7 +16777,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 12 BaseType int32
             Operations:
@@ -16793,7 +16793,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16803,7 +16803,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -16819,7 +16819,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16829,7 +16829,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 6 BaseType uint16
             Operations:
@@ -16845,7 +16845,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16855,7 +16855,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 2 BaseType uint32
             Operations:
@@ -16871,7 +16871,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16881,7 +16881,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 8 BaseType uint64
             Operations:
@@ -16897,7 +16897,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16907,7 +16907,7 @@ Types:
                   ByteSize: 1
         - Name: x
           Offset: 2
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 3 BaseType uint8
             Operations:
@@ -16923,7 +16923,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -16933,7 +16933,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 11 BaseType uint
             Operations:
@@ -16949,7 +16949,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
@@ -16959,7 +16959,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 272 GoSliceHeaderType []struct {}
             Operations:
@@ -16975,7 +16975,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
@@ -16985,7 +16985,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 264 GoSliceHeaderType [][]uint
             Operations:
@@ -17001,7 +17001,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -17011,7 +17011,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 182 GoMapType map[string]int
             Operations:
@@ -17027,7 +17027,7 @@ Types:
       Expressions:
         - Name: i
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17037,7 +17037,7 @@ Types:
                   ByteSize: 8
         - Name: i
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17089,7 +17089,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -17099,7 +17099,7 @@ Types:
                   ByteSize: 40
         - Name: arg
           Offset: 41
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 167 ArrayType [5]int
             Operations:
@@ -17151,7 +17151,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -17161,7 +17161,7 @@ Types:
                   ByteSize: 32
         - Name: x
           Offset: 33
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 117 ArrayType [2]string
             Operations:
@@ -17177,7 +17177,7 @@ Types:
       Expressions:
         - Name: z
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 101 PointerType *string
             Operations:
@@ -17187,7 +17187,7 @@ Types:
                   ByteSize: 8
         - Name: z
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 101 PointerType *string
             Operations:
@@ -17203,7 +17203,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 269 GoSliceHeaderType []string
             Operations:
@@ -17213,7 +17213,7 @@ Types:
                   ByteSize: 24
         - Name: s
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 269 GoSliceHeaderType []string
             Operations:
@@ -17229,7 +17229,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 157 PointerType *main.stringType1
             Operations:
@@ -17239,7 +17239,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 157 PointerType *main.stringType1
             Operations:
@@ -17255,7 +17255,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 159 PointerType **main.stringType2
             Operations:
@@ -17265,7 +17265,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 159 PointerType **main.stringType2
             Operations:
@@ -17281,16 +17281,6 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 266 GoSliceHeaderType []main.structWithNoStrings
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 134, index: 0, name: xs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: xs
-          Offset: 25
           Kind: template_segment
           Expression:
             Type: 266 GoSliceHeaderType []main.structWithNoStrings
@@ -17300,8 +17290,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: a
-          Offset: 49
-          Kind: argument
+          Offset: 25
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17309,9 +17299,19 @@ Types:
                   Variable: {subprogram: 134, index: 1, name: a}
                   Offset: 0
                   ByteSize: 8
+        - Name: xs
+          Offset: 33
+          Kind: argument
+          Expression:
+            Type: 266 GoSliceHeaderType []main.structWithNoStrings
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 134, index: 0, name: xs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: a
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -17327,7 +17327,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 170 StructureType main.structWithAny
             Operations:
@@ -17337,7 +17337,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 170 StructureType main.structWithAny
             Operations:
@@ -17353,7 +17353,7 @@ Types:
       Expressions:
         - Name: arg
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 262 StructureType main.structWithArray
             Operations:
@@ -17363,7 +17363,7 @@ Types:
                   ByteSize: 24
         - Name: arg
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 262 StructureType main.structWithArray
             Operations:
@@ -17405,7 +17405,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
@@ -17415,7 +17415,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 291 StructureType main.structWithCyclicMaps
             Operations:
@@ -17431,7 +17431,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
@@ -17441,7 +17441,7 @@ Types:
                   ByteSize: 144
         - Name: a
           Offset: 145
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 278 StructureType main.structWithCyclicSlices
             Operations:
@@ -17457,7 +17457,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 171 StructureType main.structWithMap
             Operations:
@@ -17467,7 +17467,7 @@ Types:
                   ByteSize: 8
         - Name: s
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 171 StructureType main.structWithMap
             Operations:
@@ -17499,7 +17499,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 322 StructureType main.aStruct
             Operations:
@@ -17509,7 +17509,7 @@ Types:
                   ByteSize: 56
         - Name: x
           Offset: 57
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 322 StructureType main.aStruct
             Operations:
@@ -17525,16 +17525,6 @@ Types:
       Expressions:
         - Name: as
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 0, name: as}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: as
-          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17544,17 +17534,7 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: bs
-          Offset: 50
-          Kind: argument
-          Expression:
-            Type: 263 GoSliceHeaderType []uint
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 142, index: 1, name: bs}
-                  Offset: 0
-                  ByteSize: 24
-        - Name: bs
-          Offset: 74
+          Offset: 26
           Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
@@ -17564,8 +17544,8 @@ Types:
                   Offset: 0
                   ByteSize: 24
         - Name: cs
-          Offset: 98
-          Kind: argument
+          Offset: 50
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17573,9 +17553,29 @@ Types:
                   Variable: {subprogram: 142, index: 2, name: cs}
                   Offset: 0
                   ByteSize: 24
+        - Name: as
+          Offset: 74
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 0, name: as}
+                  Offset: 0
+                  ByteSize: 24
+        - Name: bs
+          Offset: 98
+          Kind: argument
+          Expression:
+            Type: 263 GoSliceHeaderType []uint
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 142, index: 1, name: bs}
+                  Offset: 0
+                  ByteSize: 24
         - Name: cs
           Offset: 122
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -17591,16 +17591,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: a
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17610,17 +17600,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: b
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 152, index: 1, name: b}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: b
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17630,8 +17610,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: c
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17639,9 +17619,29 @@ Types:
                   Variable: {subprogram: 152, index: 2, name: c}
                   Offset: 0
                   ByteSize: 16
+        - Name: a
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: b
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 152, index: 1, name: b}
+                  Offset: 0
+                  ByteSize: 16
         - Name: c
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17673,7 +17673,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
@@ -17683,7 +17683,7 @@ Types:
                   ByteSize: 8
         - Name: a
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 275 PointerType *main.threeStringStruct
             Operations:
@@ -17744,7 +17744,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 274 StructureType main.threeStringStruct
             Operations:
@@ -17754,7 +17754,7 @@ Types:
                   ByteSize: 48
         - Name: a
           Offset: 49
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 274 StructureType main.threeStringStruct
             Operations:
@@ -17806,16 +17806,6 @@ Types:
       Expressions:
         - Name: x
           Offset: 2
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 0, name: x}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: x
-          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17825,17 +17815,7 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: y
-          Offset: 34
-          Kind: argument
-          Expression:
-            Type: 9 GoStringHeaderType string
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 145, index: 1, name: y}
-                  Offset: 0
-                  ByteSize: 16
-        - Name: y
-          Offset: 50
+          Offset: 18
           Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
@@ -17845,8 +17825,8 @@ Types:
                   Offset: 0
                   ByteSize: 16
         - Name: z
-          Offset: 66
-          Kind: argument
+          Offset: 34
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17854,9 +17834,29 @@ Types:
                   Variable: {subprogram: 145, index: 2, name: z}
                   Offset: 0
                   ByteSize: 16
+        - Name: x
+          Offset: 50
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 0, name: x}
+                  Offset: 0
+                  ByteSize: 16
+        - Name: y
+          Offset: 66
+          Kind: argument
+          Expression:
+            Type: 9 GoStringHeaderType string
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 145, index: 1, name: y}
+                  Offset: 0
+                  ByteSize: 16
         - Name: z
           Offset: 82
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -17872,7 +17872,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 133 BaseType main.typeAlias
             Operations:
@@ -17882,7 +17882,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 133 BaseType main.typeAlias
             Operations:
@@ -17898,7 +17898,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 124 ArrayType [2]uint16
             Operations:
@@ -17908,7 +17908,7 @@ Types:
                   ByteSize: 4
         - Name: x
           Offset: 5
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 124 ArrayType [2]uint16
             Operations:
@@ -17924,7 +17924,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 125 ArrayType [2]uint32
             Operations:
@@ -17934,7 +17934,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 125 ArrayType [2]uint32
             Operations:
@@ -17950,7 +17950,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 58 ArrayType [2]uint64
             Operations:
@@ -17960,7 +17960,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 58 ArrayType [2]uint64
             Operations:
@@ -17976,7 +17976,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -17986,7 +17986,7 @@ Types:
                   ByteSize: 2
         - Name: x
           Offset: 3
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 115 ArrayType [2]uint8
             Operations:
@@ -18002,7 +18002,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 123 ArrayType [2]uint
             Operations:
@@ -18012,7 +18012,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 123 ArrayType [2]uint
             Operations:
@@ -18028,7 +18028,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 112 PointerType *uint
             Operations:
@@ -18038,7 +18038,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 112 PointerType *uint
             Operations:
@@ -18054,7 +18054,7 @@ Types:
       Expressions:
         - Name: u
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18064,7 +18064,7 @@ Types:
                   ByteSize: 24
         - Name: u
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18080,7 +18080,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18090,7 +18090,7 @@ Types:
                   ByteSize: 16
         - Name: x
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -18106,7 +18106,7 @@ Types:
       Expressions:
         - Name: x
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
@@ -18116,7 +18116,7 @@ Types:
                   ByteSize: 8
         - Name: x
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 16 VoidPointerType unsafe.Pointer
             Operations:
@@ -18132,7 +18132,7 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 ArrayType [100]uint
             Operations:
@@ -18142,7 +18142,7 @@ Types:
                   ByteSize: 800
         - Name: a
           Offset: 801
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 ArrayType [100]uint
             Operations:
@@ -18158,7 +18158,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18168,7 +18168,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18184,7 +18184,7 @@ Types:
       Expressions:
         - Name: xs
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18194,7 +18194,7 @@ Types:
                   ByteSize: 24
         - Name: xs
           Offset: 25
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 263 GoSliceHeaderType []uint
             Operations:
@@ -18210,16 +18210,6 @@ Types:
       Expressions:
         - Name: a
           Offset: 1
-          Kind: argument
-          Expression:
-            Type: 259 ArrayType [0]int
-            Operations:
-                - __kind: LocationOp
-                  Variable: {subprogram: 130, index: 0, name: a}
-                  Offset: 0
-                  ByteSize: 0
-        - Name: a
-          Offset: 1
           Kind: template_segment
           Expression:
             Type: 259 ArrayType [0]int
@@ -18230,7 +18220,7 @@ Types:
                   ByteSize: 0
         - Name: b
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 7 BaseType int
             Operations:
@@ -18238,9 +18228,19 @@ Types:
                   Variable: {subprogram: 130, index: 1, name: b}
                   Offset: 0
                   ByteSize: 8
+        - Name: a
+          Offset: 9
+          Kind: argument
+          Expression:
+            Type: 259 ArrayType [0]int
+            Operations:
+                - __kind: LocationOp
+                  Variable: {subprogram: 130, index: 0, name: a}
+                  Offset: 0
+                  ByteSize: 0
         - Name: b
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 7 BaseType int
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.23.11.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4274,7 +4274,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4284,7 +4284,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4316,7 +4316,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 GoMapType map[string]main.bigStruct
             Operations:
@@ -4326,7 +4326,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]main.bigStruct
             Operations:
@@ -6375,7 +6375,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 GoMapType map[string]int
             Operations:
@@ -6385,7 +6385,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 GoMapType map[string]int
             Operations:
@@ -6429,7 +6429,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -6439,7 +6439,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.24.3.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4312,7 +4312,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 PointerType *****int
             Operations:
@@ -4322,7 +4322,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 PointerType *****int
             Operations:
@@ -4354,7 +4354,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 GoMapType map[string]main.bigStruct
             Operations:
@@ -4364,7 +4364,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 GoMapType map[string]main.bigStruct
             Operations:
@@ -6413,7 +6413,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 GoMapType map[string]int
             Operations:
@@ -6423,7 +6423,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 GoMapType map[string]int
             Operations:
@@ -6467,7 +6467,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6477,7 +6477,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.25.0.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4324,7 +4324,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4334,7 +4334,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4366,7 +4366,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 GoMapType map[string]main.bigStruct
             Operations:
@@ -4376,7 +4376,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 GoMapType map[string]main.bigStruct
             Operations:
@@ -6425,7 +6425,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 GoMapType map[string]int
             Operations:
@@ -6435,7 +6435,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]int
             Operations:
@@ -6479,7 +6479,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6489,7 +6489,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=amd64,toolchain=go1.26rc1.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4398,7 +4398,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 137 PointerType *****int
             Operations:
@@ -4408,7 +4408,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 137 PointerType *****int
             Operations:
@@ -4440,7 +4440,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 GoMapType map[string]main.bigStruct
             Operations:
@@ -4450,7 +4450,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 GoMapType map[string]main.bigStruct
             Operations:
@@ -6499,7 +6499,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 GoMapType map[string]int
             Operations:
@@ -6509,7 +6509,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 GoMapType map[string]int
             Operations:
@@ -6553,7 +6553,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6563,7 +6563,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.23.11.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4274,7 +4274,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4284,7 +4284,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4316,7 +4316,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 GoMapType map[string]main.bigStruct
             Operations:
@@ -4326,7 +4326,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]main.bigStruct
             Operations:
@@ -6375,7 +6375,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 104 GoMapType map[string]int
             Operations:
@@ -6385,7 +6385,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 104 GoMapType map[string]int
             Operations:
@@ -6429,7 +6429,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:
@@ -6439,7 +6439,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 10 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.24.3.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4312,7 +4312,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 130 PointerType *****int
             Operations:
@@ -4322,7 +4322,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 130 PointerType *****int
             Operations:
@@ -4354,7 +4354,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 114 GoMapType map[string]main.bigStruct
             Operations:
@@ -4364,7 +4364,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 114 GoMapType map[string]main.bigStruct
             Operations:
@@ -6413,7 +6413,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 109 GoMapType map[string]int
             Operations:
@@ -6423,7 +6423,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 109 GoMapType map[string]int
             Operations:
@@ -6467,7 +6467,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6477,7 +6477,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.25.0.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4330,7 +4330,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4340,7 +4340,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 132 PointerType *****int
             Operations:
@@ -4372,7 +4372,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 GoMapType map[string]main.bigStruct
             Operations:
@@ -4382,7 +4382,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 GoMapType map[string]main.bigStruct
             Operations:
@@ -6431,7 +6431,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 111 GoMapType map[string]int
             Operations:
@@ -6441,7 +6441,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 111 GoMapType map[string]int
             Operations:
@@ -6485,7 +6485,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6495,7 +6495,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:

--- a/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
+++ b/pkg/dyninst/irgen/testdata/snapshot/simple.arch=arm64,toolchain=go1.26rc1.yaml
@@ -21,7 +21,7 @@ Probes:
             - JSON: {Ref: ptr}
               DSL: ptr
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: PointerSmallChainArg
       version: 0
       type: LOG_PROBE
@@ -60,7 +60,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: condBool_cond_false
       version: 0
       type: LOG_PROBE
@@ -2764,7 +2764,7 @@ Probes:
             - JSON: {Ref: m}
               DSL: m
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: noArgs
       version: 0
       type: LOG_PROBE
@@ -2806,7 +2806,7 @@ Probes:
             - JSON: {Ref: s}
               DSL: s
               EventKind: Entry
-              EventExpressionIndex: 1
+              EventExpressionIndex: 0
     - id: stringArrayArg
       version: 0
       type: LOG_PROBE
@@ -4410,7 +4410,7 @@ Types:
       Expressions:
         - Name: ptr
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 137 PointerType *****int
             Operations:
@@ -4420,7 +4420,7 @@ Types:
                   ByteSize: 8
         - Name: ptr
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 137 PointerType *****int
             Operations:
@@ -4452,7 +4452,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 121 GoMapType map[string]main.bigStruct
             Operations:
@@ -4462,7 +4462,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 121 GoMapType map[string]main.bigStruct
             Operations:
@@ -6511,7 +6511,7 @@ Types:
       Expressions:
         - Name: m
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 116 GoMapType map[string]int
             Operations:
@@ -6521,7 +6521,7 @@ Types:
                   ByteSize: 8
         - Name: m
           Offset: 9
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 116 GoMapType map[string]int
             Operations:
@@ -6565,7 +6565,7 @@ Types:
       Expressions:
         - Name: s
           Offset: 1
-          Kind: argument
+          Kind: template_segment
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:
@@ -6575,7 +6575,7 @@ Types:
                   ByteSize: 16
         - Name: s
           Offset: 17
-          Kind: template_segment
+          Kind: argument
           Expression:
             Type: 9 GoStringHeaderType string
             Operations:


### PR DESCRIPTION
### What does this PR do?

Stable-sort analyzed expressions so template segment expressions are evaluated before snapshot (argument/local) expressions in the eBPF program. If we run out of space, we lose snapshot data below the fold rather than the user-visible log message.

### Motivation

We see ugly messages from users when the template variables are not populated due to
running out of buffer space. We should make those messages better, yes, and we should
also not run out of buffer space so easily, but also let's try not to run out of buffer space for them. 

### Describe how you validated your changes

Looked at the generated IR.

### Additional Notes

In lieu of [DEBUG-4188](https://datadoghq.atlassian.net/browse/DEBUG-4188) this is a band-aid.

[DEBUG-4188]: https://datadoghq.atlassian.net/browse/DEBUG-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ