### PR TITLE
Add (experimental) ability to run agent.build against locally bazel-built rtloader

### DIFF
--- a/deps/bzip2/overlay.BUILD.bazel
+++ b/deps/bzip2/overlay.BUILD.bazel
@@ -153,7 +153,7 @@ pkg_filegroup(
         ":lib_files",
     ],
     prefix = "embedded",
-    visibility = ["@@//deps/openscap:__pkg__", "@@//packages:__subpackages__"],
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -465,6 +465,7 @@ pkg_filegroup(
         "@platforms//os:windows": "embedded3",
         "//conditions:default": "embedded",
     }),
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/deps/sqlite3.BUILD.bazel
+++ b/deps/sqlite3.BUILD.bazel
@@ -57,6 +57,7 @@ pkg_filegroup(
         ":lib_files",
     ],
     prefix = "embedded",
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/deps/xz.BUILD.bazel
+++ b/deps/xz.BUILD.bazel
@@ -144,6 +144,7 @@ pkg_filegroup(
         ":lib_files",
     ],
     prefix = "embedded",
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/deps/zlib.BUILD.bazel
+++ b/deps/zlib.BUILD.bazel
@@ -145,6 +145,7 @@ pkg_filegroup(
         ":lib_files",
     ],
     prefix = "embedded",
+    visibility = ["//visibility:public"],
 )
 
 pkg_install(

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -80,13 +80,13 @@ build do
     if not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}/bin/agent\""
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}"
     # Put the static rtloader library where it gets picked up by the go build linking to it
     command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install_static --destdir=\"#{project_dir}/rtloader/build/rtloader\""
     command "dda inv -- -e agent.build --exclude-rtloader --no-development --install-path=#{install_dir} --embedded-path=#{install_dir}/embedded #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env, :live_stream => Omnibus.logger.live_stream(:info)
     command "dda inv -- -e systray.build", env: env, :live_stream => Omnibus.logger.live_stream(:info)
   else
-    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}/embedded'"
+    command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir='#{install_dir}'"
     sh_ext = if linux_target? then "so" else "dylib" end
     command_on_repo_root "bazelisk run #{bazel_flags} -- //bazel/rules:replace_prefix" \
       " --prefix '#{install_dir}/embedded'" \

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -258,6 +258,42 @@ pkg_install(
     srcs = [":all_files"],
 )
 
+# Dev-only: installs rtloader + the full Python environment (CPython + deps) in one shot.
+# Used by the invoke tasks instead of separate per-dependency bazel run calls.
+pkg_filegroup(
+    name = "rtloader_files_embedded",
+    srcs = [":all_files"],
+    prefix = "embedded",
+)
+
+# OpenSSL shared libs only — exclude headers to avoid conflict with CPython's include/.
+pkg_filegroup(
+    name = "openssl_libs_embedded",
+    srcs = [
+        "@openssl//:libssl_with_symlink",
+        "@openssl//:libcrypto_with_symlink",
+    ],
+    prefix = "embedded",
+)
+
+pkg_filegroup(
+    name = "python_env_files",
+    srcs = [
+        ":rtloader_files_embedded",
+        ":openssl_libs_embedded",
+        "@bzip2//:all_files",
+        "@sqlite3//:all_files",
+        "@xz//:all_files",
+        "@zlib//:all_files",
+        "@cpython//:all_files",
+    ],
+)
+
+pkg_install(
+    name = "install_python_env",
+    srcs = [":python_env_files"],
+)
+
 # Temporary install target meant as a way to integrate with non-bazelified Agent build
 pkg_install(
     name = "install_static",

--- a/rtloader/BUILD.bazel
+++ b/rtloader/BUILD.bazel
@@ -228,7 +228,7 @@ pkg_files(
     name = "rtloader_three_pkg_files",
     srcs = [":datadog-agent-three"],
     prefix = select({
-        "@platforms//os:windows": "",
+        "@platforms//os:windows": "bin/agent",
         "//conditions:default": "lib",
     }),
 )
@@ -250,48 +250,16 @@ pkg_filegroup(
             ":rtloader_with_symlinks",
         ],
     }),
+    prefix = select({
+        "@platforms//os:windows": "",
+        "//conditions:default": "embedded",
+    }),
     visibility = ["//packages:__subpackages__"],
 )
 
 pkg_install(
     name = "install",
     srcs = [":all_files"],
-)
-
-# Dev-only: installs rtloader + the full Python environment (CPython + deps) in one shot.
-# Used by the invoke tasks instead of separate per-dependency bazel run calls.
-pkg_filegroup(
-    name = "rtloader_files_embedded",
-    srcs = [":all_files"],
-    prefix = "embedded",
-)
-
-# OpenSSL shared libs only — exclude headers to avoid conflict with CPython's include/.
-pkg_filegroup(
-    name = "openssl_libs_embedded",
-    srcs = [
-        "@openssl//:libssl_with_symlink",
-        "@openssl//:libcrypto_with_symlink",
-    ],
-    prefix = "embedded",
-)
-
-pkg_filegroup(
-    name = "python_env_files",
-    srcs = [
-        ":rtloader_files_embedded",
-        ":openssl_libs_embedded",
-        "@bzip2//:all_files",
-        "@sqlite3//:all_files",
-        "@xz//:all_files",
-        "@zlib//:all_files",
-        "@cpython//:all_files",
-    ],
-)
-
-pkg_install(
-    name = "install_python_env",
-    srcs = [":python_env_files"],
 )
 
 # Temporary install target meant as a way to integrate with non-bazelified Agent build
@@ -306,4 +274,35 @@ pkg_files(
     renames = {
         ":rtloader_static": "libdatadog-agent-rtloader.a",
     },
+)
+
+# Dev-only: installs rtloader + the full Python environment (CPython + deps) in one shot.
+# Used by the invoke tasks instead of separate per-dependency bazel run calls.
+
+# OpenSSL shared libs only — exclude headers to avoid conflict with CPython's include/.
+pkg_filegroup(
+    name = "openssl_libs_embedded",
+    srcs = [
+        "@openssl//:libcrypto_with_symlink",
+        "@openssl//:libssl_with_symlink",
+    ],
+    prefix = "embedded",
+)
+
+pkg_filegroup(
+    name = "python_env_files",
+    srcs = [
+        ":all_files",
+        ":openssl_libs_embedded",
+        "@bzip2//:all_files",
+        "@cpython//:all_files",
+        "@sqlite3//:all_files",
+        "@xz//:all_files",
+        "@zlib//:all_files",
+    ],
+)
+
+pkg_install(
+    name = "install_python_env",
+    srcs = [":python_env_files"],
 )

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -38,6 +38,7 @@ from tasks.libs.common.utils import (
 from tasks.libs.releasing.version import create_version_json
 from tasks.rtloader import clean as rtloader_clean
 from tasks.rtloader import install as rtloader_install
+from tasks.rtloader import install_with_bazel as rtloader_install_with_bazel
 from tasks.rtloader import make as rtloader_make
 from tasks.windows_resources import build_messagetable, build_rc, versioninfo_vars
 
@@ -148,6 +149,7 @@ def build(
     agent_bin=None,
     run_on=None,  # noqa: U100, F841. Used by the run_on_devcontainer decorator
     glibc=True,
+    enable_bazel=False,
 ):
     """
     Build the agent. If the bits to include in the build are not specified,
@@ -159,11 +161,14 @@ def build(
     flavor = AgentFlavor[flavor]
 
     if not exclude_rtloader and not flavor.is_iot():
-        # If embedded_path is set, we should give it to rtloader as it should install the headers/libs
-        # in the embedded path folder because that's what is used in get_build_flags()
         with gitlab_section("Install embedded rtloader", collapsed=True):
-            rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
-            rtloader_install(ctx)
+            if enable_bazel:
+                bazel_embedded = rtloader_install_with_bazel(ctx)
+                embedded_path = bazel_embedded
+                python_home_3 = bazel_embedded
+            else:
+                rtloader_make(ctx, install_prefix=embedded_path, cmake_options=cmake_options)
+                rtloader_install(ctx)
 
     ldflags, gcflags, env = get_build_flags(
         ctx,

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -112,7 +112,13 @@ def install_with_bazel(ctx):
         bin_dir = os.path.join(os.path.dirname(os.path.abspath(dev_path)), "bin")
 
         # Put static rtloader lib where the go build expects to find it
-        bazel(ctx, "run", "//rtloader:install_static", "--", f"--destdir={os.path.join(get_rtloader_build_path(), 'rtloader')}")
+        bazel(
+            ctx,
+            "run",
+            "//rtloader:install_static",
+            "--",
+            f"--destdir={os.path.join(get_rtloader_build_path(), 'rtloader')}",
+        )
 
         # Install rtloader and cpython where the Agent expects them at runtime
         bazel(ctx, "run", "//rtloader:install", "--", f"--destdir={os.path.dirname(bin_dir)}")
@@ -133,7 +139,9 @@ def install_with_bazel(ctx):
             f"find {embedded} -type f \\( -name '*.so' -o -name '*.so.*' -o -name '*.dylib'"
             f" -o -name '*.pc' -o -path '*/bin/*' \\)",
             hide="out",
-        ).stdout.strip().split("\n")
+        )
+        .stdout.strip()
+        .split("\n")
         if f
     ]
     if files_to_patch:

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -115,7 +115,7 @@ def install_with_bazel(ctx):
         bazel(ctx, "run", "//rtloader:install_static", "--", f"--destdir={os.path.join(get_rtloader_build_path(), 'rtloader')}")
 
         # Install rtloader and cpython where the Agent expects them at runtime
-        bazel(ctx, "run", "//rtloader:install", "--", f"--destdir={os.path.join(bin_dir, 'agent')}")
+        bazel(ctx, "run", "//rtloader:install", "--", f"--destdir={os.path.dirname(bin_dir)}")
         bazel(ctx, "run", "@cpython//:install", "--", f"--destdir={bin_dir}")
 
         return os.path.join(bin_dir, "embedded3")

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -10,6 +10,7 @@ import sys
 from invoke import task
 from invoke.exceptions import Exit
 
+from tasks.libs.build.bazel import bazel
 from tasks.libs.common.utils import gitlab_section
 
 
@@ -71,15 +72,16 @@ def make(ctx, install_prefix=None, cmake_options=''):
 @task
 def clean(_):
     """
-    Clean up CMake's cache.
+    Clean up CMake's cache and Bazel install artifacts under dev/.
     Necessary when the paths to some libraries found by CMake (for example Python) have changed on the system.
     """
     dev_path = get_dev_path()
+    embedded_path = os.path.join(dev_path, "embedded")
     include_path = os.path.join(dev_path, "include")
     lib_path = os.path.join(dev_path, "lib")
     rtloader_build_path = get_rtloader_build_path()
 
-    for p in [include_path, lib_path, rtloader_build_path]:
+    for p in [embedded_path, include_path, lib_path, rtloader_build_path]:
         try:
             shutil.rmtree(p)
             print(f"Successfully cleaned '{p}'")
@@ -91,6 +93,53 @@ def clean(_):
 def install(ctx):
     with gitlab_section("Install rtloader", collapsed=True):
         run_make_command(ctx, "install")
+
+
+@task
+def install_with_bazel(ctx):
+    """
+    Install rtloader, Python, and Python's shared-library dependencies using Bazel.
+
+    This is intended for local development alongside `agent.build`, as a way to leverage Bazel
+    while we're still in a transitional stage. It installs an "embedded" environment which includes
+    Python, under `dev/embedded`.
+
+    Returns the embedded path.
+    """
+    dev_path = get_dev_path()
+
+    if sys.platform == "win32":
+        bin_dir = os.path.join(os.path.dirname(os.path.abspath(dev_path)), "bin")
+
+        # Put static rtloader lib where the go build expects to find it
+        bazel(ctx, "run", "//rtloader:install_static", "--", f"--destdir={os.path.join(get_rtloader_build_path(), 'rtloader')}")
+
+        # Install rtloader and cpython where the Agent expects them at runtime
+        bazel(ctx, "run", "//rtloader:install", "--", f"--destdir={os.path.join(bin_dir, 'agent')}")
+        bazel(ctx, "run", "@cpython//:install", "--", f"--destdir={bin_dir}")
+
+        return os.path.join(bin_dir, "embedded3")
+
+    embedded = os.path.join(dev_path, "embedded")
+
+    # Install rtloader + CPython + all Python deps
+    bazel(ctx, "run", "//rtloader:install_python_env", "--", f"--destdir={dev_path}")
+
+    # Patch RPATH in all installed binaries/libraries so they find their
+    # dependencies under <embedded>/lib at runtime.
+    files_to_patch = [
+        f
+        for f in ctx.run(
+            f"find {embedded} -type f \\( -name '*.so' -o -name '*.so.*' -o -name '*.dylib'"
+            f" -o -name '*.pc' -o -path '*/bin/*' \\)",
+            hide="out",
+        ).stdout.strip().split("\n")
+        if f
+    ]
+    if files_to_patch:
+        bazel(ctx, "run", "//bazel/rules:replace_prefix", "--", "--prefix", embedded, *files_to_patch)
+
+    return embedded
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This introduces a way to plug together the bazel-built rtloader with the existing, not-yet-bazelified, `agent.build`-driven Agent build. It adds:

- A `dda inv rtloader.install-with-bazel` command that builds rtloader and all its runtime dependencies, and puts them under the local `dev` (on linux) or under `bin`, roughly matching the expectations on a working Agent.
- A `--enable-bazel` flag to `dda inv agent.build` that will first run `rtloader.install-with-bazel` and then build the agent pointing at what bazel installed.

This includes a few extra tweaks to facilitate the installation of all the dependencies from this temporary rule.

### Motivation

Put the result of [ABLD-323](https://datadoghq.atlassian.net/browse/ABLD-323) in the hands of those that may want to try to reap some of the benefits locally. In particular, many contributors complain about problems with the linking to a python environment for rtloader when building it, which this helps with by installing one which should closely match the one used by the agent in actual builds.

### Describe how you validated your changes

I ran `agent.build --enable-bazel` on all three platforms and ran the resulting Agent without any obvious errors, and with the "python home" being properly detected.

### Additional Notes

This is opt-in behavior as there may be rough edges and we don't want to commit too much effort to making this a "blessed path", given that we're already working towards building the agent binary itself with Bazel, which would remove the need to have this kind of bridge.

We won't be able to fully deprecate CMake usage until further down the bazel migration.

---- 

The two commands can also be run separately in this sequence, such that we can just run the second one on subsequent builds:
```
dda inv rtloader.install-with-bazel
dda inv agent.build --exclude-rtloader --python-home-3=dev/embedded --embedded-path=dev/embedded
```

[ABLD-323]: https://datadoghq.atlassian.net/browse/ABLD-323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ