### PR TITLE
[observer] Log patterns example

### DIFF
--- a/cmd/agent/subcommands/extractpatterns/command.go
+++ b/cmd/agent/subcommands/extractpatterns/command.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// Package extractpatterns implements 'agent extract-patterns'.
+package extractpatterns
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/command"
+	"github.com/DataDog/datadog-agent/comp/observer/impl/patterns"
+)
+
+// Commands returns a slice of subcommands for the 'agent' command.
+func Commands(_ *command.GlobalParams) []*cobra.Command {
+	var summaryOnly bool
+
+	cmd := &cobra.Command{
+		Use:   "extract-patterns <file>",
+		Short: "Read a file line by line and print the extracted log pattern for each line",
+		Long:  `Reads a file line by line, clusters each line using the observer pattern clusterer, and prints the extracted pattern alongside the original line.`,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runExtractPatterns(args[0], summaryOnly)
+		},
+	}
+
+	cmd.Flags().BoolVar(&summaryOnly, "summary", false, "Display only patterns sorted by count (smallest to biggest)")
+
+	return []*cobra.Command{cmd}
+}
+
+func runExtractPatterns(path string, summaryOnly bool) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	clusterer := patterns.NewPatternClusterer(patterns.IDComputeInfo{
+		Offset: 0,
+		Stride: 1,
+		Index:  0,
+	})
+
+	scanner := bufio.NewScanner(f)
+	type lineResult struct {
+		line    string
+		pattern string
+	}
+	var lineResults []lineResult
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		result := clusterer.Process(line)
+		if result == nil {
+			continue
+		}
+		lineResults = append(lineResults, lineResult{line: line, pattern: result.Pattern})
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	if summaryOnly {
+		clusters := clusterer.GetClusters()
+		sort.Slice(clusters, func(i, j int) bool {
+			return clusters[i].Count < clusters[j].Count
+		})
+		for _, c := range clusters {
+			fmt.Printf("(%d) %s\n", c.Count, c.PatternString())
+		}
+		return nil
+	}
+
+	for _, lr := range lineResults {
+		fmt.Printf("Line   : %s\n", lr.line)
+		fmt.Printf("Pattern: %s\n", lr.pattern)
+		fmt.Println()
+	}
+	return nil
+}

--- a/cmd/agent/subcommands/subcommands.go
+++ b/cmd/agent/subcommands/subcommands.go
@@ -19,6 +19,7 @@ import (
 	cmddogstatsdcapture "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdcapture"
 	cmddogstatsdreplay "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdreplay"
 	cmddogstatsdstats "github.com/DataDog/datadog-agent/cmd/agent/subcommands/dogstatsdstats"
+	cmdextractpatterns "github.com/DataDog/datadog-agent/cmd/agent/subcommands/extractpatterns"
 	cmdflare "github.com/DataDog/datadog-agent/cmd/agent/subcommands/flare"
 	cmdhealth "github.com/DataDog/datadog-agent/cmd/agent/subcommands/health"
 	cmdhostname "github.com/DataDog/datadog-agent/cmd/agent/subcommands/hostname"
@@ -60,6 +61,7 @@ func AgentSubcommands() []command.SubcommandFactory {
 		cmdimport.Commands,
 		cmdlaunchgui.Commands,
 		cmdanalyzelogs.Commands,
+		cmdextractpatterns.Commands,
 		cmdremoteconfig.Commands,
 		cmdrun.Commands,
 		cmdsecret.Commands,


### PR DESCRIPTION
### What does this PR do?

This is an example of the log patterns usage.

It adds this command:

```sh
$ ./bin/agent/agent extract-patterns /tmp/patterns/logs.txt
[...]
Line   : [2026-03-25 09:55:00] DEBUG: Scheduled task 'generate_reports' started
Pattern: [*] DEBUG: Scheduled task '*' *

Line   : [2026-03-25 09:55:02] INFO: Generating daily report for 2026-03-24
Pattern: [*] INFO: Generating daily report for 2026-03-24

Line   : [2026-03-25 09:55:20] INFO: Report generated with 2912 records
Pattern: [*] INFO: Report generated with * records

Line   : [2026-03-25 09:55:21] DEBUG: Scheduled task 'generate_reports' completed
Pattern: [*] DEBUG: Scheduled task '*' *

$ ./bin/agent/agent extract-patterns --summary /tmp/patterns/logs.txt
[...]
(2) [*] INFO: Retry attempt 1/3 for payment service connection
(2) [*] ERROR: Failed to connect to payment service (timeout after 30000ms)
(3) [*] WARNING: External API response time: * (threshold: 1000ms)
(3) [*] INFO: Report generated with * records
(3) [*] INFO: Generating daily report for 2026-03-24
(3) [*] INFO: * * *
(3) [*] INFO: Synced * records successfully
(3) [*] *: * * * * * *
(4) [*] WARNING: Memory usage at *% of allocated heap
(4) [*] INFO: * * * * *
(4) [*] INFO: * * * *
(6) [*] INFO: Removed * expired sessions from cache
(20) [*] INFO: * * - * * (*)
(24) [*] DEBUG: Scheduled task '*' *
```

### Motivation

### Describe how you validated your changes

### Additional Notes
