### PR TITLE
[PROF-14105] Change profiler name to host-profiler

### DIFF
--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/additional-endpoints-only/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/basic-config/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/duplicate-site/otel.yaml
@@ -20,7 +20,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-add-ep/otel.yaml
@@ -20,7 +20,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/infer-dc-url/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/invalid-add-ep/otel.yaml
@@ -20,7 +20,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/multi-keys-per-ep/otel.yaml
@@ -30,7 +30,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/no-site/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/prof-dd-url-prec/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
+++ b/comp/host-profiler/collector/impl/agentprovider/td/provider/profiling-dd-url/otel.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-missing/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/add-prof-to-pipe/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-apikey/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-appkey/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/conv-nonstr-key-exp/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/create-default-prof/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ensures-headers/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/global-procs-notmap/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/headers-wrong-type/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/ignore-non-otlp/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-hostprof-recv/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-otlp-exp/out.yaml
@@ -11,7 +11,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/multi-symbol-ep/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-all-res-attrs/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-arch/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-host-name/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-os-type/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-otlp-proto/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/preserve-res-attrs-no-system/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/proc-name-similar/out.yaml
@@ -13,7 +13,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-agent-ext/out.yaml
@@ -15,7 +15,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/rm-infraattr-metrics/out.yaml
@@ -9,7 +9,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/str-key-exporter/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-disabled/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
+++ b/comp/host-profiler/collector/impl/converters/td/no_agent/symbol-up-str-keys/out.yaml
@@ -7,7 +7,7 @@ processors:
         attributes:
             - action: upsert
               key: profiler_name
-              value: full-host-profiler
+              value: host-profiler
             - action: upsert
               key: profiler_version
               value: 7.0.0-test

--- a/comp/host-profiler/version/version.go
+++ b/comp/host-profiler/version/version.go
@@ -10,6 +10,6 @@ package version
 
 import "github.com/DataDog/datadog-agent/pkg/version"
 
-const ProfilerName = "full-host-profiler"
+const ProfilerName = "host-profiler"
 
 var ProfilerVersion = version.AgentVersion


### PR DESCRIPTION
### What does this PR do?

Change profiler name to host-profiler.
Fix golden tests to match new name.

### Motivation

Adapts the profiler name to the recently chosen new name.

### Describe how you validated your changes

### Additional Notes
