### PR TITLE
Remove bazel references on python sysconfigdata

### DIFF
--- a/bazel/rules/replace_prefix.sh
+++ b/bazel/rules/replace_prefix.sh
@@ -25,7 +25,7 @@ fi
 
 patch_text_file() {
     f="$1"
-    sed -ibak -e "s|^prefix=.*|prefix=$PREFIX|" -e "s|##PREFIX##|$PREFIX|" -e "s|\${EXT_BUILD_DEPS}|$PREFIX|" "$f" && rm -f "${f}bak"
+    sed -ibak -e "s|^prefix=.*|prefix=$PREFIX|" -e "s|##PREFIX##|$PREFIX|g" -e "s|\${EXT_BUILD_DEPS}|$PREFIX|g" "$f" && rm -f "${f}bak"
 }
 
 for f in "$@"; do
@@ -40,7 +40,7 @@ for f in "$@"; do
     fi
 
     case $f in
-        *.pc)
+        *.pc | *.py)
             patch_text_file "$f"
             ;;
         *)

--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -271,8 +271,14 @@ configure_make(
     # However, in our case, that means using tools that are stored in the build sandbox, so they aren't
     # usable when building an extension, causing all builds to fail.
     # fix_sysconfigdata.py strips sandbox-absolute paths from known tool entries (leaving just the
-    # basename so they can be found on PATH) and clears build flags that are Bazel-specific.
-    postfix_script = "$(execpath @python_3_12//:python3) $(execpath @@//deps/cpython:fix_sysconfigdata.py) $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py".format(
+    # basename so they can be found on PATH), clears build flags that are Bazel-specific, and replaces
+    # sandbox paths with their install-prefix-relative equivalents.
+    postfix_script = """
+    $(execpath @python_3_12//:python3) $(execpath @@//deps/cpython:fix_sysconfigdata.py) \
+      --install-prefix "##PREFIX##" \
+      --sandbox-prefix "$$BUILD_TMPDIR/$$INSTALL_PREFIX" \
+      $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py
+    """.format(
         version = VERSION_STR,
     ),
 )

--- a/deps/cpython/BUILD.bazel
+++ b/deps/cpython/BUILD.bazel
@@ -1,3 +1,18 @@
 """Package delimiter."""
 
+load("@rules_python//python:py_library.bzl", "py_library")
+load("@rules_python//python:py_test.bzl", "py_test")
+
 exports_files(["fix_sysconfigdata.py"])
+
+py_library(
+    name = "fix_sysconfigdata_lib",
+    srcs = ["fix_sysconfigdata.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "fix_sysconfigdata_test",
+    srcs = ["fix_sysconfigdata_test.py"],
+    deps = [":fix_sysconfigdata_lib"],
+)

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -40,7 +40,7 @@ _PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
 
 # Tokens containing these substrings are Bazel sandbox paths and should be dropped.
 # A "token" here is a maximal run of non-whitespace, non-single-quote characters.
-_BAZEL_PATH_RE = re.compile(r"[^\s']*(?:_bazel_root|bazel-out|execroot)[^\s']*\s*")
+_BAZEL_PATH_RE = re.compile(r"[^\s']*(?:_bazel_root|bazel-out|execroot)[^\s']*")
 
 
 def _fix_tool_path(segment):

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -12,6 +12,7 @@ import argparse
 import ast
 import os
 import re
+import shlex
 import sys
 
 # Names of tool to strip to their basenames
@@ -38,9 +39,8 @@ FLAGS_TO_CLEAR = frozenset(
 # Needs to account for paths being preceded by `=` or quotes.
 _PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
 
-# Tokens containing these substrings are Bazel sandbox paths and should be dropped.
-# A "token" here is a maximal run of non-whitespace, non-single-quote characters.
-_BAZEL_PATH_RE = re.compile(r"[^\s']*(?:_bazel_root|bazel-out|execroot)[^\s']*")
+# Matches any value that contains a Bazel sandbox path reference.
+_BAZEL_PATH_REFERENCE_RE = re.compile(r"_bazel_root|bazel-out|execroot")
 
 
 def _fix_tool_path(segment):
@@ -52,10 +52,14 @@ def _fix_value(key, value):
     if key in FLAGS_TO_CLEAR:
         return ""
     if isinstance(value, str):
-        # The split leaves path-candidates (non-separators) at odd-indexed positions
+        # Fix tool paths to only refer to base names
+        # The RE-based split leaves path-candidates (non-separators) at odd-indexed positions
         result = "".join(_fix_tool_path(p) if i % 2 == 1 else p for i, p in enumerate(_PATH_SPLITTER_RE.split(value)))
-        # Strip any remaining whitespace-separated token that still contains a Bazel sandbox path
-        result = _BAZEL_PATH_RE.sub("", result)
+        # If Bazel sandbox paths remain, use shlex to tokenize the value (respecting shell quoting),
+        # drop any token that contains a Bazel path and then rejoin cleanly.
+        if _BAZEL_PATH_REFERENCE_RE.search(result):
+            tokens = [t for t in shlex.split(result) if not _BAZEL_PATH_REFERENCE_RE.search(t)]
+            result = shlex.join(tokens)
         return result
     return value
 

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -38,6 +38,10 @@ FLAGS_TO_CLEAR = frozenset(
 # Needs to account for paths being preceded by `=` or quotes.
 _PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
 
+# Tokens containing these substrings are Bazel sandbox paths and should be dropped.
+# A "token" here is a maximal run of non-whitespace, non-single-quote characters.
+_BAZEL_PATH_RE = re.compile(r"[^\s']*(?:_bazel_root|bazel-out|execroot)[^\s']*\s*")
+
 
 def _fix_tool_path(segment):
     basename = os.path.basename(segment)
@@ -48,9 +52,11 @@ def _fix_value(key, value):
     if key in FLAGS_TO_CLEAR:
         return ""
     if isinstance(value, str):
-        parts = _PATH_SPLITTER_RE.split(value)
         # The split leaves path-candidates (non-separators) at odd-indexed positions
-        return "".join(_fix_tool_path(p) if i % 2 == 1 else p for i, p in enumerate(parts))
+        result = "".join(_fix_tool_path(p) if i % 2 == 1 else p for i, p in enumerate(_PATH_SPLITTER_RE.split(value)))
+        # Strip any remaining whitespace-separated token that still contains a Bazel sandbox path
+        result = _BAZEL_PATH_RE.sub("", result)
+        return result
     return value
 
 

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -1,8 +1,10 @@
 """Fix sandbox-absolute tool paths in Python's _sysconfigdata__*.py.
 
-Replaces tool paths recorded by CPython's build system with just the
-tool's basename (stripping Bazel sandbox prefixes), and clears build
-flags that are meaningless outside of Bazel.
+- Replaces tool paths recorded by CPython's build system with just the
+tool's basename (stripping Bazel sandbox prefixes)
+- Completely clears a set of predetermined fields
+- Replaces known sandbox paths as well as paths with references to execroot (bazel-out)
+  to use a predetermined replacement prefix.
 
 The resulting file will lose original formatting and comments, but this
 is acceptable given the file's usage.
@@ -12,7 +14,6 @@ import argparse
 import ast
 import os
 import re
-import shlex
 import sys
 
 # Names of tool to strip to their basenames
@@ -35,12 +36,12 @@ FLAGS_TO_CLEAR = frozenset(
     ]
 )
 
+# Subdirectory suffixes we can confidently map to the same suffix under the install prefix.
+_KNOWN_SUFFIXES = frozenset(["lib", "lib64", "include"])
+
 # Regexp to split into alternating path candidates and other tokens
 # Needs to account for paths being preceded by `=` or quotes.
 _PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
-
-# Matches any value that contains a Bazel sandbox path reference.
-_BAZEL_PATH_REFERENCE_RE = re.compile(r"_bazel_root|bazel-out|execroot")
 
 
 def _fix_tool_path(segment):
@@ -48,23 +49,40 @@ def _fix_tool_path(segment):
     return basename if basename in TOOL_BASENAMES else segment
 
 
-def _fix_value(key, value):
+def _fix_bazel_out_path(segment, install_prefix):
+    """Best-effort: collapse bazel-out sandbox paths to the install prefix.
+
+    Paths containing bazel-out are Bazel build artefacts that don't exist at
+    install time. If the path ends with a known suffix (lib, include, ...) we
+    keep that suffix; otherwise we map the whole path to the install prefix.
+    """
+    if "bazel-out" not in segment:
+        return segment
+    basename = os.path.basename(segment)
+    if basename in _KNOWN_SUFFIXES:
+        return install_prefix + "/" + basename
+    return install_prefix
+
+
+def _fix_value(key, value, install_prefix, sandbox_prefix):
     if key in FLAGS_TO_CLEAR:
         return ""
     if isinstance(value, str):
-        # Fix tool paths to only refer to base names
-        # The RE-based split leaves path-candidates (non-separators) at odd-indexed positions
+        # Fix tool paths to only refer to base names.
+        # The RE-based split leaves path-candidates (non-separators) at odd-indexed positions.
         result = "".join(_fix_tool_path(p) if i % 2 == 1 else p for i, p in enumerate(_PATH_SPLITTER_RE.split(value)))
-        # If Bazel sandbox paths remain, use shlex to tokenize the value (respecting shell quoting),
-        # drop any token that contains a Bazel path and then rejoin cleanly.
-        if _BAZEL_PATH_REFERENCE_RE.search(result):
-            tokens = [t for t in shlex.split(result) if not _BAZEL_PATH_REFERENCE_RE.search(t)]
-            result = shlex.join(tokens)
+        # Replace known sandbox install prefix with the real install prefix.
+        result = result.replace(sandbox_prefix, install_prefix)
+        # Collapse remaining bazel-out paths to the install prefix.
+        result = "".join(
+            _fix_bazel_out_path(p, install_prefix) if i % 2 == 1 else p
+            for i, p in enumerate(_PATH_SPLITTER_RE.split(result))
+        )
         return result
     return value
 
 
-def fix_file(path):
+def fix_file(path, install_prefix, sandbox_prefix):
     with open(path) as f:
         source = f.read()
 
@@ -77,7 +95,7 @@ def fix_file(path):
             isinstance(t, ast.Name) and t.id == "build_time_vars" for t in node.targets
         ):
             build_time_vars = ast.literal_eval(node.value)
-            fixed = {k: _fix_value(k, v) for k, v in build_time_vars.items()}
+            fixed = {k: _fix_value(k, v, install_prefix, sandbox_prefix) for k, v in build_time_vars.items()}
             node.value = ast.Dict(
                 keys=[ast.Constant(value=k) for k in fixed],
                 values=[ast.Constant(value=v) for v in fixed.values()],
@@ -92,10 +110,22 @@ def fix_file(path):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--install-prefix",
+        metavar="DIR",
+        required=True,
+        help="Install prefix to substitute for sandbox paths (e.g. ##PREFIX##)",
+    )
+    parser.add_argument(
+        "--sandbox-prefix",
+        metavar="DIR",
+        required=True,
+        help="Bazel sandbox install root",
+    )
     parser.add_argument("files", nargs="+", metavar="FILE", help="_sysconfigdata__*.py file(s) to fix")
     args = parser.parse_args()
     for path in args.files:
-        fix_file(path)
+        fix_file(path, install_prefix=args.install_prefix, sandbox_prefix=args.sandbox_prefix)
 
 
 if __name__ == "__main__":

--- a/deps/cpython/fix_sysconfigdata_test.py
+++ b/deps/cpython/fix_sysconfigdata_test.py
@@ -9,8 +9,6 @@ import unittest
 import fix_sysconfigdata
 
 # A minimal _sysconfigdata__*.py fixture that exercises the fix-up rules:
-# CONFIG_ARGS is included to verify that the single-quote-boundary logic does
-# not corrupt embedded shell-quoted arguments.
 _FIXTURE = textwrap.dedent("""\
     build_time_vars = {
         "CC": "/execroot/_main/external/+toolchain/bin/gcc",
@@ -53,17 +51,16 @@ class TestFixSysconfigdata(unittest.TestCase):
         self.assertEqual(build_time_vars["AR"], "ar")
 
         # Compound values: tool basename kept, useful flags kept, sandbox tokens stripped.
-        # The extra spacing is due to the "gaps" where words were removed
-        self.assertEqual(build_time_vars["LDSHARED"], "gcc -shared -Wl,-z,relro  ")
-        self.assertEqual(build_time_vars["PY_CFLAGS"], " -O2")
+        self.assertEqual(build_time_vars["LDSHARED"], "gcc -shared -Wl,-z,relro")
+        self.assertEqual(build_time_vars["PY_CFLAGS"], "-O2")
 
         # --flag=/path/to/tool: the '=' boundary is respected so
         # the flag prefix is preserved and only the path portion is replaced.
         self.assertEqual(build_time_vars["CONFIGURED_CC"], "--cc=gcc -O2")
 
-        # Bazel tokens inside single-quoted shell args are stripped,
-        # but the surrounding quotes are left intact to avoid leaving unclosed shell quotes
-        self.assertEqual(build_time_vars["CONFIG_ARGS"], "  '--enable-ipv6' ''")
+        # Single-quoted shell args containing Bazel paths are dropped as whole tokens;
+        # args without Bazel paths are preserved.
+        self.assertEqual(build_time_vars["CONFIG_ARGS"], "--enable-ipv6")
 
         # Non-string values pass through unchanged
         self.assertEqual(build_time_vars["VERSION"], "3.13.0")

--- a/deps/cpython/fix_sysconfigdata_test.py
+++ b/deps/cpython/fix_sysconfigdata_test.py
@@ -1,0 +1,73 @@
+"""Tests for fix_sysconfigdata.py."""
+
+import importlib.util
+import os
+import tempfile
+import textwrap
+import unittest
+
+import fix_sysconfigdata
+
+# A minimal _sysconfigdata__*.py fixture that exercises the fix-up rules:
+# CONFIG_ARGS is included to verify that the single-quote-boundary logic does
+# not corrupt embedded shell-quoted arguments.
+_FIXTURE = textwrap.dedent("""\
+    build_time_vars = {
+        "CC": "/execroot/_main/external/+toolchain/bin/gcc",
+        "AR": "/execroot/_main/external/+toolchain/bin/ar",
+        "CFLAGS": "-O2 -nostdinc -isystem /execroot/_main/sysroot/include",
+        "LDFLAGS": "-Wl,-rpath,/bazel-out/k8-opt/bin",
+        "LDSHARED": "/execroot/_main/bin/gcc -shared -Wl,-z,relro -B/execroot/_main/bin -L/bazel-out/k8-opt/lib",
+        "CONFIGURED_CC": "--cc=/execroot/_main/bin/gcc -O2",
+        "CONFIG_ARGS": "  '--enable-ipv6' 'LDFLAGS=-Wl,-rpath,/execroot/_main/lib'",
+        "PY_CFLAGS": "-isystem/execroot/_main/external/gcc_toolchain/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/include -O2",
+        "VERSION": "3.13.0",
+    }
+""")
+
+
+def _load_fixed(path):
+    """Import a patched sysconfigdata file and return its build_time_vars."""
+    # https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+    spec = importlib.util.spec_from_file_location("_sysconfigdata_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.build_time_vars
+
+
+class TestFixSysconfigdata(unittest.TestCase):
+    def test_fix_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "_sysconfigdata__test.py")
+            with open(path, "w") as f:
+                f.write(_FIXTURE)
+            fix_sysconfigdata.fix_file(path)
+            build_time_vars = _load_fixed(path)
+
+        # FLAGS_TO_CLEAR: wiped entirely
+        self.assertEqual(build_time_vars["CFLAGS"], "")
+        self.assertEqual(build_time_vars["LDFLAGS"], "")
+
+        # Tool paths reduced to basename
+        self.assertEqual(build_time_vars["CC"], "gcc")
+        self.assertEqual(build_time_vars["AR"], "ar")
+
+        # Compound values: tool basename kept, useful flags kept, sandbox tokens stripped.
+        # The extra spacing is due to the "gaps" where words were removed
+        self.assertEqual(build_time_vars["LDSHARED"], "gcc -shared -Wl,-z,relro  ")
+        self.assertEqual(build_time_vars["PY_CFLAGS"], " -O2")
+
+        # --flag=/path/to/tool: the '=' boundary is respected so
+        # the flag prefix is preserved and only the path portion is replaced.
+        self.assertEqual(build_time_vars["CONFIGURED_CC"], "--cc=gcc -O2")
+
+        # Bazel tokens inside single-quoted shell args are stripped,
+        # but the surrounding quotes are left intact to avoid leaving unclosed shell quotes
+        self.assertEqual(build_time_vars["CONFIG_ARGS"], "  '--enable-ipv6' ''")
+
+        # Non-string values pass through unchanged
+        self.assertEqual(build_time_vars["VERSION"], "3.13.0")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deps/cpython/fix_sysconfigdata_test.py
+++ b/deps/cpython/fix_sysconfigdata_test.py
@@ -8,9 +8,14 @@ import unittest
 
 import fix_sysconfigdata
 
-# A minimal _sysconfigdata__*.py fixture that exercises the fix-up rules:
-_FIXTURE = textwrap.dedent("""\
-    build_time_vars = {
+# The sandbox install prefix used in the fixture below, matching what
+# $BUILD_TMPDIR/$INSTALL_PREFIX would expand to during the Bazel build.
+_SANDBOX_PREFIX = "/execroot/_main/bazel-out/arch/bin/external/+repo+cpython/python_unix.build_tmpdir/python_unix"
+
+# A minimal _sysconfigdata__*.py fixture that exercises the fix-up rules.
+# Paths under _SANDBOX_PREFIX represent fields recorded relative to the Python install root
+_FIXTURE = textwrap.dedent(f"""\
+    build_time_vars = {{
         "CC": "/execroot/_main/external/+toolchain/bin/gcc",
         "AR": "/execroot/_main/external/+toolchain/bin/ar",
         "CFLAGS": "-O2 -nostdinc -isystem /execroot/_main/sysroot/include",
@@ -20,8 +25,13 @@ _FIXTURE = textwrap.dedent("""\
         "CONFIG_ARGS": "  '--enable-ipv6' 'LDFLAGS=-Wl,-rpath,/execroot/_main/lib'",
         "PY_CFLAGS": "-isystem/execroot/_main/external/gcc_toolchain/lib/gcc/aarch64-unknown-linux-gnu/12.3.0/include -O2",
         "VERSION": "3.13.0",
-    }
+        "LIBDIR": "{_SANDBOX_PREFIX}/lib",
+        "INCLUDEPY": "{_SANDBOX_PREFIX}/include/python3.13",
+        "prefix": "{_SANDBOX_PREFIX}",
+    }}
 """)
+
+_PREFIX = "##PREFIX##"
 
 
 def _load_fixed(path):
@@ -39,31 +49,33 @@ class TestFixSysconfigdata(unittest.TestCase):
             path = os.path.join(tmpdir, "_sysconfigdata__test.py")
             with open(path, "w") as f:
                 f.write(_FIXTURE)
-            fix_sysconfigdata.fix_file(path)
+            fix_sysconfigdata.fix_file(path, install_prefix=_PREFIX, sandbox_prefix=_SANDBOX_PREFIX)
             build_time_vars = _load_fixed(path)
+
+        # Pure install-dir paths are rewritten using the placeholder prefix
+        self.assertEqual(build_time_vars["LIBDIR"], _PREFIX + "/lib")
+        self.assertEqual(build_time_vars["INCLUDEPY"], _PREFIX + "/include/python3.13")
+        self.assertEqual(build_time_vars["prefix"], _PREFIX)
 
         # FLAGS_TO_CLEAR: wiped entirely
         self.assertEqual(build_time_vars["CFLAGS"], "")
         self.assertEqual(build_time_vars["LDFLAGS"], "")
 
-        # Tool paths reduced to basename
+        # Tool paths reduced to basename (via _fix_tool_path)
         self.assertEqual(build_time_vars["CC"], "gcc")
         self.assertEqual(build_time_vars["AR"], "ar")
-
-        # Compound values: tool basename kept, useful flags kept, sandbox tokens stripped.
-        self.assertEqual(build_time_vars["LDSHARED"], "gcc -shared -Wl,-z,relro")
-        self.assertEqual(build_time_vars["PY_CFLAGS"], "-O2")
 
         # --flag=/path/to/tool: the '=' boundary is respected so
         # the flag prefix is preserved and only the path portion is replaced.
         self.assertEqual(build_time_vars["CONFIGURED_CC"], "--cc=gcc -O2")
 
-        # Single-quoted shell args containing Bazel paths are dropped as whole tokens;
-        # args without Bazel paths are preserved.
-        self.assertEqual(build_time_vars["CONFIG_ARGS"], "--enable-ipv6")
-
         # Non-string values pass through unchanged
         self.assertEqual(build_time_vars["VERSION"], "3.13.0")
+
+        # bazel-out paths in LDSHARED are collapsed:
+        # -L/bazel-out/k8-opt/lib  -> -L##PREFIX##/lib  (known suffix)
+        # -B/execroot/... is not bazel-out so left alone
+        self.assertEqual(build_time_vars["LDSHARED"], "gcc -shared -Wl,-z,relro -B/execroot/_main/bin -L##PREFIX##/lib")
 
 
 if __name__ == "__main__":

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -34,8 +34,9 @@ build do
     sh_ext = if linux_target? then "so" else "dylib" end
     command_on_repo_root "bazelisk run --//:install_dir=#{install_dir} -- //bazel/rules:replace_prefix --prefix '#{install_dir}/embedded'" \
       " #{install_dir}/embedded/lib/libpython3.*#{sh_ext}" \
-      " #{install_dir}/embedded/lib/python3.13/lib-dynload/*.so" \
-      " #{install_dir}/embedded/bin/python3*"
+      " #{install_dir}/embedded/lib/python3.*/lib-dynload/*.so" \
+      " #{install_dir}/embedded/bin/python3*" \
+      " #{install_dir}/embedded/lib/python3.*/_sysconfigdata__*.py"
     python = "#{install_dir}/embedded/bin/python3"
   else
     command_on_repo_root "bazelisk run #{flavor_flag} --//:install_dir=#{install_dir} -- @cpython//:install --destdir=#{install_dir}"


### PR DESCRIPTION
### What does this PR do?

It further cleans up variables in sysconfigdata file produced by the Python build such that sandbox paths as well as other output root (`bazel-out/...`) paths are replaced by placeholders into which later the final install location can be injected (which it is done using a slightly tweaked replace_prefix rule for now).

It also adds a test covering some of the previous replacement logic as well as the new one.

### Motivation

Spotted while looking at [this](https://github.com/DataDog/datadog-agent/pull/48184#issuecomment-4108641155). I realized, looking at the file, that there were lots of references that don't make sense to keep.

This is mostly dead weight, so we may as well claim those bytes back, and it's also a reproducibility concern.

### Describe how you validated your changes

- Passing tests.
- Passing integrations-core test pipeline against a build from this branch: https://github.com/DataDog/integrations-core/actions/runs/24349158368

### Additional Notes

Rather than be selective and list variables manually (there are lots of them), this change leverages the knowledge of sandbox build dir used by rules_foreign_cc as well as a basic heuristic around `bazel-out` to replace paths throughout.

The current choice of replace_prefix is merely tactical – it's less of a jump than trying to use the `install_dir` config flag value. We may end up replacing this as we refine our strategy around the whole path replacement/patching business in general.