### PR TITLE
[EBPF] gpu: add extra logging in e2e test

### DIFF
--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -308,7 +308,9 @@ func (v *gpuBaseSuite[Env]) TestGPUCheckIsEnabled() {
 		err := json.Unmarshal([]byte(jsonStatus), &status)
 
 		assert.NoError(c, err, "failed to unmarshal agent status")
-		assert.Contains(c, status.RunnerStats.Checks, "gpu")
+		assert.Contains(c, status.RunnerStats.Checks, "gpu", "gpu check should be enabled")
+
+		v.T().Logf("gpu check status: %+v", status.RunnerStats.Checks["gpu"])
 
 		gpuCheckStatus := status.RunnerStats.Checks["gpu"]
 		assert.Equal(c, gpuCheckStatus.LastError, "")


### PR DESCRIPTION
### What does this PR do?

Adds extra logging to the `TestGPUCheckIsEnabled` in e2e gpu tests.

### Motivation

Debugging for #incident-51605

### Describe how you validated your changes

Test only changes

### Additional Notes
