### PR TITLE
[Backport 7.78.x] Use FIPS agent as base image for FIPS DDOT

### DIFF
--- a/.gitlab/deploy/container_build/docker_linux.yml
+++ b/.gitlab/deploy/container_build/docker_linux.yml
@@ -11,7 +11,7 @@
       else
         export ECR_RELEASE_SUFFIX=${CI_COMMIT_TAG+-release}
       fi
-    - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/agent-base-image${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-$ARCH
+    - AGENT_BASE_IMAGE_TAG=registry.ddbuild.io/ci/datadog-agent/${BASE_IMAGE_NAME:-agent-base-image}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${BASE_IMAGE_TAG_SUFFIX:-}-$ARCH
     - TARGET_TAG=${IMAGE}${ECR_RELEASE_SUFFIX}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}$TAG_SUFFIX-$ARCH
     # Caching setup
     - DOCKER_CACHE_REGISTRY_TARGET="${IMAGE}${TAG_SUFFIX}-${ARCH}:cache"
@@ -359,19 +359,23 @@ docker_build_ot_agent_standalone_fips_amd64:
   extends:
     [.docker_build_ot_agent_standalone, .docker_build_amd64]
   needs:
-    - job: docker_build_base_image_amd64
+    - job: docker_build_fips_agent7
     - job: datadog-otel-agent-x64-fips
   variables:
     TAG_SUFFIX: -7-fips
+    BASE_IMAGE_NAME: agent
+    BASE_IMAGE_TAG_SUFFIX: -7-fips
 
 docker_build_ot_agent_standalone_fips_arm64:
   extends:
     [.docker_build_ot_agent_standalone, .docker_build_arm64]
   needs:
-    - job: docker_build_base_image_arm64
+    - job: docker_build_fips_agent7_arm64
     - job: datadog-otel-agent-arm64-fips
   variables:
     TAG_SUFFIX: -7-fips
+    BASE_IMAGE_NAME: agent
+    BASE_IMAGE_TAG_SUFFIX: -7-fips
 
 docker_build_agent7_full:
   extends: [.docker_build_amd64, .docker_build_agent7]


### PR DESCRIPTION
### What does this PR do?

Backport of #48340

Use the FIPS agent as a base image for the FIPS DDOT, to reuse the OpenSSL installation and config

### Motivation

FIPS requires:
- the OpenSSL .so
- an OpenSSL config file
- the `fips.so` OpenSSL plugin

### Describe how you validated your changes

Built the image locally, verified the content and ran it without issue