### PR TITLE
NDMC-234: Parallelize SNMP cache loading by probing cached devices concurrently

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -133,30 +133,40 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 		return
 	}
 
-	// Try to unmarshal with the old cache format
-	var deviceIPs []net.IP
-	err = json.Unmarshal([]byte(cacheValue), &deviceIPs)
-	if err == nil {
-		for _, deviceIP := range deviceIPs {
-			entityID := subnet.config.Digest(deviceIP.String())
-			deviceInfo := l.checkDeviceInfo(subnet.config.Authentications[0], subnet.config.Port, deviceIP.String())
-
-			l.createService(entityID, subnet, deviceIP.String(), deviceInfo, 0, 0, true)
-		}
-		return
-	}
-
 	var devices []deviceCache
-	err = json.Unmarshal([]byte(cacheValue), &devices)
-	if err != nil {
+	var deviceIPs []net.IP
+
+	// Try to unmarshal with the old cache format
+	if err = json.Unmarshal([]byte(cacheValue), &deviceIPs); err == nil {
+		for _, deviceIP := range deviceIPs {
+			devices = append(devices, deviceCache{IP: deviceIP, AuthIndex: 0})
+		}
+	} else if err = json.Unmarshal([]byte(cacheValue), &devices); err != nil {
 		log.Errorf("Couldn't unmarshal cache for %s: %s", subnet.cacheKey, err)
 		return
 	}
-	for _, device := range devices {
-		entityID := subnet.config.Digest(device.IP.String())
-		deviceInfo := l.checkDeviceInfo(subnet.config.Authentications[device.AuthIndex], subnet.config.Port, device.IP.String())
 
-		l.createService(entityID, subnet, device.IP.String(), deviceInfo, device.AuthIndex, device.Failures, true)
+	// Probe devices concurrently to collect device info
+	deviceInfos := make([]devicededuper.DeviceInfo, len(devices))
+
+	workers := l.config.Workers
+	var wg sync.WaitGroup
+	loadJob := make(chan struct{}, workers)
+	for i, device := range devices {
+		wg.Add(1)
+		loadJob <- struct{}{}
+		go func(i int, device deviceCache) {
+			defer wg.Done()
+			defer func() { <-loadJob }()
+			deviceInfos[i] = l.checkDeviceInfo(subnet.config.Authentications[device.AuthIndex], subnet.config.Port, device.IP.String())
+		}(i, device)
+	}
+	wg.Wait()
+
+	// Create services sequentially
+	for i, device := range devices {
+		entityID := subnet.config.Digest(device.IP.String())
+		l.createService(entityID, subnet, device.IP.String(), deviceInfos[i], device.AuthIndex, device.Failures, true)
 	}
 }
 
@@ -390,8 +400,6 @@ func migrateCache(config snmp.Config) string {
 }
 
 func (l *SNMPListener) checkDevices() {
-	subnets := l.initializeSubnets()
-
 	if l.config.Workers == 0 {
 		l.config.Workers = defaultWorkers
 	}
@@ -403,6 +411,8 @@ func (l *SNMPListener) checkDevices() {
 	if l.config.DiscoveryInterval == 0 {
 		l.config.DiscoveryInterval = defaultDiscoveryInterval
 	}
+
+	subnets := l.initializeSubnets()
 
 	jobs := make(chan snmpJob)
 	for w := 0; w < l.config.Workers; w++ {

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -155,6 +155,7 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 	for i, device := range devices {
 		select {
 		case <-l.stop:
+			wg.Wait()
 			return
 		case loadJob <- struct{}{}:
 		}

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -57,7 +57,7 @@ type SNMPListener struct {
 	sync.RWMutex
 	newService     chan<- Service
 	delService     chan<- Service
-	stop           chan bool
+	stop           chan struct{}
 	config         snmp.ListenerConfig
 	services       map[string]*SNMPService
 	deviceDeduper  devicededuper.DeviceDeduper
@@ -107,7 +107,7 @@ func NewSNMPListener(ServiceListernerDeps) (ServiceListener, error) {
 	}
 	return &SNMPListener{
 		services:       map[string]*SNMPService{},
-		stop:           make(chan bool),
+		stop:           make(chan struct{}),
 		config:         snmpConfig,
 		deviceDeduper:  devicededuper.NewDeviceDeduper(snmpConfig),
 		sessionFactory: newGosnmpSession,
@@ -153,11 +153,20 @@ func (l *SNMPListener) loadCache(subnet *snmpSubnet) {
 	var wg sync.WaitGroup
 	loadJob := make(chan struct{}, workers)
 	for i, device := range devices {
+		select {
+		case <-l.stop:
+			return
+		case loadJob <- struct{}{}:
+		}
 		wg.Add(1)
-		loadJob <- struct{}{}
 		go func(i int, device deviceCache) {
 			defer wg.Done()
 			defer func() { <-loadJob }()
+			select {
+			case <-l.stop:
+				return
+			default:
+			}
 			deviceInfos[i] = l.checkDeviceInfo(subnet.config.Authentications[device.AuthIndex], subnet.config.Port, device.IP.String())
 		}(i, device)
 	}
@@ -590,7 +599,7 @@ func (l *SNMPListener) deleteService(entityID string, subnet *snmpSubnet) {
 
 // Stop queues a shutdown of SNMPListener
 func (l *SNMPListener) Stop() {
-	l.stop <- true
+	close(l.stop)
 }
 
 // Equal returns whether the two SNMPService are equal

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -111,7 +111,7 @@ func TestSNMPListenerSubnets(t *testing.T) {
 	services := map[string]*SNMPService{}
 	l := &SNMPListener{
 		services:       services,
-		stop:           make(chan bool),
+		stop:           make(chan struct{}),
 		config:         snmpListenerConfig,
 		sessionFactory: newGosnmpSession,
 	}
@@ -772,7 +772,7 @@ func setupTestListener(t *testing.T, configs []interface{}, extraOpts map[string
 
 	l := &SNMPListener{
 		services:       map[string]*SNMPService{},
-		stop:           make(chan bool),
+		stop:           make(chan struct{}),
 		config:         listenerConfig,
 		deviceDeduper:  devicededuper.NewDeviceDeduper(listenerConfig),
 		sessionFactory: factory.build,


### PR DESCRIPTION
### What does this PR do?

Parallelizes the probing of cached SNMP devices when the agent starts up. Previously, `loadCache` probed each cached device sequentially; now it dispatches goroutines bounded by `config.Workers` using a semaphore, matching the concurrency model used during normal discovery.

### Motivation
On large subnets with many cached devices, the sequential probe on startup could be slow, delaying loading of previously discovered devices. Parallelizing this step reduces agent startup time proportionally to the number of cached devices.

### Describe how you validated your changes
- When testing locally, the devices should be loaded into cache normally
- Existing unit tests continue to pass

### Additional Notes
- Status delays in showing registered devices, but the devices are already registered in the backend. This is expected.