### PR TITLE
fix(fleet/installer): fall back to system temp dir when packages dir is missing on Windows

### DIFF
--- a/.gitlab/windows/test/e2e_install_packages/windows.yml
+++ b/.gitlab/windows/test/e2e_install_packages/windows.yml
@@ -196,6 +196,7 @@ new-e2e-installer-windows:
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestStopWithoutExperiment$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestRevertsExperimentWhenServiceDies$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestRevertsExperimentWhenTimeout$"
+      - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestRemoveExperimentNoTempDirError$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestExperimentMSIRollbackMaintainsCustomUserAndAltDir$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestRevertsExperimentWhenServiceDiesMaintainsCustomUserAndAltDir$"
       - EXTRA_PARAMS: --run "TestAgentUpgrades$/TestUpgradeWithHostNameChange$"

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -148,8 +148,12 @@ func (i *InstallerExec) RemoveExperiment(ctx context.Context, pkg string) (err e
 	// on windows we need to make a copy of installer binary so that it isn't in use
 	// while the MSI tries to remove it
 	if runtime.GOOS == "windows" && pkg == "datadog-agent" {
-		repositories := repository.NewRepositories(paths.PackagesPath, nil)
-		tmpDir, err := repositories.MkdirTemp()
+		tmpRootPath := paths.PackagesPath
+		if _, statErr := os.Stat(tmpRootPath); statErr != nil {
+			// packages directory does not exist, fall back to system temp dir
+			tmpRootPath = ""
+		}
+		tmpDir, err := os.MkdirTemp(tmpRootPath, "tmp-installer-*")
 		if err != nil {
 			return fmt.Errorf("error creating temp dir: %w", err)
 		}

--- a/pkg/fleet/installer/exec/installer_exec.go
+++ b/pkg/fleet/installer/exec/installer_exec.go
@@ -153,7 +153,7 @@ func (i *InstallerExec) RemoveExperiment(ctx context.Context, pkg string) (err e
 			// packages directory does not exist, fall back to system temp dir
 			tmpRootPath = ""
 		}
-		tmpDir, err := os.MkdirTemp(tmpRootPath, "tmp-installer-*")
+		tmpDir, err := os.MkdirTemp(tmpRootPath, "tmp-i-*")
 		if err != nil {
 			return fmt.Errorf("error creating temp dir: %w", err)
 		}

--- a/pkg/fleet/installer/exec/installer_exec_test.go
+++ b/pkg/fleet/installer/exec/installer_exec_test.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+
+package exec
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/env"
+	"github.com/DataDog/datadog-agent/pkg/fleet/installer/paths"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRemoveExperimentFallbackToSystemTempDir verifies that RemoveExperiment does not
+// fail with "error creating temp dir" when paths.PackagesPath does not exist.
+// This reproduces the scenario where the packages directory is missing (e.g. deleted
+// or the installer never fully initialized) and the one-shot binary tries to recover.
+func TestRemoveExperimentFallbackToSystemTempDir(t *testing.T) {
+	// Override PackagesPath to a directory that does not exist.
+	origPackagesPath := paths.PackagesPath
+	paths.PackagesPath = filepath.Join(t.TempDir(), "nonexistent", "packages")
+	defer func() { paths.PackagesPath = origPackagesPath }()
+
+	// Provide a real file as the installer binary so that paths.CopyFile succeeds.
+	fakeInstallerBin := filepath.Join(t.TempDir(), "datadog-installer.exe")
+	require.NoError(t, os.WriteFile(fakeInstallerBin, []byte("fake"), 0o644))
+
+	i := NewInstallerExec(&env.Env{}, fakeInstallerBin)
+	err := i.RemoveExperiment(context.Background(), "datadog-agent")
+	// The call will fail because the copied binary is not a valid executable,
+	// but it must NOT fail with "error creating temp dir".
+	if err != nil {
+		require.NotContains(t, err.Error(), "error creating temp dir",
+			"MkdirTemp should fall back to system temp dir when PackagesPath is missing")
+	}
+}

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -436,7 +436,16 @@ func (s *testAgentUpgradeSuite) TestRemoveExperimentNoTempDirError() {
 	_, err := s.Env().RemoteHost.Execute(`Rename-Item -Path 'C:\ProgramData\Datadog\Installer\packages' -NewName 'packages.bak'`)
 	s.Require().NoError(err)
 	_, removeErr := s.Installer().RemoveExperiment(consts.AgentPackage)
-	_, restoreErr := s.Env().RemoteHost.Execute(`Rename-Item -Path 'C:\ProgramData\Datadog\Installer\packages.bak' -NewName 'packages'`)
+	// RemoveExperiment may recreate the packages directory (e.g. when reinstalling the stable MSI),
+	// so remove it before renaming packages.bak back to avoid a Rename-Item conflict.
+	_, restoreErr := s.Env().RemoteHost.Execute(`
+		if (Test-Path 'C:\ProgramData\Datadog\Installer\packages') {
+			Remove-Item -Recurse -Force 'C:\ProgramData\Datadog\Installer\packages'
+		}
+		if (Test-Path 'C:\ProgramData\Datadog\Installer\packages.bak') {
+			Rename-Item -Path 'C:\ProgramData\Datadog\Installer\packages.bak' -NewName 'packages'
+		}
+	`)
 	s.Require().NoError(restoreErr)
 
 	// Assert: the call must not have failed due to missing temp dir

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -422,6 +422,30 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenTimeout() {
 	})
 }
 
+// TestRevertsExperimentWhenPackagesDirMissing is a regression test for FA-1143.
+// It verifies that RemoveExperiment does not fail with "error creating temp dir"
+// when the packages directory has been deleted before the call.
+func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenPackagesDirMissing() {
+	// Arrange
+	s.setAgentConfig()
+	s.installPreviousAgentVersion()
+	s.MustStartExperimentCurrentVersion()
+	s.AssertSuccessfulAgentStartExperiment(s.CurrentAgentVersion().PackageVersion())
+
+	// Act: rename packages dir to simulate it being missing, then remove experiment
+	_, err := s.Env().RemoteHost.Execute(`Rename-Item -Path 'C:\ProgramData\Datadog\Installer\packages' -NewName 'packages.bak'`)
+	s.Require().NoError(err)
+	_, removeErr := s.Installer().RemoveExperiment(consts.AgentPackage)
+	_, restoreErr := s.Env().RemoteHost.Execute(`Rename-Item -Path 'C:\ProgramData\Datadog\Installer\packages.bak' -NewName 'packages'`)
+	s.Require().NoError(restoreErr)
+
+	// Assert: the call must not have failed due to missing temp dir
+	if removeErr != nil {
+		s.Require().NotContains(removeErr.Error(), "error creating temp dir",
+			"MkdirTemp should fall back to system temp dir when packages directory is missing")
+	}
+}
+
 // TestExperimentMSIRollbackMaintainsCustomUserAndAltDir tests that the
 // stable version is reinstalled with the custom user and alt dir when an experiment MSI rolls back.
 // This is a regression test for WINA-1504, where remove-experiment subcommand used the wrong

--- a/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
+++ b/test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go
@@ -422,10 +422,10 @@ func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenTimeout() {
 	})
 }
 
-// TestRevertsExperimentWhenPackagesDirMissing is a regression test for FA-1143.
+// TestRemoveExperimentNoTempDirError is a regression test for FA-1143.
 // It verifies that RemoveExperiment does not fail with "error creating temp dir"
 // when the packages directory has been deleted before the call.
-func (s *testAgentUpgradeSuite) TestRevertsExperimentWhenPackagesDirMissing() {
+func (s *testAgentUpgradeSuite) TestRemoveExperimentNoTempDirError() {
 	// Arrange
 	s.setAgentConfig()
 	s.installPreviousAgentVersion()


### PR DESCRIPTION
## Summary

https://datadoghq.atlassian.net/browse/FA-1143
- Fixes `RemoveExperiment("datadog-agent")` failing with _"error creating temp dir"_ when `paths.PackagesPath` (`C:\ProgramData\Datadog\Installer\packages`) does not exist on Windows (FA-1143)
- Applies the same `os.Stat` fallback already used in `installAgentPackage`: if the packages directory is absent, passes `""` to `os.MkdirTemp` so it falls back to `os.TempDir()`
- The temp dir here holds only a copy of the installer binary (`CopyFile`), so same-partition semantics are not required

## Test plan

- [ ] New Windows-only unit test in `pkg/fleet/installer/exec/installer_exec_test.go` verifies the fallback does not produce _"error creating temp dir"_ when `paths.PackagesPath` is non-existent
- [ ] New E2E regression test `TestRevertsExperimentWhenPackagesDirMissing` in `test/new-e2e/tests/installer/windows/suites/agent-package/upgrade_test.go` renames the packages dir before calling `RemoveExperiment` and asserts the same