### PR TITLE
Revert "Use nodetreemodel by default, instead of viper"

### DIFF
--- a/pkg/config/create/new.go
+++ b/pkg/config/create/new.go
@@ -58,13 +58,13 @@ func NewConfig(name string, configLib string) model.BuildableConfig {
 				if res >= 0 {
 					return nodetreemodel.NewNodeTreeConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 				}
-				return viperconfig.NewViperConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+			} else {
+				// agentVersion.CompareTo didn't parse the value, it's something else
+				log.Warnf("unrecognized value for DD_CONF_NODETREEMODEL: %s", lib)
 			}
-			// agentVersion.CompareTo didn't parse the value, it's something else
-			log.Warnf("unrecognized value for DD_CONF_NODETREEMODEL: %s", lib)
 		}
 	}
 
 	// default config implementation
-	return nodetreemodel.NewNodeTreeConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
+	return viperconfig.NewViperConfig(name, "DD", strings.NewReplacer(".", "_")) // nolint: forbidigo // legit use case
 }

--- a/pkg/config/create/new_test.go
+++ b/pkg/config/create/new_test.go
@@ -22,7 +22,7 @@ func TestCreateFromParms(t *testing.T) {
 	os.Unsetenv("DD_CONF_NODETREEMODEL")
 
 	m := NewConfig("test", "")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	m = NewConfig("test", "enable")
 	assert.Equal(t, "nodetreemodel", m.GetLibType())
@@ -34,7 +34,7 @@ func TestCreateFromParms(t *testing.T) {
 	assert.Equal(t, "tee", m.GetLibType())
 
 	m = NewConfig("test", "something invalid")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	defer func(orig string) {
 		version.AgentVersion = orig
@@ -43,7 +43,7 @@ func TestCreateFromParms(t *testing.T) {
 	version.AgentVersion = "7.75.2"
 
 	m = NewConfig("test", "7.75")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	m = NewConfig("test", "7.76.0")
 	assert.Equal(t, "viper", m.GetLibType())
@@ -70,7 +70,7 @@ func TestCreateFromEnv(t *testing.T) {
 	os.Unsetenv("DD_CONF_NODETREEMODEL")
 
 	m := NewConfig("test", "")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "enable")
 	m = NewConfig("test", "")
@@ -86,7 +86,7 @@ func TestCreateFromEnv(t *testing.T) {
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "something invalid")
 	m = NewConfig("test", "")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	defer func(orig string) {
 		version.AgentVersion = orig
@@ -96,7 +96,7 @@ func TestCreateFromEnv(t *testing.T) {
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "7.75")
 	m = NewConfig("test", "")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "7.76.0")
 	m = NewConfig("test", "")
@@ -108,7 +108,7 @@ func TestCreateFromEnv(t *testing.T) {
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "7.80")
 	m = NewConfig("test", "")
-	assert.Equal(t, "nodetreemodel", m.GetLibType())
+	assert.Equal(t, "viper", m.GetLibType())
 
 	t.Setenv("DD_CONF_NODETREEMODEL", "6.80.0")
 	m = NewConfig("test", "")


### PR DESCRIPTION
Reverts DataDog/datadog-agent#48242

Tentative revert to restore the `new-e2e-agent-configuration` on `main`, see errors [here](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Ajob%20%40ci.pipeline.name%3ADataDog%2Fdatadog-agent%20%40git.branch%3Amain%20%40ci.job.name%3A%22new-e2e-agent-configuration%22&agg_m=%40ci.job.name&agg_m_source=base&agg_t=cardinality&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%2C%22value%22%5D&cipipeline_explorer_sort=time%2Cdesc&colorByAttr=meta%5B%27ci.stage.name%27%5D&cols=%40git.branch%2C%40ci.status%2Ctimestamp%2C%40ci.pipeline.name%2C%40ci.stage.name%2C%40ci.job.name%2C%40duration%2C%40ci.pipeline.id%2C%40git.repository.name&currentTab=trace&fromUser=false&graphType=flamegraph&index=cipipeline&mode=sliding&sort=time&spanViewType=metadata&step=86400000&tab=overview&viz=stream&start=1769240488540&end=1774424488540&paused=false)