### PR TITLE
[SBOM] Fix getPreferredName returning sha256 ID over repo tag

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/containerd/image.go
+++ b/comp/core/workloadmeta/collectors/internal/containerd/image.go
@@ -152,16 +152,16 @@ func (images *knownImages) getRepoDigests(imageID string) []string {
 
 // getPreferredName will return a user-friendly image name if it exists, otherwise
 // for example the name not including the digest.
+// Priority: repo digest > repo tag > raw image ID (sha256:...)
 func (images *knownImages) getPreferredName(imageID string) string {
 	var res = ""
 	for ref := range images.namesByID[imageID] {
-		if res == "" && isAnImageID(ref) {
-			res = ref
-		} else if isARepoDigest(ref) {
-			res = ref // Prefer the repo digest
-			break
-		} else {
-			res = ref // Then repo tag
+		if isARepoDigest(ref) {
+			return ref // repo digest always wins
+		} else if !isAnImageID(ref) {
+			res = ref // repo tag preferred over raw image ID
+		} else if res == "" {
+			res = ref // raw image ID only if nothing better found yet
 		}
 	}
 	return res


### PR DESCRIPTION
### What does this PR do?

getPreferredName iterates a Go map (random order) to pick the best display name for a containerd image.  The old else branch unconditionally overwrote res regardless of what was already stored, so when a repo tag was visited before a sha256 image ID the sha256 would silently replace the friendlier name.

When the workloadmeta entity ends up with Name = "sha256:...", the SBOM exclude filter (e.g. image:^mcr.microsoft.com/...$) cannot match it, and scans are triggered for images that should have been skipped entirely.

Fix the priority to: repo digest > repo tag > raw image ID, ensuring a sha256 can never overwrite a better name regardless of map iteration order.

### Motivation

### Describe how you validated your changes

### Additional Notes
