### PR TITLE
fix(tasks): Echo proper name for failing security agent tasks

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -741,7 +741,7 @@ def go_generate_check(ctx):
     if failing_tasks:
         for ft in failing_tasks:
             task = ft.name.replace("_", "-")
-            print(f"Task `dda inv {task}` resulted in dirty files, please re-run it:")
+            print(f"Task `dda inv security-agent.{task}` resulted in dirty files, please re-run it:")
             for file in ft.dirty_files:
                 print(f"* {file}")
         raise Exit(code=1)


### PR DESCRIPTION
### What does this PR do?
Prints the failing security agent tasks with the correct prefix (`security-agent.<task>` instead of just `<task>`)

### Motivation
The error message and the retry instruction can be confusing, as running the suggested command does not actually work.

https://dd.slack.com/archives/C06PBHLD4DQ/p1774432686123849
### Describe how you validated your changes
Force-failing a task and checking the error message

### Additional Notes
