### PR TITLE
[observer] Add observer input telemetry / benchmark

### DIFF
--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -289,6 +289,12 @@ export interface DetectorProcessingStats {
   total_ns: number;
 }
 
+export interface ReplayStats {
+  detector_stats: Record<string, DetectorProcessingStats>;
+  input_metrics_count: number;
+  input_logs_count: number;
+}
+
 class ApiClient {
   private async fetch<T>(path: string, options?: RequestInit): Promise<T> {
     const response = await fetch(`${API_BASE}${path}`, options);
@@ -413,7 +419,7 @@ class ApiClient {
     return this.fetch('/score');
   }
 
-  async getBenchmarkStats(): Promise<Record<string, DetectorProcessingStats>> {
+  async getBenchmarkStats(): Promise<ReplayStats> {
     return this.fetch('/benchmark');
   }
 

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -292,6 +292,7 @@ export interface DetectorProcessingStats {
 export interface ReplayStats {
   detector_stats: Record<string, DetectorProcessingStats>;
   input_metrics_count: number;
+  input_metrics_cardinality: number;
   input_logs_count: number;
 }
 

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -295,6 +295,7 @@ export interface ReplayStats {
   input_metrics_count: number;
   input_metrics_cardinality: number;
   input_logs_count: number;
+  input_anomalies_count: number;
 }
 
 class ApiClient {

--- a/cmd/observer-testbench/ui/src/api/client.ts
+++ b/cmd/observer-testbench/ui/src/api/client.ts
@@ -282,6 +282,7 @@ export interface ScoreResponse {
 
 export interface DetectorProcessingStats {
   name: string;
+  kind: 'detector' | 'correlator' | 'extractor' | '';
   count: number;
   avg_ns: number;
   median_ns: number;

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -341,9 +341,9 @@ const KIND_COLOR: Record<string, string> = {
   extractor: '#4ade80', // green-400
 };
 const KIND_LABEL: Record<string, string> = {
-  detector:  'ns/point',
-  correlator: 'ns/point',
-  extractor: 'ns/log',
+  detector:   'ns/point',
+  correlator: 'ns/anomaly',
+  extractor:  'ns/log',
 };
 
 interface EfficiencyEntry {
@@ -497,14 +497,15 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
   const [tagFilterInput, setTagFilterInput] = useState('');
   const [hoveredDetector, setHoveredDetector] = useState<string | null>(null);
 
-  // Fetch when a scenario finishes loading
+  // Fetch when a scenario finishes loading or scenario data is refreshed (e.g. toggling a
+  // correlator updates processing stats but keeps the same active scenario name).
   useEffect(() => {
     if (state.connectionState !== 'ready') return;
     api
       .getBenchmarkStats()
       .then(setReplayStats)
       .catch(() => setReplayStats(null));
-  }, [state.activeScenario, state.connectionState]);
+  }, [state.activeScenario, state.connectionState, state.scenarioDataVersion]);
 
   // Sort by p99 descending so the slowest detectors are at the top
   const stats = useMemo(() => {
@@ -519,7 +520,9 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
       .map((s) => {
         const itemCount = s.kind === 'extractor'
           ? replayStats.input_logs_count
-          : replayStats.input_metrics_count;
+          : s.kind === 'correlator'
+            ? replayStats.input_anomalies_count
+            : replayStats.input_metrics_count;
         return {
           name: s.name,
           kind: s.kind,
@@ -683,7 +686,7 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
                 Cost per Item
               </h2>
               <span className="text-xs text-slate-500">
-                total processing time ÷ items processed · detectors &amp; correlators per data point, extractors per log
+                total processing time ÷ items processed · detectors per data point, correlators per anomaly, extractors per log
               </span>
             </div>
             <EfficiencyBarChart

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -360,7 +360,7 @@ interface EfficiencyBarChartProps {
   onHover: (name: string | null) => void;
 }
 
-const EFF_MARGIN = { top: 44, right: 115, bottom: 12, left: 235 };
+const EFF_MARGIN = { top: 58, right: 115, bottom: 24, left: 235 };
 const EFF_BAR_H = 15;
 const EFF_BAR_GAP = 6;
 const EFF_GROUP_H = EFF_BAR_H + EFF_BAR_GAP;

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -330,6 +330,160 @@ function BenchmarkBarChart({ stats, highlighted, onHover }: BenchmarkBarChartPro
   );
 }
 
+// ── Efficiency chart ──────────────────────────────────────────────────────────
+// Shows total_ns / items_processed per detector:
+//   - detectors / correlators  →  total_ns / input_metrics_cardinality  (ns per series)
+//   - extractors               →  total_ns / input_logs_count            (ns per log)
+
+const KIND_COLOR: Record<string, string> = {
+  detector:  '#60a5fa', // blue-400
+  correlator: '#a78bfa', // violet-400
+  extractor: '#4ade80', // green-400
+};
+const KIND_LABEL: Record<string, string> = {
+  detector:  'ns/point',
+  correlator: 'ns/point',
+  extractor: 'ns/log',
+};
+
+interface EfficiencyEntry {
+  name: string;
+  kind: string;
+  nsPerItem: number;
+  totalNs: number;
+  itemCount: number;
+}
+
+interface EfficiencyBarChartProps {
+  entries: EfficiencyEntry[];
+  highlighted: Set<string> | null;
+  onHover: (name: string | null) => void;
+}
+
+const EFF_MARGIN = { top: 44, right: 115, bottom: 12, left: 235 };
+const EFF_BAR_H = 15;
+const EFF_BAR_GAP = 6;
+const EFF_GROUP_H = EFF_BAR_H + EFF_BAR_GAP;
+
+function EfficiencyBarChart({ entries, highlighted, onHover }: EfficiencyBarChartProps) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+  const onHoverRef = useRef(onHover);
+  onHoverRef.current = onHover;
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setContainerWidth(Math.floor(w));
+    });
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!svgRef.current || !containerRef.current || entries.length === 0) {
+      d3.select(svgRef.current).selectAll('*').remove();
+      return;
+    }
+
+    const width = containerWidth || containerRef.current.clientWidth;
+    const innerWidth = width - EFF_MARGIN.left - EFF_MARGIN.right;
+    if (innerWidth <= 0) return;
+
+    const innerHeight = entries.length * EFF_GROUP_H - EFF_BAR_GAP;
+    const totalHeight = innerHeight + EFF_MARGIN.top + EFF_MARGIN.bottom;
+
+    d3.select(svgRef.current).selectAll('*').remove();
+    const svg = d3.select(svgRef.current).attr('width', width).attr('height', totalHeight);
+
+    // Legend: one swatch per kind present
+    const kindsPresent = [...new Set(entries.map((e) => e.kind))].filter((k) => k in KIND_COLOR);
+    const legendG = svg.append('g').attr('transform', `translate(${EFF_MARGIN.left}, 14)`);
+    let lx = 0;
+    kindsPresent.forEach((kind) => {
+      const color = KIND_COLOR[kind] ?? '#94a3b8';
+      const lg = legendG.append('g').attr('transform', `translate(${lx}, 0)`);
+      lg.append('rect').attr('width', 10).attr('height', 10).attr('fill', color).attr('rx', 2);
+      lg.append('text').attr('x', 14).attr('y', 9).attr('fill', color)
+        .attr('font-size', '10px').attr('font-family', 'monospace')
+        .text(`${kind} (${KIND_LABEL[kind] ?? 'ns/item'})`);
+      lx += kind.length * 7 + 100;
+    });
+
+    const xMax = d3.max(entries, (e) => e.nsPerItem) ?? 1;
+    const xScale = d3.scaleLinear().domain([0, xMax * 1.12]).range([0, innerWidth]);
+
+    const g = svg.append('g').attr('transform', `translate(${EFF_MARGIN.left},${EFF_MARGIN.top})`);
+
+    // Top axis
+    g.append('g')
+      .attr('transform', 'translate(0,-6)')
+      .call(d3.axisTop(xScale).ticks(5).tickFormat((d) => (+d === 0 ? '' : fmtUs(+d))))
+      .call((ax) => ax.select('.domain').attr('stroke', '#334155'))
+      .call((ax) => ax.selectAll('text').attr('fill', '#64748b').attr('font-size', '10px'))
+      .call((ax) => ax.selectAll('.tick line').attr('stroke', '#334155'));
+
+    // Grid
+    xScale.ticks(5).forEach((t) => {
+      g.append('line')
+        .attr('x1', xScale(t)).attr('x2', xScale(t))
+        .attr('y1', 0).attr('y2', innerHeight)
+        .attr('stroke', '#1e293b').attr('stroke-width', 1);
+    });
+
+    entries.forEach((entry, i) => {
+      const y = i * EFF_GROUP_H;
+      const isActive = highlighted === null || highlighted.has(entry.name);
+      const color = KIND_COLOR[entry.kind] ?? '#94a3b8';
+      const label = KIND_LABEL[entry.kind] ?? 'ns/item';
+      const barW = Math.max(0, xScale(entry.nsPerItem));
+
+      const rowG = g.append('g')
+        .attr('transform', `translate(0,${y})`)
+        .attr('opacity', isActive ? 1 : 0.15)
+        .style('cursor', 'default')
+        .on('mouseenter', () => onHoverRef.current(entry.name))
+        .on('mouseleave', () => onHoverRef.current(null));
+
+      // Hit zone
+      rowG.append('rect')
+        .attr('x', -EFF_MARGIN.left).attr('y', -2)
+        .attr('width', EFF_MARGIN.left + innerWidth + EFF_MARGIN.right)
+        .attr('height', EFF_BAR_H + 4)
+        .attr('fill', 'transparent');
+
+      // Bar
+      rowG.append('rect')
+        .attr('x', 0).attr('y', 0).attr('width', barW).attr('height', EFF_BAR_H)
+        .attr('fill', color).attr('rx', 2).attr('opacity', 0.85);
+
+      // Value label
+      rowG.append('text')
+        .attr('x', barW + 6).attr('y', EFF_BAR_H / 2)
+        .attr('dominant-baseline', 'middle')
+        .attr('fill', color).attr('font-size', '10px').attr('font-family', 'monospace')
+        .text(`${fmtUs(entry.nsPerItem)} ${label}`);
+
+      // Detector name
+      const displayName = entry.name.length > 20 ? entry.name.slice(0, 19) + '…' : entry.name;
+      rowG.append('text')
+        .attr('x', -10).attr('y', EFF_BAR_H / 2)
+        .attr('text-anchor', 'end').attr('dominant-baseline', 'middle')
+        .attr('fill', isActive ? '#e2e8f0' : '#475569')
+        .attr('font-size', '11px').attr('font-family', 'monospace')
+        .text(displayName);
+    });
+  }, [entries, highlighted, containerWidth]);
+
+  return (
+    <div ref={containerRef} className="w-full">
+      <svg ref={svgRef} style={{ display: 'block' }} />
+    </div>
+  );
+}
+
 // ── Main view ─────────────────────────────────────────────────────────────────
 
 interface BenchmarkViewProps {
@@ -356,6 +510,26 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
   const stats = useMemo(() => {
     if (!replayStats?.detector_stats) return [];
     return Object.values(replayStats.detector_stats).sort((a, b) => b.p99_ns - a.p99_ns);
+  }, [replayStats]);
+
+  // Efficiency entries: total_ns / items_processed, sorted by ns-per-item descending
+  const efficiencyEntries = useMemo((): EfficiencyEntry[] => {
+    if (!replayStats?.detector_stats) return [];
+    return Object.values(replayStats.detector_stats)
+      .map((s) => {
+        const itemCount = s.kind === 'extractor'
+          ? replayStats.input_logs_count
+          : replayStats.input_metrics_count;
+        return {
+          name: s.name,
+          kind: s.kind,
+          nsPerItem: itemCount > 0 ? s.total_ns / itemCount : 0,
+          totalNs: s.total_ns,
+          itemCount,
+        };
+      })
+      .filter((e) => e.nsPerItem > 0)
+      .sort((a, b) => b.nsPerItem - a.nsPerItem);
   }, [replayStats]);
 
   // Tag groups: one entry per detector using the `detector:<name>` convention
@@ -482,7 +656,7 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
           </div>
         )}
 
-        {/* Chart widget */}
+        {/* Processing times chart */}
         {state.connectionState === 'ready' && stats.length > 0 && (
           <div className="bg-slate-800/60 border border-slate-700 rounded-lg p-4">
             <div className="flex items-baseline gap-3 mb-3">
@@ -495,6 +669,25 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
             </div>
             <BenchmarkBarChart
               stats={stats}
+              highlighted={highlightedSet}
+              onHover={setHoveredDetector}
+            />
+          </div>
+        )}
+
+        {/* Efficiency chart */}
+        {state.connectionState === 'ready' && efficiencyEntries.length > 0 && (
+          <div className="bg-slate-800/60 border border-slate-700 rounded-lg p-4 mt-4">
+            <div className="flex items-baseline gap-3 mb-3">
+              <h2 className="text-sm font-semibold text-slate-200">
+                Cost per Item
+              </h2>
+              <span className="text-xs text-slate-500">
+                total processing time ÷ items processed · detectors &amp; correlators per data point, extractors per log
+              </span>
+            </div>
+            <EfficiencyBarChart
+              entries={efficiencyEntries}
               highlighted={highlightedSet}
               onHover={setHoveredDetector}
             />

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -434,6 +434,10 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
                 <span>{replayStats.input_metrics_count.toLocaleString()}</span>
               </div>
               <div className="flex justify-between">
+                <span className="text-slate-500">unique series</span>
+                <span>{replayStats.input_metrics_cardinality.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
                 <span className="text-slate-500">log entries</span>
                 <span>{replayStats.input_logs_count.toLocaleString()}</span>
               </div>

--- a/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
+++ b/cmd/observer-testbench/ui/src/components/BenchmarkView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import * as d3 from 'd3';
 import { api } from '../api/client';
-import type { DetectorProcessingStats, ScenarioInfo } from '../api/client';
+import type { DetectorProcessingStats, ReplayStats, ScenarioInfo } from '../api/client';
 import type { ObserverState, ObserverActions } from '../hooks/useObserver';
 import { TagFilterGroups } from './TagFilterGroups';
 import { parseTagFilter, toggleTagInInput, matchesTagFilter } from '../filters';
@@ -339,7 +339,7 @@ interface BenchmarkViewProps {
 }
 
 export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewProps) {
-  const [rawStats, setRawStats] = useState<Record<string, DetectorProcessingStats> | null>(null);
+  const [replayStats, setReplayStats] = useState<ReplayStats | null>(null);
   const [tagFilterInput, setTagFilterInput] = useState('');
   const [hoveredDetector, setHoveredDetector] = useState<string | null>(null);
 
@@ -348,15 +348,15 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
     if (state.connectionState !== 'ready') return;
     api
       .getBenchmarkStats()
-      .then(setRawStats)
-      .catch(() => setRawStats(null));
+      .then(setReplayStats)
+      .catch(() => setReplayStats(null));
   }, [state.activeScenario, state.connectionState]);
 
   // Sort by p99 descending so the slowest detectors are at the top
   const stats = useMemo(() => {
-    if (!rawStats) return [];
-    return Object.values(rawStats).sort((a, b) => b.p99_ns - a.p99_ns);
-  }, [rawStats]);
+    if (!replayStats?.detector_stats) return [];
+    return Object.values(replayStats.detector_stats).sort((a, b) => b.p99_ns - a.p99_ns);
+  }, [replayStats]);
 
   // Tag groups: one entry per detector using the `detector:<name>` convention
   const tagGroups = useMemo(
@@ -420,6 +420,24 @@ export function BenchmarkView({ state, actions, sidebarWidth }: BenchmarkViewPro
               tagFilterInput={tagFilterInput}
               onToggleTag={(tag) => setTagFilterInput(toggleTagInInput(tagFilterInput, tag))}
             />
+          </div>
+        )}
+
+        {replayStats && (
+          <div className="p-4 border-b border-slate-700">
+            <h2 className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-2">
+              Input Volume
+            </h2>
+            <div className="text-xs text-slate-400 space-y-1 font-mono">
+              <div className="flex justify-between">
+                <span className="text-slate-500">metric samples</span>
+                <span>{replayStats.input_metrics_count.toLocaleString()}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-slate-500">log entries</span>
+                <span>{replayStats.input_logs_count.toLocaleString()}</span>
+              </div>
+            </div>
           </div>
         )}
 

--- a/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useState } from 'react';
+import { useRef, useEffect, useMemo, useState, useId } from 'react';
 import * as d3 from 'd3';
 import type { Point, AnomalyMarker, SeriesID } from '../api/client';
 import type { CorrelationRange, TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
@@ -60,6 +60,42 @@ export function getSeriesVariantColor(index: number) {
 function getAnomalyMarkerId(anomaly: AnomalyMarker): string {
   const detectorId = anomaly.detectorComponent ?? anomaly.detectorName;
   return `${detectorId}:${anomaly.sourceSeriesId ?? 'unknown'}:${anomaly.timestamp}:${anomaly.title}`;
+}
+
+/**
+ * When zoomed to a time window, include the last sample before the window and the
+ * first sample after it so lines still cross the plot when the window falls between
+ * bucket timestamps (strict in-range filtering would yield no points).
+ */
+function augmentPointsForTimeWindow(points: Point[], timeRange: TimeRange): Point[] {
+  if (points.length === 0) return points;
+  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
+  const { start, end } = timeRange;
+  const inside = sorted.filter((p) => p.timestamp >= start && p.timestamp <= end);
+
+  let before: Point | undefined;
+  for (const p of sorted) {
+    if (p.timestamp < start) before = p;
+    else break;
+  }
+  let after: Point | undefined;
+  for (let i = sorted.length - 1; i >= 0; i--) {
+    const p = sorted[i];
+    if (p.timestamp > end) after = p;
+    else break;
+  }
+
+  const out: Point[] = [];
+  if (before !== undefined) out.push(before);
+  out.push(...inside);
+  if (after !== undefined) out.push(after);
+
+  const seen = new Set<number>();
+  return out.filter((p) => {
+    if (seen.has(p.timestamp)) return false;
+    seen.add(p.timestamp);
+    return true;
+  });
 }
 
 // Represents one concrete tagged series variant drawn as a separate line.
@@ -136,6 +172,8 @@ export function MetricsChart({
   const panStartRangeRef = useRef<TimeRange | null>(null);
   const panTriggerRef = useRef<'middle' | 'meta-left' | null>(null);
   const xScaleRef = useRef<d3.ScaleTime<number, number> | null>(null);
+  /** Stable id for SVG clipPath (colon-free for url(#...) references). */
+  const plotClipId = useId().replace(/:/g, '');
 
   const isSeriesVisible = (seriesId?: SeriesID): boolean => {
     if (!seriesId || !visibleSeriesIds) return true;
@@ -153,19 +191,19 @@ export function MetricsChart({
     [anomalies, enabledDetectors, visibleSeriesIds]
   );
 
-  // Filter points by time range
+  // Points for the current zoom window, plus boundary samples so lines still render
+  // when the window falls between bucket timestamps.
   const displayPoints = useMemo(() => {
     if (!timeRange) return points;
-    return points.filter((p) => p.timestamp >= timeRange.start && p.timestamp <= timeRange.end);
+    return augmentPointsForTimeWindow(points, timeRange);
   }, [points, timeRange]);
 
-  // Filter variant series points by time range
   const displaySeriesVariants = useMemo(() => {
     if (!seriesVariants) return undefined;
     if (!timeRange) return seriesVariants;
     return seriesVariants.map((s) => ({
       ...s,
-      points: s.points.filter((p) => p.timestamp >= timeRange.start && p.timestamp <= timeRange.end),
+      points: augmentPointsForTimeWindow(s.points, timeRange),
     }));
   }, [seriesVariants, timeRange]);
 
@@ -228,9 +266,19 @@ export function MetricsChart({
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
+    svg
+      .append('defs')
+      .append('clipPath')
+      .attr('id', plotClipId)
+      .append('rect')
+      .attr('width', innerWidth)
+      .attr('height', innerHeight);
+
+    const plot = g.append('g').attr('class', 'metrics-plot-area').attr('clip-path', `url(#${plotClipId})`);
+
     // Determine which data to use for scales and rendering
     const useVariantData = variantMode;
-    const pointsToRender = displayPoints.length > 0 ? displayPoints : points;
+    const pointsToRender = displayPoints;
     const allVariantPoints = orderedSeriesVariants?.flatMap((s) => s.points) ?? [];
     const visibleVariantPoints = visibleOrderedSeriesVariants?.flatMap((s) => s.points) ?? [];
 
@@ -281,7 +329,7 @@ export function MetricsChart({
       const x2 = xScale(range.end * 1000);
       const rectWidth = Math.max(x2 - x1, 4); // Minimum 4px width for visibility
 
-      g.append('rect')
+      plot.append('rect')
         .attr('x', x1)
         .attr('y', 0)
         .attr('width', rectWidth)
@@ -292,6 +340,12 @@ export function MetricsChart({
         .attr('stroke-dasharray', '4,2')
         .attr('opacity', 0.5);
     });
+
+    // Grid lines (under series lines; clipped to plot area)
+    plot.append('g')
+      .attr('class', 'grid')
+      .attr('opacity', 0.1)
+      .call(d3.axisLeft(yScale).ticks(5).tickSize(-innerWidth).tickFormat(() => ''));
 
     // Group anomalies by timestamp to handle overlaps
     const anomaliesByTimestamp = new Map<number, typeof filteredAnomalies>();
@@ -359,7 +413,7 @@ export function MetricsChart({
         const colorIdx = orderedSeriesVariants?.findIndex((s) => s.seriesId === series.seriesId && s.label === series.label) ?? 0;
         const color = getSeriesVariantColor(Math.max(colorIdx, 0));
         const isHighlighted = !activeHighlightedSeriesId || !series.seriesId || series.seriesId === activeHighlightedSeriesId;
-        g.append('path')
+        plot.append('path')
           .datum(series.points)
           .attr('fill', 'none')
           .attr('stroke', color)
@@ -371,7 +425,7 @@ export function MetricsChart({
 
     } else {
       // Draw single line
-      g.append('path')
+      plot.append('path')
         .datum(pointsToRender)
         .attr('fill', 'none')
         .attr('stroke', '#8b5cf6')
@@ -379,37 +433,11 @@ export function MetricsChart({
         .attr('d', line);
     }
 
-    // X axis
-    g.append('g')
-      .attr('transform', `translate(0,${innerHeight})`)
-      .call(
-        d3
-          .axisBottom(xScale)
-          .ticks(6)
-          .tickFormat((d) => d3.timeFormat('%H:%M:%S')(d as Date))
-      )
-      .attr('color', '#64748b')
-      .selectAll('text')
-      .attr('fill', '#94a3b8');
-
-    // Y axis
-    g.append('g')
-      .call(d3.axisLeft(yScale).ticks(5))
-      .attr('color', '#64748b')
-      .selectAll('text')
-      .attr('fill', '#94a3b8');
-
-    // Grid lines
-    g.append('g')
-      .attr('class', 'grid')
-      .attr('opacity', 0.1)
-      .call(d3.axisLeft(yScale).ticks(5).tickSize(-innerWidth).tickFormat(() => ''));
-
     // Phase marker lines (dotted vertical lines for episode phases)
     phaseMarkers.forEach((marker) => {
       const x = xScale(marker.timestamp * 1000);
       if (x < -20 || x > innerWidth + 20) return;
-      g.append('line')
+      plot.append('line')
         .attr('x1', x).attr('x2', x)
         .attr('y1', 0).attr('y2', innerHeight)
         .attr('stroke', marker.color)
@@ -417,7 +445,7 @@ export function MetricsChart({
         .attr('stroke-dasharray', '4,3')
         .attr('opacity', 0.75)
         .attr('pointer-events', 'none');
-      g.append('text')
+      plot.append('text')
         .attr('x', x + 3)
         .attr('y', 10)
         .attr('fill', marker.color)
@@ -452,7 +480,7 @@ export function MetricsChart({
 
         // Clear the brush selection visually
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        g.select('.brush').call(brush.move as any, null);
+        plot.select('.brush').call(brush.move as any, null);
 
         // Call the callback to set global time range
         if (onTimeRangeChangeRef.current && end > start) {
@@ -461,7 +489,7 @@ export function MetricsChart({
       });
 
     // Append brush to chart
-    g.append('g')
+    plot.append('g')
       .attr('class', 'brush')
       .call(brush)
       .selectAll('rect')
@@ -469,13 +497,13 @@ export function MetricsChart({
       .attr('ry', 2);
 
     // Style the brush selection
-    g.select('.brush .selection')
+    plot.select('.brush .selection')
       .attr('fill', 'rgba(139, 92, 246, 0.3)')
       .attr('stroke', '#8b5cf6')
       .attr('stroke-width', 1);
 
     // --- Hover: vertical guideline + snap dot ---
-    const hoverLine = g.append('line')
+    const hoverLine = plot.append('line')
       .attr('y1', 0)
       .attr('y2', innerHeight)
       .attr('stroke', '#94a3b8')
@@ -484,7 +512,7 @@ export function MetricsChart({
       .attr('pointer-events', 'none')
       .style('display', 'none');
 
-    const hoverDot = g.append('circle')
+    const hoverDot = plot.append('circle')
       .attr('r', 5)
       .attr('stroke', '#f8fafc')
       .attr('stroke-width', 2)
@@ -494,7 +522,7 @@ export function MetricsChart({
     type SeriesEntry = { points: Point[]; label: string; color: string; seriesKey: string };
 
     const restoreSeriesOpacity = () => {
-      g.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
+      plot.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
         const key = d3.select(this).attr('data-series-key');
         const isHighlighted = !activeHighlightedSeriesId || key === activeHighlightedSeriesId;
         d3.select(this)
@@ -506,7 +534,7 @@ export function MetricsChart({
     // Draw anomaly marker circles on top of the brush so they receive pointer events.
     // The brush overlay rect (pointer-events: all) covers the full plot area; any element
     // appended before the brush group is painted beneath it and its handlers never fire.
-    const markerSelection = g
+    const markerSelection = plot
       .append('g')
       .attr('class', 'anomaly-markers')
       .selectAll('circle')
@@ -543,7 +571,7 @@ export function MetricsChart({
       });
 
     // Add mouse handlers on the brush overlay rect so they fire regardless of brush state
-    g.select<SVGRectElement>('.brush rect.overlay')
+    plot.select<SVGRectElement>('.brush rect.overlay')
       .on('mousemove.hover', (event: MouseEvent) => {
         if (isPanningRef.current || isBrushingRef.current) {
           hoverDot.style('display', 'none');
@@ -628,7 +656,7 @@ export function MetricsChart({
 
         // Dim all series except the hovered one
         if (useVariantData && nearestSeriesKey) {
-          g.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
+          plot.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
             const key = d3.select(this).attr('data-series-key');
             const active = key === nearestSeriesKey;
             d3.select(this)
@@ -655,7 +683,27 @@ export function MetricsChart({
         setHoveredMetricRef.current(null);
       });
 
+    // Axes are not clipped so tick labels stay in the margins; drawn on top of the plot.
+    g.append('g')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(
+        d3
+          .axisBottom(xScale)
+          .ticks(6)
+          .tickFormat((d) => d3.timeFormat('%H:%M:%S')(d as Date))
+      )
+      .attr('color', '#64748b')
+      .selectAll('text')
+      .attr('fill', '#94a3b8');
+
+    g.append('g')
+      .call(d3.axisLeft(yScale).ticks(5))
+      .attr('color', '#64748b')
+      .selectAll('text')
+      .attr('fill', '#94a3b8');
+
   }, [
+    plotClipId,
     points,
     displayPoints,
     filteredAnomalies,

--- a/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsChart.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useMemo, useState, useId } from 'react';
+import { useRef, useEffect, useMemo, useState } from 'react';
 import * as d3 from 'd3';
 import type { Point, AnomalyMarker, SeriesID } from '../api/client';
 import type { CorrelationRange, TimeRange, PhaseMarker } from './ChartWithAnomalyDetails';
@@ -60,42 +60,6 @@ export function getSeriesVariantColor(index: number) {
 function getAnomalyMarkerId(anomaly: AnomalyMarker): string {
   const detectorId = anomaly.detectorComponent ?? anomaly.detectorName;
   return `${detectorId}:${anomaly.sourceSeriesId ?? 'unknown'}:${anomaly.timestamp}:${anomaly.title}`;
-}
-
-/**
- * When zoomed to a time window, include the last sample before the window and the
- * first sample after it so lines still cross the plot when the window falls between
- * bucket timestamps (strict in-range filtering would yield no points).
- */
-function augmentPointsForTimeWindow(points: Point[], timeRange: TimeRange): Point[] {
-  if (points.length === 0) return points;
-  const sorted = [...points].sort((a, b) => a.timestamp - b.timestamp);
-  const { start, end } = timeRange;
-  const inside = sorted.filter((p) => p.timestamp >= start && p.timestamp <= end);
-
-  let before: Point | undefined;
-  for (const p of sorted) {
-    if (p.timestamp < start) before = p;
-    else break;
-  }
-  let after: Point | undefined;
-  for (let i = sorted.length - 1; i >= 0; i--) {
-    const p = sorted[i];
-    if (p.timestamp > end) after = p;
-    else break;
-  }
-
-  const out: Point[] = [];
-  if (before !== undefined) out.push(before);
-  out.push(...inside);
-  if (after !== undefined) out.push(after);
-
-  const seen = new Set<number>();
-  return out.filter((p) => {
-    if (seen.has(p.timestamp)) return false;
-    seen.add(p.timestamp);
-    return true;
-  });
 }
 
 // Represents one concrete tagged series variant drawn as a separate line.
@@ -172,8 +136,6 @@ export function MetricsChart({
   const panStartRangeRef = useRef<TimeRange | null>(null);
   const panTriggerRef = useRef<'middle' | 'meta-left' | null>(null);
   const xScaleRef = useRef<d3.ScaleTime<number, number> | null>(null);
-  /** Stable id for SVG clipPath (colon-free for url(#...) references). */
-  const plotClipId = useId().replace(/:/g, '');
 
   const isSeriesVisible = (seriesId?: SeriesID): boolean => {
     if (!seriesId || !visibleSeriesIds) return true;
@@ -191,19 +153,19 @@ export function MetricsChart({
     [anomalies, enabledDetectors, visibleSeriesIds]
   );
 
-  // Points for the current zoom window, plus boundary samples so lines still render
-  // when the window falls between bucket timestamps.
+  // Filter points by time range
   const displayPoints = useMemo(() => {
     if (!timeRange) return points;
-    return augmentPointsForTimeWindow(points, timeRange);
+    return points.filter((p) => p.timestamp >= timeRange.start && p.timestamp <= timeRange.end);
   }, [points, timeRange]);
 
+  // Filter variant series points by time range
   const displaySeriesVariants = useMemo(() => {
     if (!seriesVariants) return undefined;
     if (!timeRange) return seriesVariants;
     return seriesVariants.map((s) => ({
       ...s,
-      points: augmentPointsForTimeWindow(s.points, timeRange),
+      points: s.points.filter((p) => p.timestamp >= timeRange.start && p.timestamp <= timeRange.end),
     }));
   }, [seriesVariants, timeRange]);
 
@@ -266,19 +228,9 @@ export function MetricsChart({
 
     const g = svg.append('g').attr('transform', `translate(${margin.left},${margin.top})`);
 
-    svg
-      .append('defs')
-      .append('clipPath')
-      .attr('id', plotClipId)
-      .append('rect')
-      .attr('width', innerWidth)
-      .attr('height', innerHeight);
-
-    const plot = g.append('g').attr('class', 'metrics-plot-area').attr('clip-path', `url(#${plotClipId})`);
-
     // Determine which data to use for scales and rendering
     const useVariantData = variantMode;
-    const pointsToRender = displayPoints;
+    const pointsToRender = displayPoints.length > 0 ? displayPoints : points;
     const allVariantPoints = orderedSeriesVariants?.flatMap((s) => s.points) ?? [];
     const visibleVariantPoints = visibleOrderedSeriesVariants?.flatMap((s) => s.points) ?? [];
 
@@ -329,7 +281,7 @@ export function MetricsChart({
       const x2 = xScale(range.end * 1000);
       const rectWidth = Math.max(x2 - x1, 4); // Minimum 4px width for visibility
 
-      plot.append('rect')
+      g.append('rect')
         .attr('x', x1)
         .attr('y', 0)
         .attr('width', rectWidth)
@@ -340,12 +292,6 @@ export function MetricsChart({
         .attr('stroke-dasharray', '4,2')
         .attr('opacity', 0.5);
     });
-
-    // Grid lines (under series lines; clipped to plot area)
-    plot.append('g')
-      .attr('class', 'grid')
-      .attr('opacity', 0.1)
-      .call(d3.axisLeft(yScale).ticks(5).tickSize(-innerWidth).tickFormat(() => ''));
 
     // Group anomalies by timestamp to handle overlaps
     const anomaliesByTimestamp = new Map<number, typeof filteredAnomalies>();
@@ -413,7 +359,7 @@ export function MetricsChart({
         const colorIdx = orderedSeriesVariants?.findIndex((s) => s.seriesId === series.seriesId && s.label === series.label) ?? 0;
         const color = getSeriesVariantColor(Math.max(colorIdx, 0));
         const isHighlighted = !activeHighlightedSeriesId || !series.seriesId || series.seriesId === activeHighlightedSeriesId;
-        plot.append('path')
+        g.append('path')
           .datum(series.points)
           .attr('fill', 'none')
           .attr('stroke', color)
@@ -425,7 +371,7 @@ export function MetricsChart({
 
     } else {
       // Draw single line
-      plot.append('path')
+      g.append('path')
         .datum(pointsToRender)
         .attr('fill', 'none')
         .attr('stroke', '#8b5cf6')
@@ -433,11 +379,37 @@ export function MetricsChart({
         .attr('d', line);
     }
 
+    // X axis
+    g.append('g')
+      .attr('transform', `translate(0,${innerHeight})`)
+      .call(
+        d3
+          .axisBottom(xScale)
+          .ticks(6)
+          .tickFormat((d) => d3.timeFormat('%H:%M:%S')(d as Date))
+      )
+      .attr('color', '#64748b')
+      .selectAll('text')
+      .attr('fill', '#94a3b8');
+
+    // Y axis
+    g.append('g')
+      .call(d3.axisLeft(yScale).ticks(5))
+      .attr('color', '#64748b')
+      .selectAll('text')
+      .attr('fill', '#94a3b8');
+
+    // Grid lines
+    g.append('g')
+      .attr('class', 'grid')
+      .attr('opacity', 0.1)
+      .call(d3.axisLeft(yScale).ticks(5).tickSize(-innerWidth).tickFormat(() => ''));
+
     // Phase marker lines (dotted vertical lines for episode phases)
     phaseMarkers.forEach((marker) => {
       const x = xScale(marker.timestamp * 1000);
       if (x < -20 || x > innerWidth + 20) return;
-      plot.append('line')
+      g.append('line')
         .attr('x1', x).attr('x2', x)
         .attr('y1', 0).attr('y2', innerHeight)
         .attr('stroke', marker.color)
@@ -445,7 +417,7 @@ export function MetricsChart({
         .attr('stroke-dasharray', '4,3')
         .attr('opacity', 0.75)
         .attr('pointer-events', 'none');
-      plot.append('text')
+      g.append('text')
         .attr('x', x + 3)
         .attr('y', 10)
         .attr('fill', marker.color)
@@ -480,7 +452,7 @@ export function MetricsChart({
 
         // Clear the brush selection visually
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        plot.select('.brush').call(brush.move as any, null);
+        g.select('.brush').call(brush.move as any, null);
 
         // Call the callback to set global time range
         if (onTimeRangeChangeRef.current && end > start) {
@@ -489,7 +461,7 @@ export function MetricsChart({
       });
 
     // Append brush to chart
-    plot.append('g')
+    g.append('g')
       .attr('class', 'brush')
       .call(brush)
       .selectAll('rect')
@@ -497,13 +469,13 @@ export function MetricsChart({
       .attr('ry', 2);
 
     // Style the brush selection
-    plot.select('.brush .selection')
+    g.select('.brush .selection')
       .attr('fill', 'rgba(139, 92, 246, 0.3)')
       .attr('stroke', '#8b5cf6')
       .attr('stroke-width', 1);
 
     // --- Hover: vertical guideline + snap dot ---
-    const hoverLine = plot.append('line')
+    const hoverLine = g.append('line')
       .attr('y1', 0)
       .attr('y2', innerHeight)
       .attr('stroke', '#94a3b8')
@@ -512,7 +484,7 @@ export function MetricsChart({
       .attr('pointer-events', 'none')
       .style('display', 'none');
 
-    const hoverDot = plot.append('circle')
+    const hoverDot = g.append('circle')
       .attr('r', 5)
       .attr('stroke', '#f8fafc')
       .attr('stroke-width', 2)
@@ -522,7 +494,7 @@ export function MetricsChart({
     type SeriesEntry = { points: Point[]; label: string; color: string; seriesKey: string };
 
     const restoreSeriesOpacity = () => {
-      plot.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
+      g.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
         const key = d3.select(this).attr('data-series-key');
         const isHighlighted = !activeHighlightedSeriesId || key === activeHighlightedSeriesId;
         d3.select(this)
@@ -534,7 +506,7 @@ export function MetricsChart({
     // Draw anomaly marker circles on top of the brush so they receive pointer events.
     // The brush overlay rect (pointer-events: all) covers the full plot area; any element
     // appended before the brush group is painted beneath it and its handlers never fire.
-    const markerSelection = plot
+    const markerSelection = g
       .append('g')
       .attr('class', 'anomaly-markers')
       .selectAll('circle')
@@ -571,7 +543,7 @@ export function MetricsChart({
       });
 
     // Add mouse handlers on the brush overlay rect so they fire regardless of brush state
-    plot.select<SVGRectElement>('.brush rect.overlay')
+    g.select<SVGRectElement>('.brush rect.overlay')
       .on('mousemove.hover', (event: MouseEvent) => {
         if (isPanningRef.current || isBrushingRef.current) {
           hoverDot.style('display', 'none');
@@ -656,7 +628,7 @@ export function MetricsChart({
 
         // Dim all series except the hovered one
         if (useVariantData && nearestSeriesKey) {
-          plot.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
+          g.selectAll<SVGPathElement, unknown>('path[data-series-key]').each(function() {
             const key = d3.select(this).attr('data-series-key');
             const active = key === nearestSeriesKey;
             d3.select(this)
@@ -683,27 +655,7 @@ export function MetricsChart({
         setHoveredMetricRef.current(null);
       });
 
-    // Axes are not clipped so tick labels stay in the margins; drawn on top of the plot.
-    g.append('g')
-      .attr('transform', `translate(0,${innerHeight})`)
-      .call(
-        d3
-          .axisBottom(xScale)
-          .ticks(6)
-          .tickFormat((d) => d3.timeFormat('%H:%M:%S')(d as Date))
-      )
-      .attr('color', '#64748b')
-      .selectAll('text')
-      .attr('fill', '#94a3b8');
-
-    g.append('g')
-      .call(d3.axisLeft(yScale).ticks(5))
-      .attr('color', '#64748b')
-      .selectAll('text')
-      .attr('fill', '#94a3b8');
-
   }, [
-    plotClipId,
     points,
     displayPoints,
     filteredAnomalies,

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -24,6 +24,10 @@ function getAggregationType(name: string): AggregationType | null {
   return match ? (match[1] as AggregationType) : null;
 }
 
+function isPatternCounterBaseName(baseName: string): boolean {
+  return /^log\.log_pattern_extractor\.[0-9a-f]+\.count$/.test(baseName);
+}
+
 function getDetectorComponent(anomaly: { detectorName: string; detectorComponent?: string }): string {
   return anomaly.detectorComponent ?? anomaly.detectorName;
 }
@@ -63,7 +67,7 @@ function CounterRateToggleBar({
   const modes: { mode: CounterChartViewMode; label: string; title: string }[] = [
     { mode: 'raw', label: firstLabel, title: firstTitle },
     { mode: 'rate-sec', label: 'evt/s', title: 'Events per second (count ÷ bucket size)' },
-    { mode: 'rate-min', label: 'evt/min', title: 'Events per minute (60 s sliding window)' },
+    { mode: 'rate-min', label: 'evt/min', title: 'Events per minute ((count ÷ bucket size) × 60)' },
   ];
   return (
     <div className="inline-flex shrink-0 rounded overflow-hidden border border-slate-600 text-xs">
@@ -163,26 +167,13 @@ export function MetricsView({
     return dense.map((p) => ({ timestamp: p.timestamp, value: p.value / bucketSec }));
   };
 
-  // Rate (evt/min): sliding-window sum over the last 60 s of dense buckets — O(N).
+  // Rate (evt/min): same per-bucket count normalized to one minute.
   const toRatePerMinSeries = (points: Point[]): Point[] => {
     if (points.length === 0) return points;
     if (points.length === 1) return [{ timestamp: points[0].timestamp, value: 0 }];
     const [bucketSec, dense] = fillBuckets(points);
     if (bucketSec <= 0) return points;
-    const windowSec = 60;
-    const result: Point[] = [];
-    let windowSum = 0;
-    let left = 0;
-    for (let right = 0; right < dense.length; right++) {
-      windowSum += dense[right].value;
-      // Evict buckets that fall outside the 60 s window.
-      while (dense[right].timestamp - dense[left].timestamp >= windowSec) {
-        windowSum -= dense[left].value;
-        left++;
-      }
-      result.push({ timestamp: dense[right].timestamp, value: windowSum });
-    }
-    return result;
+    return dense.map((p) => ({ timestamp: p.timestamp, value: (p.value / bucketSec) * 60 }));
   };
 
   /** Per-group display for counters: raw bucket values (or cumulative for telemetry), evt/s, evt/min. Pattern groups default to evt/s until changed. */
@@ -279,8 +270,12 @@ export function MetricsView({
     () =>
       allSeries.filter((s) => {
         const agg = getAggregationType(s.name);
+        const baseName = getBaseMetricName(s.name);
         if (s.metricKind === 'counter') {
           return agg === 'sum' || agg === 'avg' || agg === 'count';
+        }
+        if (isPatternCounterBaseName(baseName)) {
+          return agg === 'count';
         }
         return agg === aggregationType;
       }),

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -44,6 +44,45 @@ function cumulativeFromStart(points: Point[]): Point[] {
   });
 }
 
+type CounterChartViewMode = 'raw' | 'rate-sec' | 'rate-min';
+
+/** Raw | evt/s | evt/min for counter series (first label describes raw: count per bucket or cumulative). */
+function CounterRateToggleBar({
+  viewMode,
+  onModeChange,
+  firstLabel,
+  firstTitle,
+  activeClassName,
+}: {
+  viewMode: CounterChartViewMode;
+  onModeChange: (m: CounterChartViewMode) => void;
+  firstLabel: string;
+  firstTitle: string;
+  activeClassName: string;
+}) {
+  const modes: { mode: CounterChartViewMode; label: string; title: string }[] = [
+    { mode: 'raw', label: firstLabel, title: firstTitle },
+    { mode: 'rate-sec', label: 'evt/s', title: 'Events per second (count ÷ bucket size)' },
+    { mode: 'rate-min', label: 'evt/min', title: 'Events per minute (60 s sliding window)' },
+  ];
+  return (
+    <div className="inline-flex shrink-0 rounded overflow-hidden border border-slate-600 text-xs">
+      {modes.map(({ mode, label, title }) => (
+        <button
+          key={mode}
+          type="button"
+          onClick={() => onModeChange(mode)}
+          className={`px-2.5 py-1 transition-colors ${
+            viewMode === mode ? `${activeClassName} text-white` : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
+          }`}
+          title={title}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 interface MetricGroup {
   key: string;
@@ -146,13 +185,21 @@ export function MetricsView({
     return result;
   };
 
-  type PatternViewMode = 'raw' | 'rate-sec' | 'rate-min';
-
-  // Per-group view mode for pattern series. Defaults to 'rate-sec' when first selected.
-  const [patternViewMode, setPatternViewMode] = useState<Map<string, PatternViewMode>>(new Map());
-  const setGroupViewMode = (groupKey: string, mode: PatternViewMode) => {
-    setPatternViewMode((prev) => new Map([...prev, [groupKey, mode]]));
+  /** Per-group display for counters: raw bucket values (or cumulative for telemetry), evt/s, evt/min. Pattern groups default to evt/s until changed. */
+  const [counterChartViewMode, setCounterChartViewMode] = useState<Map<string, CounterChartViewMode>>(new Map());
+  const setGroupCounterChartMode = (groupKey: string, mode: CounterChartViewMode) => {
+    setCounterChartViewMode((prev) => new Map([...prev, [groupKey, mode]]));
   };
+
+  function getCounterChartViewMode(
+    groupKey: string,
+    isPatternSeries: boolean
+  ): CounterChartViewMode {
+    const v = counterChartViewMode.get(groupKey);
+    if (v !== undefined) return v;
+    return isPatternSeries ? 'rate-sec' : 'raw';
+  }
+
 
   // When LogView requests a jump to a specific series group, select it, then clear the request
   // so the same groupKey can be requested again (same pattern as requestedPatternFilter in LogView).
@@ -163,7 +210,7 @@ export function MetricsView({
     setAggregationType('count');
     setSelectedGroups((prev) => new Set([...prev, requestedFocusedGroupKey]));
     if (getPatternHash(requestedFocusedGroupKey)) {
-      setPatternViewMode((prev) => new Map([...prev, [requestedFocusedGroupKey, 'rate-sec']]));
+      setCounterChartViewMode((prev) => new Map([...prev, [requestedFocusedGroupKey, 'rate-sec']]));
     }
     onRequestedFocusedGroupKeyConsumed?.();
   }, [requestedFocusedGroupKey, onRequestedFocusedGroupKeyConsumed]);
@@ -174,7 +221,7 @@ export function MetricsView({
     const prev = prevSelectedForRateRef.current;
     const added = [...selectedGroups].filter((k) => !prev.has(k) && getPatternHash(k) !== null);
     if (added.length > 0) {
-      setPatternViewMode((m) => {
+      setCounterChartViewMode((m) => {
         const next = new Map(m);
         for (const k of added) if (!next.has(k)) next.set(k, 'rate-sec');
         return next;
@@ -671,6 +718,18 @@ export function MetricsView({
                       return g && g.namespace !== 'telemetry' && !g.virtual;
                     })
                     .map((groupKey) => {
+                      const group = groupByKey.get(groupKey);
+                      if (!group) return null;
+                      const isCounterGroup = group.members.some((m) => m.metricKind === 'counter');
+                      const viewMode = getCounterChartViewMode(groupKey, false);
+                      const transformPoints =
+                        isCounterGroup
+                          ? (viewMode === 'rate-sec'
+                            ? toRateSeries
+                            : viewMode === 'rate-min'
+                              ? toRatePerMinSeries
+                              : (pts: Point[]) => pts)
+                          : (pts: Point[]) => pts;
                       const dataList = groupSeriesData.get(groupKey) ?? [];
                       if (dataList.length === 0) return null;
                       const tagFiltered = (tagFilter.include.size > 0 || tagFilter.exclude.size > 0)
@@ -685,15 +744,31 @@ export function MetricsView({
                       const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
                       const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                         label: formatSeriesLabel(d.tags),
-                        points: d.points,
+                        points: transformPoints(d.points),
                         seriesId: d.id,
                       }));
                       const primary = chartSeries[0];
+                      const primaryPoints = transformPoints(primary.points);
+                      const modeLabel =
+                        isCounterGroup && viewMode === 'rate-sec'
+                          ? ' (evt/s)'
+                          : isCounterGroup && viewMode === 'rate-min'
+                            ? ' (evt/min)'
+                            : '';
+                      const subtitle = isCounterGroup ? (
+                        <CounterRateToggleBar
+                          viewMode={viewMode}
+                          onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
+                          firstLabel="Raw"
+                          firstTitle="Values per time bucket (counter deltas or aggregation)"
+                          activeClassName="bg-purple-700"
+                        />
+                      ) : undefined;
                       return (
                         <ChartWithAnomalyDetails
-                          key={groupKey}
-                          name={primary.name}
-                          points={primary.points}
+                          key={`${groupKey}-${isCounterGroup ? viewMode : 'gauge'}`}
+                          name={`${primary.name}${modeLabel}`}
+                          points={primaryPoints}
                           anomalyMarkers={anomalyMarkers}
                           anomalies={seriesAnomalies}
                           correlationRanges={[]}
@@ -703,6 +778,7 @@ export function MetricsView({
                           smoothLines={smoothLines}
                           seriesVariants={seriesVariants}
                           phaseMarkers={phaseMarkers}
+                          subtitle={subtitle}
                         />
                       );
                     })
@@ -730,6 +806,20 @@ export function MetricsView({
                           return g && g.virtual;
                         })
                         .map((groupKey) => {
+                          const grp = groupByKey.get(groupKey);
+                          if (!grp) return null;
+                          const patternHash = getPatternHash(groupKey);
+                          const isPatternSeries = patternHash !== null;
+                          const isCounterVirtual = grp.members.some((m) => m.metricKind === 'counter');
+                          const showCounterRateUi = isPatternSeries || isCounterVirtual;
+                          const viewMode = getCounterChartViewMode(groupKey, isPatternSeries);
+                          const transformPoints = showCounterRateUi
+                            ? (viewMode === 'rate-sec'
+                              ? toRateSeries
+                              : viewMode === 'rate-min'
+                                ? toRatePerMinSeries
+                                : (pts: Point[]) => pts)
+                            : (pts: Point[]) => pts;
                           const dataList = groupSeriesData.get(groupKey) ?? [];
                           if (dataList.length === 0) return null;
                           const chartSeries = showAnomalyOnlySeriesLines
@@ -739,13 +829,6 @@ export function MetricsView({
                           const seriesIDs = new Set(chartSeries.map((d) => d.id));
                           const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                           const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
-                          const patternHash = getPatternHash(groupKey);
-                          const isPatternSeries = patternHash !== null;
-                          const viewMode: PatternViewMode = (isPatternSeries && patternViewMode.get(groupKey)) || 'raw';
-                          const transformPoints =
-                            viewMode === 'rate-sec' ? toRateSeries :
-                            viewMode === 'rate-min' ? toRatePerMinSeries :
-                            (pts: Point[]) => pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                             label: formatSeriesLabel(d.tags),
                             points: transformPoints(d.points),
@@ -754,8 +837,13 @@ export function MetricsView({
                           const primary = chartSeries[0];
                           const primaryPoints = transformPoints(primary.points);
                           const patternString = patternHash ? logPatternByHash.get(patternHash) : undefined;
-                          const modeLabel = viewMode === 'rate-sec' ? ' (evt/s)' : viewMode === 'rate-min' ? ' (evt/min)' : '';
-                          const subtitle = (patternString || isPatternSeries) ? (
+                          const modeLabel =
+                            showCounterRateUi && viewMode === 'rate-sec'
+                              ? ' (evt/s)'
+                              : showCounterRateUi && viewMode === 'rate-min'
+                                ? ' (evt/min)'
+                                : '';
+                          const subtitle = (patternString || showCounterRateUi) ? (
                             <div className="space-y-2">
                               {patternString && (
                                 <div>
@@ -765,41 +853,33 @@ export function MetricsView({
                                   </pre>
                                 </div>
                               )}
-                              <div className="flex items-center gap-2">
-                                <div className="flex rounded overflow-hidden border border-slate-600 text-xs">
-                                  {(
-                                    [
-                                      { mode: 'raw' as PatternViewMode, label: 'Raw', title: 'Count per bucket' },
-                                      { mode: 'rate-sec' as PatternViewMode, label: 'evt/s', title: 'Events per second (count ÷ bucket size)' },
-                                      { mode: 'rate-min' as PatternViewMode, label: 'evt/min', title: 'Events per minute (60 s sliding window)' },
-                                    ] as const
-                                  ).map(({ mode, label, title }) => (
+                              {showCounterRateUi && (
+                                <div className="flex items-center gap-2">
+                                  <CounterRateToggleBar
+                                    viewMode={viewMode}
+                                    onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
+                                    firstLabel="Raw"
+                                    firstTitle="Count per bucket"
+                                    activeClassName="bg-cyan-700"
+                                  />
+                                  <div className="flex-1" />
+                                  {onJumpToPattern && patternHash && (
                                     <button
-                                      key={mode}
-                                      onClick={() => setGroupViewMode(groupKey, mode)}
-                                      className={`px-2.5 py-1 transition-colors ${viewMode === mode ? 'bg-cyan-700 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'}`}
-                                      title={title}
+                                      type="button"
+                                      onClick={() => onJumpToPattern(patternHash)}
+                                      className="text-xs px-2.5 py-1.5 rounded bg-slate-700 text-slate-300 hover:bg-slate-600 transition-colors"
+                                      title="Filter logs by this pattern in the Logs tab"
                                     >
-                                      {label}
+                                      ↗ View in logs
                                     </button>
-                                  ))}
+                                  )}
                                 </div>
-                                <div className="flex-1" />
-                                {onJumpToPattern && patternHash && (
-                                  <button
-                                    onClick={() => onJumpToPattern(patternHash)}
-                                    className="text-xs px-2.5 py-1.5 rounded bg-slate-700 text-slate-300 hover:bg-slate-600 transition-colors"
-                                    title="Filter logs by this pattern in the Logs tab"
-                                  >
-                                    ↗ View in logs
-                                  </button>
-                                )}
-                              </div>
+                              )}
                             </div>
                           ) : undefined;
                           return (
                             <ChartWithAnomalyDetails
-                              key={`${groupKey}-${viewMode}`}
+                              key={`${groupKey}-${showCounterRateUi ? viewMode : 'nov'}`}
                               name={`${primary.name}${modeLabel}`}
                               points={primaryPoints}
                               anomalyMarkers={anomalyMarkers}
@@ -831,9 +911,9 @@ export function MetricsView({
                         </div>
                         <span
                           className="text-[10px] text-slate-500 max-w-md text-center px-2"
-                          title="Counter metrics: sum of deltas per time bucket, displayed as a running total from scenario start. Gauges follow the aggregation control."
+                          title="Counter metrics: default chart is cumulative from start; use Raw | evt/s | evt/min on each chart for rates. Gauges follow the aggregation control."
                         >
-                          Counters: cumulative from start · Gauges: aggregation above
+                          Counters: use chart toggle for cumulative vs rate · Gauges: aggregation above
                         </span>
                       </div>
                       <div className="flex-1 border-t border-purple-800/50" />
@@ -847,6 +927,7 @@ export function MetricsView({
                         .map((groupKey) => {
                           const group = groupByKey.get(groupKey);
                           const isCounterTelemetry = group?.members.some((m) => m.metricKind === 'counter');
+                          const viewMode = getCounterChartViewMode(groupKey, false);
                           const dataList = groupSeriesData.get(groupKey) ?? [];
                           if (dataList.length === 0) return null;
                           const chartSeries = showAnomalyOnlySeriesLines
@@ -856,8 +937,12 @@ export function MetricsView({
                           const seriesIDs = new Set(chartSeries.map((d) => d.id));
                           const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                           const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
-                          const mapPoints = (pts: Point[]) =>
-                            isCounterTelemetry ? cumulativeFromStart(pts) : pts;
+                          const mapPoints = (pts: Point[]) => {
+                            if (!isCounterTelemetry) return pts;
+                            if (viewMode === 'rate-sec') return toRateSeries(pts);
+                            if (viewMode === 'rate-min') return toRatePerMinSeries(pts);
+                            return cumulativeFromStart(pts);
+                          };
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                             label: formatSeriesLabel(d.tags),
                             points: mapPoints(d.points),
@@ -865,10 +950,27 @@ export function MetricsView({
                           }));
                           const primary = chartSeries[0];
                           const chartTitleBase = getBaseMetricName(primary.name);
-                          const chartTitle = isCounterTelemetry ? `${chartTitleBase} (cumulative)` : primary.name;
+                          const counterSuffix =
+                            isCounterTelemetry && viewMode === 'rate-sec'
+                              ? ' (evt/s)'
+                              : isCounterTelemetry && viewMode === 'rate-min'
+                                ? ' (evt/min)'
+                                : isCounterTelemetry
+                                  ? ' (cumulative)'
+                                  : '';
+                          const chartTitle = isCounterTelemetry ? `${chartTitleBase}${counterSuffix}` : primary.name;
+                          const subtitle = isCounterTelemetry ? (
+                            <CounterRateToggleBar
+                              viewMode={viewMode}
+                              onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
+                              firstLabel="Cumulative"
+                              firstTitle="Running total from scenario start (sum of per-bucket deltas)"
+                              activeClassName="bg-purple-700"
+                            />
+                          ) : undefined;
                           return (
                             <ChartWithAnomalyDetails
-                              key={groupKey}
+                              key={`${groupKey}-${isCounterTelemetry ? viewMode : 'gauge'}`}
                               name={chartTitle}
                               points={mapPoints(primary.points)}
                               anomalyMarkers={anomalyMarkers}
@@ -881,6 +983,7 @@ export function MetricsView({
                               seriesVariants={seriesVariants}
                               isTelemetry
                               phaseMarkers={phaseMarkers}
+                              subtitle={subtitle}
                             />
                           );
                         })}

--- a/cmd/observer-testbench/ui/src/components/MetricsView.tsx
+++ b/cmd/observer-testbench/ui/src/components/MetricsView.tsx
@@ -48,46 +48,6 @@ function cumulativeFromStart(points: Point[]): Point[] {
   });
 }
 
-type CounterChartViewMode = 'raw' | 'rate-sec' | 'rate-min';
-
-/** Raw | evt/s | evt/min for counter series (first label describes raw: count per bucket or cumulative). */
-function CounterRateToggleBar({
-  viewMode,
-  onModeChange,
-  firstLabel,
-  firstTitle,
-  activeClassName,
-}: {
-  viewMode: CounterChartViewMode;
-  onModeChange: (m: CounterChartViewMode) => void;
-  firstLabel: string;
-  firstTitle: string;
-  activeClassName: string;
-}) {
-  const modes: { mode: CounterChartViewMode; label: string; title: string }[] = [
-    { mode: 'raw', label: firstLabel, title: firstTitle },
-    { mode: 'rate-sec', label: 'evt/s', title: 'Events per second (count ÷ bucket size)' },
-    { mode: 'rate-min', label: 'evt/min', title: 'Events per minute ((count ÷ bucket size) × 60)' },
-  ];
-  return (
-    <div className="inline-flex shrink-0 rounded overflow-hidden border border-slate-600 text-xs">
-      {modes.map(({ mode, label, title }) => (
-        <button
-          key={mode}
-          type="button"
-          onClick={() => onModeChange(mode)}
-          className={`px-2.5 py-1 transition-colors ${
-            viewMode === mode ? `${activeClassName} text-white` : 'bg-slate-800 text-slate-400 hover:bg-slate-700'
-          }`}
-          title={title}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 interface MetricGroup {
   key: string;
   namespace: string;
@@ -176,21 +136,13 @@ export function MetricsView({
     return dense.map((p) => ({ timestamp: p.timestamp, value: (p.value / bucketSec) * 60 }));
   };
 
-  /** Per-group display for counters: raw bucket values (or cumulative for telemetry), evt/s, evt/min. Pattern groups default to evt/s until changed. */
-  const [counterChartViewMode, setCounterChartViewMode] = useState<Map<string, CounterChartViewMode>>(new Map());
-  const setGroupCounterChartMode = (groupKey: string, mode: CounterChartViewMode) => {
-    setCounterChartViewMode((prev) => new Map([...prev, [groupKey, mode]]));
+  type PatternViewMode = 'raw' | 'rate-sec' | 'rate-min';
+
+  // Per-group view mode for pattern series. Defaults to 'rate-sec' when first selected.
+  const [patternViewMode, setPatternViewMode] = useState<Map<string, PatternViewMode>>(new Map());
+  const setGroupViewMode = (groupKey: string, mode: PatternViewMode) => {
+    setPatternViewMode((prev) => new Map([...prev, [groupKey, mode]]));
   };
-
-  function getCounterChartViewMode(
-    groupKey: string,
-    isPatternSeries: boolean
-  ): CounterChartViewMode {
-    const v = counterChartViewMode.get(groupKey);
-    if (v !== undefined) return v;
-    return isPatternSeries ? 'rate-sec' : 'raw';
-  }
-
 
   // When LogView requests a jump to a specific series group, select it, then clear the request
   // so the same groupKey can be requested again (same pattern as requestedPatternFilter in LogView).
@@ -201,7 +153,7 @@ export function MetricsView({
     setAggregationType('count');
     setSelectedGroups((prev) => new Set([...prev, requestedFocusedGroupKey]));
     if (getPatternHash(requestedFocusedGroupKey)) {
-      setCounterChartViewMode((prev) => new Map([...prev, [requestedFocusedGroupKey, 'rate-sec']]));
+      setPatternViewMode((prev) => new Map([...prev, [requestedFocusedGroupKey, 'rate-sec']]));
     }
     onRequestedFocusedGroupKeyConsumed?.();
   }, [requestedFocusedGroupKey, onRequestedFocusedGroupKeyConsumed]);
@@ -212,7 +164,7 @@ export function MetricsView({
     const prev = prevSelectedForRateRef.current;
     const added = [...selectedGroups].filter((k) => !prev.has(k) && getPatternHash(k) !== null);
     if (added.length > 0) {
-      setCounterChartViewMode((m) => {
+      setPatternViewMode((m) => {
         const next = new Map(m);
         for (const k of added) if (!next.has(k)) next.set(k, 'rate-sec');
         return next;
@@ -713,18 +665,6 @@ export function MetricsView({
                       return g && g.namespace !== 'telemetry' && !g.virtual;
                     })
                     .map((groupKey) => {
-                      const group = groupByKey.get(groupKey);
-                      if (!group) return null;
-                      const isCounterGroup = group.members.some((m) => m.metricKind === 'counter');
-                      const viewMode = getCounterChartViewMode(groupKey, false);
-                      const transformPoints =
-                        isCounterGroup
-                          ? (viewMode === 'rate-sec'
-                            ? toRateSeries
-                            : viewMode === 'rate-min'
-                              ? toRatePerMinSeries
-                              : (pts: Point[]) => pts)
-                          : (pts: Point[]) => pts;
                       const dataList = groupSeriesData.get(groupKey) ?? [];
                       if (dataList.length === 0) return null;
                       const tagFiltered = (tagFilter.include.size > 0 || tagFilter.exclude.size > 0)
@@ -739,31 +679,15 @@ export function MetricsView({
                       const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
                       const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                         label: formatSeriesLabel(d.tags),
-                        points: transformPoints(d.points),
+                        points: d.points,
                         seriesId: d.id,
                       }));
                       const primary = chartSeries[0];
-                      const primaryPoints = transformPoints(primary.points);
-                      const modeLabel =
-                        isCounterGroup && viewMode === 'rate-sec'
-                          ? ' (evt/s)'
-                          : isCounterGroup && viewMode === 'rate-min'
-                            ? ' (evt/min)'
-                            : '';
-                      const subtitle = isCounterGroup ? (
-                        <CounterRateToggleBar
-                          viewMode={viewMode}
-                          onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
-                          firstLabel="Raw"
-                          firstTitle="Values per time bucket (counter deltas or aggregation)"
-                          activeClassName="bg-purple-700"
-                        />
-                      ) : undefined;
                       return (
                         <ChartWithAnomalyDetails
-                          key={`${groupKey}-${isCounterGroup ? viewMode : 'gauge'}`}
-                          name={`${primary.name}${modeLabel}`}
-                          points={primaryPoints}
+                          key={groupKey}
+                          name={primary.name}
+                          points={primary.points}
                           anomalyMarkers={anomalyMarkers}
                           anomalies={seriesAnomalies}
                           correlationRanges={[]}
@@ -773,7 +697,6 @@ export function MetricsView({
                           smoothLines={smoothLines}
                           seriesVariants={seriesVariants}
                           phaseMarkers={phaseMarkers}
-                          subtitle={subtitle}
                         />
                       );
                     })
@@ -801,20 +724,6 @@ export function MetricsView({
                           return g && g.virtual;
                         })
                         .map((groupKey) => {
-                          const grp = groupByKey.get(groupKey);
-                          if (!grp) return null;
-                          const patternHash = getPatternHash(groupKey);
-                          const isPatternSeries = patternHash !== null;
-                          const isCounterVirtual = grp.members.some((m) => m.metricKind === 'counter');
-                          const showCounterRateUi = isPatternSeries || isCounterVirtual;
-                          const viewMode = getCounterChartViewMode(groupKey, isPatternSeries);
-                          const transformPoints = showCounterRateUi
-                            ? (viewMode === 'rate-sec'
-                              ? toRateSeries
-                              : viewMode === 'rate-min'
-                                ? toRatePerMinSeries
-                                : (pts: Point[]) => pts)
-                            : (pts: Point[]) => pts;
                           const dataList = groupSeriesData.get(groupKey) ?? [];
                           if (dataList.length === 0) return null;
                           const chartSeries = showAnomalyOnlySeriesLines
@@ -824,6 +733,13 @@ export function MetricsView({
                           const seriesIDs = new Set(chartSeries.map((d) => d.id));
                           const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                           const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
+                          const patternHash = getPatternHash(groupKey);
+                          const isPatternSeries = patternHash !== null;
+                          const viewMode: PatternViewMode = (isPatternSeries && patternViewMode.get(groupKey)) || 'raw';
+                          const transformPoints =
+                            viewMode === 'rate-sec' ? toRateSeries :
+                            viewMode === 'rate-min' ? toRatePerMinSeries :
+                            (pts: Point[]) => pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                             label: formatSeriesLabel(d.tags),
                             points: transformPoints(d.points),
@@ -832,13 +748,8 @@ export function MetricsView({
                           const primary = chartSeries[0];
                           const primaryPoints = transformPoints(primary.points);
                           const patternString = patternHash ? logPatternByHash.get(patternHash) : undefined;
-                          const modeLabel =
-                            showCounterRateUi && viewMode === 'rate-sec'
-                              ? ' (evt/s)'
-                              : showCounterRateUi && viewMode === 'rate-min'
-                                ? ' (evt/min)'
-                                : '';
-                          const subtitle = (patternString || showCounterRateUi) ? (
+                          const modeLabel = viewMode === 'rate-sec' ? ' (evt/s)' : viewMode === 'rate-min' ? ' (evt/min)' : '';
+                          const subtitle = (patternString || isPatternSeries) ? (
                             <div className="space-y-2">
                               {patternString && (
                                 <div>
@@ -848,33 +759,41 @@ export function MetricsView({
                                   </pre>
                                 </div>
                               )}
-                              {showCounterRateUi && (
-                                <div className="flex items-center gap-2">
-                                  <CounterRateToggleBar
-                                    viewMode={viewMode}
-                                    onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
-                                    firstLabel="Raw"
-                                    firstTitle="Count per bucket"
-                                    activeClassName="bg-cyan-700"
-                                  />
-                                  <div className="flex-1" />
-                                  {onJumpToPattern && patternHash && (
+                              <div className="flex items-center gap-2">
+                                <div className="flex rounded overflow-hidden border border-slate-600 text-xs">
+                                  {(
+                                    [
+                                      { mode: 'raw' as PatternViewMode, label: 'Raw', title: 'Count per bucket' },
+                                      { mode: 'rate-sec' as PatternViewMode, label: 'evt/s', title: 'Events per second (count ÷ bucket size)' },
+                                      { mode: 'rate-min' as PatternViewMode, label: 'evt/min', title: 'Events per minute (60 s sliding window)' },
+                                    ] as const
+                                  ).map(({ mode, label, title }) => (
                                     <button
-                                      type="button"
-                                      onClick={() => onJumpToPattern(patternHash)}
-                                      className="text-xs px-2.5 py-1.5 rounded bg-slate-700 text-slate-300 hover:bg-slate-600 transition-colors"
-                                      title="Filter logs by this pattern in the Logs tab"
+                                      key={mode}
+                                      onClick={() => setGroupViewMode(groupKey, mode)}
+                                      className={`px-2.5 py-1 transition-colors ${viewMode === mode ? 'bg-cyan-700 text-white' : 'bg-slate-800 text-slate-400 hover:bg-slate-700'}`}
+                                      title={title}
                                     >
-                                      ↗ View in logs
+                                      {label}
                                     </button>
-                                  )}
+                                  ))}
                                 </div>
-                              )}
+                                <div className="flex-1" />
+                                {onJumpToPattern && patternHash && (
+                                  <button
+                                    onClick={() => onJumpToPattern(patternHash)}
+                                    className="text-xs px-2.5 py-1.5 rounded bg-slate-700 text-slate-300 hover:bg-slate-600 transition-colors"
+                                    title="Filter logs by this pattern in the Logs tab"
+                                  >
+                                    ↗ View in logs
+                                  </button>
+                                )}
+                              </div>
                             </div>
                           ) : undefined;
                           return (
                             <ChartWithAnomalyDetails
-                              key={`${groupKey}-${showCounterRateUi ? viewMode : 'nov'}`}
+                              key={`${groupKey}-${viewMode}`}
                               name={`${primary.name}${modeLabel}`}
                               points={primaryPoints}
                               anomalyMarkers={anomalyMarkers}
@@ -906,9 +825,9 @@ export function MetricsView({
                         </div>
                         <span
                           className="text-[10px] text-slate-500 max-w-md text-center px-2"
-                          title="Counter metrics: default chart is cumulative from start; use Raw | evt/s | evt/min on each chart for rates. Gauges follow the aggregation control."
+                          title="Counter metrics: sum of deltas per time bucket, displayed as a running total from scenario start. Gauges follow the aggregation control."
                         >
-                          Counters: use chart toggle for cumulative vs rate · Gauges: aggregation above
+                          Counters: cumulative from start · Gauges: aggregation above
                         </span>
                       </div>
                       <div className="flex-1 border-t border-purple-800/50" />
@@ -922,7 +841,6 @@ export function MetricsView({
                         .map((groupKey) => {
                           const group = groupByKey.get(groupKey);
                           const isCounterTelemetry = group?.members.some((m) => m.metricKind === 'counter');
-                          const viewMode = getCounterChartViewMode(groupKey, false);
                           const dataList = groupSeriesData.get(groupKey) ?? [];
                           if (dataList.length === 0) return null;
                           const chartSeries = showAnomalyOnlySeriesLines
@@ -932,12 +850,8 @@ export function MetricsView({
                           const seriesIDs = new Set(chartSeries.map((d) => d.id));
                           const seriesAnomalies = anomalies.filter((a) => a.sourceSeriesId && seriesIDs.has(a.sourceSeriesId));
                           const anomalyMarkers = chartSeries.flatMap((d) => d.anomalies);
-                          const mapPoints = (pts: Point[]) => {
-                            if (!isCounterTelemetry) return pts;
-                            if (viewMode === 'rate-sec') return toRateSeries(pts);
-                            if (viewMode === 'rate-min') return toRatePerMinSeries(pts);
-                            return cumulativeFromStart(pts);
-                          };
+                          const mapPoints = (pts: Point[]) =>
+                            isCounterTelemetry ? cumulativeFromStart(pts) : pts;
                           const seriesVariants: SeriesVariant[] = chartSeries.map((d) => ({
                             label: formatSeriesLabel(d.tags),
                             points: mapPoints(d.points),
@@ -945,27 +859,10 @@ export function MetricsView({
                           }));
                           const primary = chartSeries[0];
                           const chartTitleBase = getBaseMetricName(primary.name);
-                          const counterSuffix =
-                            isCounterTelemetry && viewMode === 'rate-sec'
-                              ? ' (evt/s)'
-                              : isCounterTelemetry && viewMode === 'rate-min'
-                                ? ' (evt/min)'
-                                : isCounterTelemetry
-                                  ? ' (cumulative)'
-                                  : '';
-                          const chartTitle = isCounterTelemetry ? `${chartTitleBase}${counterSuffix}` : primary.name;
-                          const subtitle = isCounterTelemetry ? (
-                            <CounterRateToggleBar
-                              viewMode={viewMode}
-                              onModeChange={(m) => setGroupCounterChartMode(groupKey, m)}
-                              firstLabel="Cumulative"
-                              firstTitle="Running total from scenario start (sum of per-bucket deltas)"
-                              activeClassName="bg-purple-700"
-                            />
-                          ) : undefined;
+                          const chartTitle = isCounterTelemetry ? `${chartTitleBase} (cumulative)` : primary.name;
                           return (
                             <ChartWithAnomalyDetails
-                              key={`${groupKey}-${isCounterTelemetry ? viewMode : 'gauge'}`}
+                              key={groupKey}
                               name={chartTitle}
                               points={mapPoints(primary.points)}
                               anomalyMarkers={anomalyMarkers}
@@ -978,7 +875,6 @@ export function MetricsView({
                               seriesVariants={seriesVariants}
                               isTelemetry
                               phaseMarkers={phaseMarkers}
-                              subtitle={subtitle}
                             />
                           );
                         })}

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -336,7 +336,9 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 
 	// Advance correlators so they can update their internal state.
 	for _, correlator := range correlators {
+		advanceStart := time.Now()
 		correlator.Advance(upTo)
+		allTelemetry = append(allTelemetry, newTelemetryGauge([]string{"detector:" + correlator.Name()}, telemetryDetectorProcessingTimeNs, float64(time.Since(advanceStart).Nanoseconds()), upTo))
 		e.accumulateCorrelations(correlator.ActiveCorrelations())
 		e.emit(engineEvent{
 			kind:      eventCorrelationUpdated,

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -191,12 +191,14 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observerdef.ObserverTelemetry) {
 	sourceTag := "observer_source:" + source
 	view := &logView{obs: l}
-	var logTelemetry []observerdef.ObserverTelemetry
+	logTelemetry := []observerdef.ObserverTelemetry{
+		newTelemetryCounter([]string{}, telemetryInputLogsCount, 1, l.timestampMs/1000),
+	}
 	for _, extractor := range e.extractors {
 		processingStartTime := time.Now()
 		out := extractor.ProcessLog(view)
 		processingTime := time.Since(processingStartTime)
-		logTelemetry = append(logTelemetry, newTelemetryGauge(extractor.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
+		logTelemetry = append(logTelemetry, newTelemetryGauge([]string{"detector:" + extractor.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
 		for _, m := range out.Metrics {
 			tags := copyTags(m.Tags)
 			if !sliceContains(tags, sourceTag) {
@@ -219,7 +221,7 @@ func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observ
 		processingStartTime := time.Now()
 		lo.ProcessLog(view)
 		processingTime := time.Since(processingStartTime)
-		logTelemetry = append(logTelemetry, newTelemetryGauge(lo.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
+		logTelemetry = append(logTelemetry, newTelemetryGauge([]string{"detector:" + lo.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), l.timestampMs/1000))
 	}
 	if len(logTelemetry) > 0 {
 		e.telemetryMu.Lock()
@@ -312,7 +314,7 @@ func (e *engine) runDetectorsAndCorrelatorsSnapshot(upTo int64, detectors []obse
 		processingStartTime := time.Now()
 		result := detector.Detect(e.storage, upTo)
 		processingTime := time.Since(processingStartTime)
-		allTelemetry = append(allTelemetry, newTelemetryGauge(detector.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), upTo))
+		allTelemetry = append(allTelemetry, newTelemetryGauge([]string{"detector:" + detector.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), upTo))
 
 		for _, anomaly := range result.Anomalies {
 			e.enrichAnomaly(&anomaly)
@@ -395,7 +397,7 @@ func (e *engine) processAnomaly(anomaly observerdef.Anomaly) []observerdef.Obser
 		processingStartTime := time.Now()
 		correlator.ProcessAnomaly(anomaly)
 		processingTime := time.Since(processingStartTime)
-		allTelemetry = append(allTelemetry, newTelemetryGauge(correlator.Name(), telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), anomaly.Timestamp))
+		allTelemetry = append(allTelemetry, newTelemetryGauge([]string{"detector:" + correlator.Name()}, telemetryDetectorProcessingTimeNs, float64(processingTime.Nanoseconds()), anomaly.Timestamp))
 	}
 
 	return allTelemetry

--- a/comp/observer/impl/engine.go
+++ b/comp/observer/impl/engine.go
@@ -191,9 +191,7 @@ func (e *engine) IngestMetric(source string, m *metricObs) []advanceRequest {
 func (e *engine) IngestLog(source string, l *logObs) ([]advanceRequest, []observerdef.ObserverTelemetry) {
 	sourceTag := "observer_source:" + source
 	view := &logView{obs: l}
-	logTelemetry := []observerdef.ObserverTelemetry{
-		newTelemetryCounter([]string{}, telemetryInputLogsCount, 1, l.timestampMs/1000),
-	}
+	var logTelemetry = []observerdef.ObserverTelemetry{}
 	for _, extractor := range e.extractors {
 		processingStartTime := time.Now()
 		out := extractor.ProcessLog(view)

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -105,7 +105,7 @@ func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.Lo
 		return observerdef.LogMetricsExtractorOutput{}
 	}
 	if clusterResult.IsNew {
-		telemetry = append(telemetry, newTelemetryCounter(e.Name(), telemetryLogPatternExtractorPatternCount, 1, log.GetTimestampUnixMilli()/1000))
+		telemetry = append(telemetry, newTelemetryCounter([]string{"detector:" + e.Name()}, telemetryLogPatternExtractorPatternCount, 1, log.GetTimestampUnixMilli()/1000))
 	}
 
 	patternKey := NewPatternKeyInfo(clusterResult.Cluster.ID)

--- a/comp/observer/impl/metrics_detector_rrcf.go
+++ b/comp/observer/impl/metrics_detector_rrcf.go
@@ -436,7 +436,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 		})
 
 		// Emit telemetry for the CoDisp score at every scored shingle
-		telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFScore, score, s.endTimestamp))
+		telemetry = append(telemetry, newTelemetryGauge([]string{"detector:" + r.Name()}, telemetryRRCFScore, score, s.endTimestamp))
 
 		// Skip warmup phase — scores are artificial during forest filling
 		if r.totalScored <= warmup {
@@ -448,7 +448,7 @@ func (r *RRCFDetector) scoreAndDetect(shingles []shingle, _ int64) observer.Dete
 
 		// Emit telemetry for the dynamic threshold (only after warmup when threshold is meaningful)
 		if threshold > 0 {
-			telemetry = append(telemetry, newTelemetryGauge(r.Name(), telemetryRRCFThreshold, threshold, s.endTimestamp))
+			telemetry = append(telemetry, newTelemetryGauge([]string{"detector:" + r.Name()}, telemetryRRCFThreshold, threshold, s.endTimestamp))
 		}
 
 		// Update rolling window (after computing threshold, so current score

--- a/comp/observer/impl/output.go
+++ b/comp/observer/impl/output.go
@@ -23,13 +23,13 @@ type ObserverOutput struct {
 
 // ObserverMetadata describes the scenario and pipeline configuration.
 type ObserverMetadata struct {
-	Scenario            string                             `json:"scenario"`
-	TimelineStart       int64                              `json:"timeline_start"`
-	TimelineEnd         int64                              `json:"timeline_end"`
-	DetectorsEnabled    []string                           `json:"detectors_enabled"`
-	CorrelatorsEnabled  []string                           `json:"correlators_enabled"`
-	TotalAnomalyPeriods int                                `json:"total_anomaly_periods"`
-	DetectorStats       map[string]DetectorProcessingStats `json:"detector_stats,omitempty"`
+	Scenario            string       `json:"scenario"`
+	TimelineStart       int64        `json:"timeline_start"`
+	TimelineEnd         int64        `json:"timeline_end"`
+	DetectorsEnabled    []string     `json:"detectors_enabled"`
+	CorrelatorsEnabled  []string     `json:"correlators_enabled"`
+	TotalAnomalyPeriods int          `json:"total_anomaly_periods"`
+	Stats               *ReplayStats `json:"stats,omitempty"`
 }
 
 // ObserverCorrelation is one correlation cluster.
@@ -79,7 +79,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			correlatorNames = append(correlatorNames, name)
 		}
 	}
-	detectorStats := tb.detectorProcessingStats
+	replayStats := tb.replayStats
 	tb.mu.RUnlock()
 
 	sort.Strings(detectorNames)
@@ -129,7 +129,7 @@ func (tb *TestBench) WriteObserverOutput(path string, verbose bool) error {
 			DetectorsEnabled:    detectorNames,
 			CorrelatorsEnabled:  correlatorNames,
 			TotalAnomalyPeriods: len(outCorrelations),
-			DetectorStats:       detectorStats,
+			Stats:               replayStats,
 		},
 		AnomalyPeriods: outCorrelations,
 	}

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -175,19 +175,20 @@ func newTimeSeriesStorage() *timeSeriesStorage {
 // Invalid values are dropped at ingest with accounting and sampled logging.
 // Timestamps are maintained in sorted order so replay and live ingestion remain
 // correct even when data arrives out of order.
-func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) {
+// Returns true if this point created a new series (cardinality +1), false otherwise.
+func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp int64, tags []string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if math.IsInf(value, 0) || math.IsNaN(value) {
 		s.recordDroppedValue("non_finite", namespace, name, value, timestamp, tags)
-		return
+		return false
 	}
 	// Guard against known finite sentinel values (MaxFloat64 used as "unlimited")
 	// that overflow downstream aggregation math when summed.
 	if value == math.MaxFloat64 || value == -math.MaxFloat64 {
 		s.recordDroppedValue("extreme", namespace, name, value, timestamp, tags)
-		return
+		return false
 	}
 	key := seriesKey(namespace, name, tags)
 
@@ -207,6 +208,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		s.seriesIDStats = append(s.seriesIDStats, stats)
 		s.seriesGen++
 	}
+	isNew := !exists
 	stats.writeGeneration++
 
 	// Bucket by second.
@@ -227,7 +229,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 		if value > stats.maxes[idx] {
 			stats.maxes[idx] = value
 		}
-		return
+		return isNew
 	}
 
 	stats.timestamps = insertInt64(stats.timestamps, idx, bucket)
@@ -235,6 +237,7 @@ func (s *timeSeriesStorage) Add(namespace, name string, value float64, timestamp
 	stats.counts = insertInt64(stats.counts, idx, 1)
 	stats.mins = insertFloat64(stats.mins, idx, value)
 	stats.maxes = insertFloat64(stats.maxes, idx, value)
+	return isNew
 }
 
 // insertInt64 inserts v at position idx in s, maintaining order.

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -766,6 +766,21 @@ func (s *timeSeriesStorage) TotalPointCount(excludeNamespace string) int {
 	return total
 }
 
+// TotalSeriesCount returns the number of unique series (name + tag combinations),
+// excluding series in excludeNamespace (pass "" to include all namespaces).
+func (s *timeSeriesStorage) TotalSeriesCount(excludeNamespace string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	total := 0
+	for _, stats := range s.series {
+		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
+			continue
+		}
+		total++
+	}
+	return total
+}
+
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 // Uses binary search since timestamps are sorted.
 func (s *timeSeriesStorage) PointCountUpTo(handle observer.SeriesHandle, endTime int64) int {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -751,6 +751,21 @@ func (s *timeSeriesStorage) PointCount(handle observer.SeriesHandle) int {
 	return 0
 }
 
+// TotalPointCount returns the total number of stored data points across all series,
+// excluding series in excludeNamespace (pass "" to include all namespaces).
+func (s *timeSeriesStorage) TotalPointCount(excludeNamespace string) int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	total := 0
+	for _, stats := range s.series {
+		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
+			continue
+		}
+		total += stats.pointCount()
+	}
+	return total
+}
+
 // PointCountUpTo returns the number of raw data points with timestamp <= endTime.
 // Uses binary search since timestamps are sorted.
 func (s *timeSeriesStorage) PointCountUpTo(handle observer.SeriesHandle, endTime int64) int {

--- a/comp/observer/impl/storage.go
+++ b/comp/observer/impl/storage.go
@@ -70,6 +70,16 @@ func (s *seriesStats) pointCount() int {
 	return len(s.timestamps)
 }
 
+// sampleCount returns the total number of samples for a series.
+// A point can contain multiple samples if it is aggregated.
+func (s *seriesStats) sampleCount() int64 {
+	count := int64(0)
+	for _, c := range s.counts {
+		count += c
+	}
+	return count
+}
+
 // Aggregate is an alias to the definition in the observer component for internal use.
 type Aggregate = observer.Aggregate
 
@@ -754,17 +764,18 @@ func (s *timeSeriesStorage) PointCount(handle observer.SeriesHandle) int {
 	return 0
 }
 
-// TotalPointCount returns the total number of stored data points across all series,
+// TotalSampleCount returns the total number of stored samples across all series,
 // excluding series in excludeNamespace (pass "" to include all namespaces).
-func (s *timeSeriesStorage) TotalPointCount(excludeNamespace string) int {
+// A point can contain multiple samples if it is aggregated.
+func (s *timeSeriesStorage) TotalSampleCount(excludeNamespace string) int64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	total := 0
+	total := int64(0)
 	for _, stats := range s.series {
 		if excludeNamespace != "" && stats.Namespace == excludeNamespace {
 			continue
 		}
-		total += stats.pointCount()
+		total += stats.sampleCount()
 	}
 	return total
 }

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -14,9 +14,10 @@ import (
 const (
 	// Observer
 	telemetryDetectorProcessingTimeNs = "observer.detector.processing_time_ns"
-	telemetryInputMetricsCount        = "observer.input_metrics.count"
-	telemetryInputMetricsCardinality  = "observer.input_metrics.cardinality"
-	telemetryInputLogsCount           = "observer.input_logs.count"
+	// Only in testbench
+	telemetryTbInputMetricsCount       = "observer.input_metrics.count"
+	telemetryTbInputMetricsCardinality = "observer.input_metrics.cardinality"
+	telemetryTbInputLogsCount          = "observer.input_logs.count"
 
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
@@ -59,21 +60,21 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 	)
 
 	// Counters
-	counters[telemetryInputMetricsCount] = telemetryComp.NewCounter(
+	counters[telemetryTbInputMetricsCount] = telemetryComp.NewCounter(
 		"observer",
-		telemetryInputMetricsCount,
+		telemetryTbInputMetricsCount,
 		[]string{},
 		"Total number of metrics processed by the observer",
 	)
-	counters[telemetryInputLogsCount] = telemetryComp.NewCounter(
+	counters[telemetryTbInputLogsCount] = telemetryComp.NewCounter(
 		"observer",
-		telemetryInputLogsCount,
+		telemetryTbInputLogsCount,
 		[]string{},
 		"Total number of logs processed by the observer",
 	)
-	counters[telemetryInputMetricsCardinality] = telemetryComp.NewCounter(
+	counters[telemetryTbInputMetricsCardinality] = telemetryComp.NewCounter(
 		"observer",
-		telemetryInputMetricsCardinality,
+		telemetryTbInputMetricsCardinality,
 		[]string{},
 		"Total number of unique metrics processed by the observer (metrics with different tags are counted as different metrics)",
 	)

--- a/comp/observer/impl/telemetry.go
+++ b/comp/observer/impl/telemetry.go
@@ -14,6 +14,9 @@ import (
 const (
 	// Observer
 	telemetryDetectorProcessingTimeNs = "observer.detector.processing_time_ns"
+	telemetryInputMetricsCount        = "observer.input_metrics.count"
+	telemetryInputMetricsCardinality  = "observer.input_metrics.cardinality"
+	telemetryInputLogsCount           = "observer.input_logs.count"
 
 	// RRCF detector
 	telemetryRRCFScore     = "observer.rrcf.score"
@@ -55,6 +58,25 @@ func newTelemetryHandler(telemetryComp telemetry.Component) *telemetryHandler {
 		"RRCF dynamic anomaly detection threshold (post-warmup)",
 	)
 
+	// Counters
+	counters[telemetryInputMetricsCount] = telemetryComp.NewCounter(
+		"observer",
+		telemetryInputMetricsCount,
+		[]string{},
+		"Total number of metrics processed by the observer",
+	)
+	counters[telemetryInputLogsCount] = telemetryComp.NewCounter(
+		"observer",
+		telemetryInputLogsCount,
+		[]string{},
+		"Total number of logs processed by the observer",
+	)
+	counters[telemetryInputMetricsCardinality] = telemetryComp.NewCounter(
+		"observer",
+		telemetryInputMetricsCardinality,
+		[]string{},
+		"Total number of unique metrics processed by the observer (metrics with different tags are counted as different metrics)",
+	)
 	counters[telemetryLogPatternExtractorPatternCount] = telemetryComp.NewCounter(
 		"observer",
 		telemetryLogPatternExtractorPatternCount,
@@ -118,30 +140,43 @@ func (h *telemetryHandler) isCounterMetric(name string) bool {
 	return ok
 }
 
-// newTelemetryGauge creates a new telemetry gauge for the given telemetry name, detector name, and data time.
+// detectorNameFromTags returns the value of the first "detector:" tag, for ObserverTelemetry.DetectorName.
+func detectorNameFromTags(tags []string) string {
+	const prefix = "detector:"
+	for _, t := range tags {
+		if len(t) > len(prefix) && t[:len(prefix)] == prefix {
+			return t[len(prefix):]
+		}
+	}
+	return ""
+}
+
+// newTelemetryGauge creates gauge telemetry for the given metric name, tags, value, and data time (unix seconds).
 // Warning: use a `telemetryName` that is defined in this file.
-func newTelemetryGauge(detectorName string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
+func newTelemetryGauge(tags []string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
+	tagsCopy := copyTags(tags)
 	return observerdef.ObserverTelemetry{
-		DetectorName: detectorName,
+		DetectorName: detectorNameFromTags(tagsCopy),
 		Kind:         observerdef.MetricKindGauge,
 		Metric: &metricObs{
 			name:      telemetryName,
 			value:     value,
-			tags:      []string{"detector:" + detectorName},
+			tags:      tagsCopy,
 			timestamp: dataTimeSec,
 		},
 	}
 }
 
 // newTelemetryCounter creates counter telemetry: the value is added to the named counter (must be registered in newTelemetryHandler).
-func newTelemetryCounter(detectorName string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
+func newTelemetryCounter(tags []string, telemetryName string, value float64, dataTimeSec int64) observerdef.ObserverTelemetry {
+	tagsCopy := copyTags(tags)
 	return observerdef.ObserverTelemetry{
-		DetectorName: detectorName,
+		DetectorName: detectorNameFromTags(tagsCopy),
 		Kind:         observerdef.MetricKindCounter,
 		Metric: &metricObs{
 			name:      telemetryName,
 			value:     value,
-			tags:      []string{"detector:" + detectorName},
+			tags:      tagsCopy,
 			timestamp: dataTimeSec,
 		},
 	}

--- a/comp/observer/impl/telemetry_test.go
+++ b/comp/observer/impl/telemetry_test.go
@@ -26,8 +26,8 @@ func TestTelemetryHandler_CounterAdd(t *testing.T) {
 	)
 
 	h.handleTelemetry([]observerdef.ObserverTelemetry{
-		newTelemetryCounter("det-a", counterName, 2, 100),
-		newTelemetryCounter("det-a", counterName, 3, 101),
+		newTelemetryCounter([]string{"detector:det-a"}, counterName, 2, 100),
+		newTelemetryCounter([]string{"detector:det-a"}, counterName, 3, 101),
 	})
 	// No-op telemetry: asserts routing does not warn or panic.
 }
@@ -37,7 +37,7 @@ func TestTelemetryHandler_GaugeSet(t *testing.T) {
 	h := newTelemetryHandler(tel)
 
 	h.handleTelemetry([]observerdef.ObserverTelemetry{
-		newTelemetryGauge("det", telemetryRRCFScore, 0.5, 100),
+		newTelemetryGauge([]string{"detector:det"}, telemetryRRCFScore, 0.5, 100),
 	})
 }
 

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -428,6 +428,8 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 
 	fmt.Printf("  Loading %d samples from parquet files\n", len(metrics))
 
+	byTimestampCounter := make(map[int64]int64)
+
 	// Batch add all metrics to storage
 	for _, m := range metrics {
 		// Strip aggregation suffix from metric name (e.g., ":avg", ":count")
@@ -445,6 +447,8 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 			}
 		}
 
+		byTimestampCounter[m.Timestamp]++
+
 		storage.Add(
 			"parquet", // namespace
 			metricName,
@@ -452,6 +456,22 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 			m.Timestamp,
 			m.Tags,
 		)
+	}
+
+	// Telemetry for the number of metrics by timestamp
+	type byTimestampEntry struct {
+		Timestamp int64
+		Count     int64
+	}
+	byTimestampOrdered := make([]byTimestampEntry, 0, len(byTimestampCounter))
+	for timestamp, count := range byTimestampCounter {
+		byTimestampOrdered = append(byTimestampOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
+	}
+	sort.Slice(byTimestampOrdered, func(i, j int) bool {
+		return byTimestampOrdered[i].Timestamp < byTimestampOrdered[j].Timestamp
+	})
+	for _, entry := range byTimestampOrdered {
+		tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
 	}
 
 	// Load trace stats and derive trace.* metrics via processStatsView
@@ -665,7 +685,13 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		}
 		_, tel := tb.engine.IngestLog("parquet", obs)
 		ingestTelemetry = append(ingestTelemetry, tel...)
+		// Count logs only here in the testbench
+		ingestTelemetry = append(ingestTelemetry, newTelemetryCounter([]string{}, telemetryTbInputLogsCount, 1, log.GetTimestampUnixMilli()/1000))
 	}
+
+	// Count total metric samples already in storage (excludes internal telemetry namespace).
+	metricSamples := tb.engine.Storage().TotalPointCount(observerdef.TelemetryNamespace)
+	ingestTelemetry = append(ingestTelemetry, newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(metricSamples), tb.engine.Storage().MaxTimestamp()))
 
 	// Replay all stored data through the scheduler policy.
 	// The engine's captureRawAnomaly deduplicates anomalies internally,
@@ -673,9 +699,12 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	result := tb.engine.ReplayStoredData()
 	unsub()
 
+	// Combine ingest telemetry (log/metric counters) with detector telemetry from the replay.
+	allTelemetry := append(ingestTelemetry, result.telemetry...)
+
 	// Handle telemetry (write telemetry metrics to storage for UI)
 	dataTime := tb.engine.Storage().MaxTimestamp()
-	for _, t := range append(ingestTelemetry, result.telemetry...) {
+	for _, t := range allTelemetry {
 		detName := t.DetectorName
 		if detName == "" {
 			detName = "unknown"
@@ -700,12 +729,11 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Publish the ordered event log captured during replay.
 	tb.reportedEvents = replay.events
 
-	// Compute all replay stats from telemetry accumulated during the replay.
-	allTelemetry := tb.engine.StateView().Telemetry()
+	// Compute all replay stats from the combined telemetry slice built above.
 	tb.replayStats = &ReplayStats{
 		DetectorStats:     computeDetectorProcessingStats(allTelemetry),
-		InputMetricsCount: sumTelemetryCounter(allTelemetry, telemetryInputMetricsCount),
-		InputLogsCount:    sumTelemetryCounter(allTelemetry, telemetryInputLogsCount),
+		InputMetricsCount: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
+		InputLogsCount:    sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
 	}
 
 	// Mark scenario ready now that all analysis is complete

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -431,6 +431,7 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 	fmt.Printf("  Loading %d samples from parquet files\n", len(metrics))
 
 	byTimestampCounter := make(map[int64]int64)
+	byTimestampCardinality := make(map[int64]int64)
 
 	// Batch add all metrics to storage
 	for _, m := range metrics {
@@ -451,13 +452,9 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 
 		byTimestampCounter[m.Timestamp]++
 
-		storage.Add(
-			"parquet", // namespace
-			metricName,
-			m.Value,
-			m.Timestamp,
-			m.Tags,
-		)
+		if storage.Add("parquet", metricName, m.Value, m.Timestamp, m.Tags) {
+			byTimestampCardinality[m.Timestamp]++
+		}
 	}
 
 	// Telemetry for the number of metrics by timestamp
@@ -474,6 +471,18 @@ func (tb *TestBench) loadParquetDir(dir string) error {
 	})
 	for _, entry := range byTimestampOrdered {
 		tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
+	}
+
+	// Telemetry for cardinality (new unique series) by timestamp
+	byCardOrdered := make([]byTimestampEntry, 0, len(byTimestampCardinality))
+	for timestamp, count := range byTimestampCardinality {
+		byCardOrdered = append(byCardOrdered, byTimestampEntry{Timestamp: timestamp, Count: count})
+	}
+	sort.Slice(byCardOrdered, func(i, j int) bool {
+		return byCardOrdered[i].Timestamp < byCardOrdered[j].Timestamp
+	})
+	for _, entry := range byCardOrdered {
+		tb.handleTelemetry([]observerdef.ObserverTelemetry{newTelemetryCounter([]string{}, telemetryTbInputMetricsCardinality, float64(entry.Count), entry.Timestamp)}, "parquet", entry.Timestamp)
 	}
 
 	// Load trace stats and derive trace.* metrics via processStatsView
@@ -691,16 +700,6 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		allTelemetry = append(allTelemetry, newTelemetryCounter([]string{}, telemetryTbInputLogsCount, 1, log.GetTimestampUnixMilli()/1000))
 	}
 
-	// Count total metric samples and unique series already in storage (excludes internal telemetry namespace).
-	storageSnapshot := tb.engine.Storage()
-	maxTs := storageSnapshot.MaxTimestamp()
-	metricSamples := storageSnapshot.TotalPointCount(observerdef.TelemetryNamespace)
-	metricCardinality := storageSnapshot.TotalSeriesCount(observerdef.TelemetryNamespace)
-	allTelemetry = append(allTelemetry,
-		newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(metricSamples), maxTs),
-		newTelemetryCounter([]string{}, telemetryTbInputMetricsCardinality, float64(metricCardinality), maxTs),
-	)
-
 	// Replay all stored data through the scheduler policy.
 	// The engine's captureRawAnomaly deduplicates anomalies internally,
 	// so stateView.Anomalies() returns a clean deduplicated set.
@@ -742,7 +741,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	tb.replayStats = &ReplayStats{
 		DetectorStats:           detectorStats,
 		InputMetricsCount:       sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
-		InputMetricsCardinality: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCardinality),
+		InputMetricsCardinality: tb.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace),
 		InputLogsCount:          sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
 		InputAnomaliesCount:     len(result.anomalies),
 	}

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -400,7 +400,9 @@ func (tb *TestBench) LoadScenario(name string) error {
 	tb.rerunDetectorsLocked()
 	fmt.Printf("  Detector phase took %s\n", time.Since(analysisStart))
 	fmt.Printf("  Total scenario load took %s\n", time.Since(scenarioStart))
-	fmt.Printf("Scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
+	rs := tb.replayStats
+	fmt.Printf("Scenario loaded: %d metric samples (%d unique series), %d metric anomalies, %d log entries, %d log anomalies\n",
+		rs.InputMetricsCount, rs.InputMetricsCardinality, len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	close(progressDone)
 	tb.mu.Unlock()
@@ -674,7 +676,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// log observers, and timestamp tracking all use the same code path as
 	// live ingestion. We ignore the returned advance requests because
 	// ReplayStoredData (below) will handle scheduling after all data is loaded.
-	var ingestTelemetry []observerdef.ObserverTelemetry
+	var allTelemetry []observerdef.ObserverTelemetry
 	for _, log := range tb.rawLogs {
 		obs := &logObs{
 			content:     log.GetContent(),
@@ -684,14 +686,20 @@ func (tb *TestBench) rerunDetectorsLocked() {
 			timestampMs: log.GetTimestampUnixMilli(),
 		}
 		_, tel := tb.engine.IngestLog("parquet", obs)
-		ingestTelemetry = append(ingestTelemetry, tel...)
+		allTelemetry = append(allTelemetry, tel...)
 		// Count logs only here in the testbench
-		ingestTelemetry = append(ingestTelemetry, newTelemetryCounter([]string{}, telemetryTbInputLogsCount, 1, log.GetTimestampUnixMilli()/1000))
+		allTelemetry = append(allTelemetry, newTelemetryCounter([]string{}, telemetryTbInputLogsCount, 1, log.GetTimestampUnixMilli()/1000))
 	}
 
-	// Count total metric samples already in storage (excludes internal telemetry namespace).
-	metricSamples := tb.engine.Storage().TotalPointCount(observerdef.TelemetryNamespace)
-	ingestTelemetry = append(ingestTelemetry, newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(metricSamples), tb.engine.Storage().MaxTimestamp()))
+	// Count total metric samples and unique series already in storage (excludes internal telemetry namespace).
+	storageSnapshot := tb.engine.Storage()
+	maxTs := storageSnapshot.MaxTimestamp()
+	metricSamples := storageSnapshot.TotalPointCount(observerdef.TelemetryNamespace)
+	metricCardinality := storageSnapshot.TotalSeriesCount(observerdef.TelemetryNamespace)
+	allTelemetry = append(allTelemetry,
+		newTelemetryCounter([]string{}, telemetryTbInputMetricsCount, float64(metricSamples), maxTs),
+		newTelemetryCounter([]string{}, telemetryTbInputMetricsCardinality, float64(metricCardinality), maxTs),
+	)
 
 	// Replay all stored data through the scheduler policy.
 	// The engine's captureRawAnomaly deduplicates anomalies internally,
@@ -699,8 +707,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	result := tb.engine.ReplayStoredData()
 	unsub()
 
-	// Combine ingest telemetry (log/metric counters) with detector telemetry from the replay.
-	allTelemetry := append(ingestTelemetry, result.telemetry...)
+	allTelemetry = append(allTelemetry, result.telemetry...)
 
 	// Handle telemetry (write telemetry metrics to storage for UI)
 	dataTime := tb.engine.Storage().MaxTimestamp()
@@ -731,9 +738,10 @@ func (tb *TestBench) rerunDetectorsLocked() {
 
 	// Compute all replay stats from the combined telemetry slice built above.
 	tb.replayStats = &ReplayStats{
-		DetectorStats:     computeDetectorProcessingStats(allTelemetry),
-		InputMetricsCount: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
-		InputLogsCount:    sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
+		DetectorStats:           computeDetectorProcessingStats(allTelemetry),
+		InputMetricsCount:       sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
+		InputMetricsCardinality: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCardinality),
+		InputLogsCount:          sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
 	}
 
 	// Mark scenario ready now that all analysis is complete
@@ -1195,8 +1203,6 @@ func (tb *TestBench) printHeadlessRunStats() {
 		return
 	}
 
-	fmt.Printf("\nInput: %d metric series, %d log entries\n", rs.InputMetricsCount, rs.InputLogsCount)
-
 	// Sort by name for deterministic output.
 	names := make([]string, 0, len(rs.DetectorStats))
 	for name := range rs.DetectorStats {
@@ -1428,7 +1434,9 @@ func (tb *TestBench) loadDemoScenario() error {
 
 	// Run analyses on all loaded data (detectors sync, correlators async)
 	tb.rerunDetectorsLocked()
-	fmt.Printf("Demo scenario loaded: %d series, %d metric anomalies, %d log entries, %d log anomalies\n", tb.seriesCount(), len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
+	rs := tb.replayStats
+	fmt.Printf("Demo scenario loaded: %d metric samples (%d unique series), %d metric anomalies, %d log entries, %d log anomalies\n",
+		rs.InputMetricsCount, rs.InputMetricsCardinality, len(tb.engine.RawAnomalies()), len(tb.rawLogs), len(tb.logAnomalies))
 
 	tb.mu.Unlock()
 	tb.broadcastStatus()

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -744,6 +744,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 		InputMetricsCount:       sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
 		InputMetricsCardinality: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCardinality),
 		InputLogsCount:          sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
+		InputAnomaliesCount:     len(result.anomalies),
 	}
 
 	// Mark scenario ready now that all analysis is complete

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -701,10 +701,11 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	tb.reportedEvents = replay.events
 
 	// Compute all replay stats from telemetry accumulated during the replay.
+	allTelemetry := tb.engine.StateView().Telemetry()
 	tb.replayStats = &ReplayStats{
-		DetectorStats:     computeDetectorProcessingStats(tb.engine.StateView().Telemetry()),
-		InputMetricsCount: tb.seriesCount(),
-		InputLogsCount:    len(tb.rawLogs),
+		DetectorStats:     computeDetectorProcessingStats(allTelemetry),
+		InputMetricsCount: sumTelemetryCounter(allTelemetry, telemetryInputMetricsCount),
+		InputLogsCount:    sumTelemetryCounter(allTelemetry, telemetryInputLogsCount),
 	}
 
 	// Mark scenario ready now that all analysis is complete

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -737,8 +737,10 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	tb.reportedEvents = replay.events
 
 	// Compute all replay stats from the combined telemetry slice built above.
+	detectorStats := computeDetectorProcessingStats(allTelemetry)
+	enrichDetectorStatsKind(detectorStats, tb.components)
 	tb.replayStats = &ReplayStats{
-		DetectorStats:           computeDetectorProcessingStats(allTelemetry),
+		DetectorStats:           detectorStats,
 		InputMetricsCount:       sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
 		InputMetricsCardinality: sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCardinality),
 		InputLogsCount:          sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -741,7 +741,7 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	enrichDetectorStatsKind(detectorStats, tb.components)
 	tb.replayStats = &ReplayStats{
 		DetectorStats:           detectorStats,
-		InputMetricsCount:       storage.TotalPointCount(observerdef.TelemetryNamespace),
+		InputMetricsCount:       storage.TotalSampleCount(observerdef.TelemetryNamespace),
 		InputMetricsCardinality: storage.TotalSeriesCount(observerdef.TelemetryNamespace),
 		InputLogsCount:          sumStoredTelemetryCounter(storage, telemetryTbInputLogsCount),
 		InputAnomaliesCount:     len(result.anomalies),
@@ -1295,7 +1295,7 @@ func replayStatsItemCountForKind(rs *ReplayStats, kind string) int {
 	case "correlator":
 		return rs.InputAnomaliesCount
 	default:
-		return rs.InputMetricsCount
+		return int(rs.InputMetricsCount)
 	}
 }
 

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -735,14 +735,15 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Publish the ordered event log captured during replay.
 	tb.reportedEvents = replay.events
 
-	// Compute all replay stats from the combined telemetry slice built above.
-	detectorStats := computeDetectorProcessingStats(allTelemetry)
+	// Compute replay stats from engine storage only for consistency.
+	storage := tb.engine.Storage()
+	detectorStats := computeDetectorProcessingStatsFromStorage(storage)
 	enrichDetectorStatsKind(detectorStats, tb.components)
 	tb.replayStats = &ReplayStats{
 		DetectorStats:           detectorStats,
-		InputMetricsCount:       sumTelemetryCounter(allTelemetry, telemetryTbInputMetricsCount),
-		InputMetricsCardinality: tb.engine.Storage().TotalSeriesCount(observerdef.TelemetryNamespace),
-		InputLogsCount:          sumTelemetryCounter(allTelemetry, telemetryTbInputLogsCount),
+		InputMetricsCount:       storage.TotalPointCount(observerdef.TelemetryNamespace),
+		InputMetricsCardinality: storage.TotalSeriesCount(observerdef.TelemetryNamespace),
+		InputLogsCount:          sumStoredTelemetryCounter(storage, telemetryTbInputLogsCount),
 		InputAnomaliesCount:     len(result.anomalies),
 	}
 

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -132,9 +132,9 @@ type TestBench struct {
 	// This is not directly used, it's mostly to ensure that telemetry metrics are registered in the telemetry handler
 	telemetryHandler *telemetryHandler
 
-	// detectorProcessingStats holds per-detector avg/median/p99 processing times
-	// computed after each replay run, keyed by detector name.
-	detectorProcessingStats map[string]DetectorProcessingStats
+	// replayStats holds all statistics computed after each replay run,
+	// including per-detector processing times and input volume counts.
+	replayStats *ReplayStats
 }
 
 // ScenarioInfo describes an available scenario.
@@ -700,8 +700,12 @@ func (tb *TestBench) rerunDetectorsLocked() {
 	// Publish the ordered event log captured during replay.
 	tb.reportedEvents = replay.events
 
-	// Compute per-detector processing stats from all telemetry accumulated during the replay.
-	tb.detectorProcessingStats = computeDetectorProcessingStats(tb.engine.StateView().Telemetry())
+	// Compute all replay stats from telemetry accumulated during the replay.
+	tb.replayStats = &ReplayStats{
+		DetectorStats:     computeDetectorProcessingStats(tb.engine.StateView().Telemetry()),
+		InputMetricsCount: tb.seriesCount(),
+		InputLogsCount:    len(tb.rawLogs),
+	}
 
 	// Mark scenario ready now that all analysis is complete
 	tb.ready = true
@@ -925,13 +929,13 @@ func (tb *TestBench) GetDetectorComponentMap() map[string]string {
 	return result
 }
 
-// GetDetectorProcessingStats returns per-detector processing-time statistics
-// (avg / median / p99, in nanoseconds) computed from the last replay run.
+// GetReplayStats returns all statistics computed from the last replay run,
+// including per-detector processing times and input volume counts.
 // Returns nil if no scenario has been run yet.
-func (tb *TestBench) GetDetectorProcessingStats() map[string]DetectorProcessingStats {
+func (tb *TestBench) GetReplayStats() *ReplayStats {
 	tb.mu.RLock()
 	defer tb.mu.RUnlock()
-	return tb.detectorProcessingStats
+	return tb.replayStats
 }
 
 // GetCorrelations returns all correlations detected across the full run.
@@ -1142,7 +1146,7 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 		return fmt.Errorf("loading scenario %q: %w", scenario, err)
 	}
 
-	tb.printDetectorProcessingStats()
+	tb.printHeadlessRunStats()
 
 	// Write structured JSON output.
 	if outputPath != "" {
@@ -1155,23 +1159,25 @@ func (tb *TestBench) RunHeadless(scenario, outputPath string, verbose bool) erro
 	return nil
 }
 
-// printDetectorProcessingStats prints per-detector processing-time statistics to stdout.
-func (tb *TestBench) printDetectorProcessingStats() {
-	stats := tb.GetDetectorProcessingStats()
-	if len(stats) == 0 {
+// printHeadlessRunStats prints per-detector processing-time statistics to stdout.
+func (tb *TestBench) printHeadlessRunStats() {
+	rs := tb.GetReplayStats()
+	if rs == nil || len(rs.DetectorStats) == 0 {
 		return
 	}
 
+	fmt.Printf("\nInput: %d metric series, %d log entries\n", rs.InputMetricsCount, rs.InputLogsCount)
+
 	// Sort by name for deterministic output.
-	names := make([]string, 0, len(stats))
-	for name := range stats {
+	names := make([]string, 0, len(rs.DetectorStats))
+	for name := range rs.DetectorStats {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	fmt.Println("\nDetector processing times:")
 	for _, name := range names {
-		s := stats[name]
+		s := rs.DetectorStats[name]
 		fmt.Printf("  %-40s  avg=%8.2fµs  median=%8.2fµs  p99=%8.2fµs  total=%s  (%d calls)\n",
 			name,
 			s.AvgNs/1e3,

--- a/comp/observer/impl/testbench.go
+++ b/comp/observer/impl/testbench.go
@@ -1225,6 +1225,40 @@ func (tb *TestBench) printHeadlessRunStats() {
 			s.Count,
 		)
 	}
+
+	// Same definition as the benchmark UI "Cost per Item" chart: total_ns ÷ input volume.
+	type perItemRow struct {
+		name      string
+		kind      string
+		nsPerItem float64
+		items     int
+	}
+	perItem := make([]perItemRow, 0, len(rs.DetectorStats))
+	for _, name := range names {
+		s := rs.DetectorStats[name]
+		nItems := replayStatsItemCountForKind(rs, s.Kind)
+		if nItems <= 0 {
+			continue
+		}
+		nsPer := s.TotalNs / float64(nItems)
+		if nsPer <= 0 {
+			continue
+		}
+		perItem = append(perItem, perItemRow{name: name, kind: s.Kind, nsPerItem: nsPer, items: nItems})
+	}
+	sort.Slice(perItem, func(i, j int) bool { return perItem[i].nsPerItem > perItem[j].nsPerItem })
+
+	if len(perItem) > 0 {
+		fmt.Println("\nProcessing time per item (total ÷ items processed — same as benchmark \"Cost per Item\"):")
+		for _, row := range perItem {
+			fmt.Printf("  %-40s  %8s  %-10s (%d items)\n",
+				row.name,
+				formatNsAsUsShort(row.nsPerItem),
+				perItemSuffixLabel(row.kind),
+				row.items,
+			)
+		}
+	}
 }
 
 // formatTotalNs formats a total duration (nanoseconds) with auto-scaling to
@@ -1239,6 +1273,41 @@ func formatTotalNs(ns float64) string {
 		return fmt.Sprintf("%8.1fms", ms)
 	}
 	return fmt.Sprintf("%8.3fs ", ms/1_000)
+}
+
+// formatNsAsUsShort formats a duration in nanoseconds as µs with the same
+// precision rules as the testbench benchmark UI (fmtUs).
+func formatNsAsUsShort(ns float64) string {
+	us := ns / 1e3
+	if us < 10 {
+		return fmt.Sprintf("%.2fµs", us)
+	}
+	if us < 100 {
+		return fmt.Sprintf("%.1fµs", us)
+	}
+	return fmt.Sprintf("%.0fµs", us)
+}
+
+func replayStatsItemCountForKind(rs *ReplayStats, kind string) int {
+	switch kind {
+	case "extractor":
+		return rs.InputLogsCount
+	case "correlator":
+		return rs.InputAnomaliesCount
+	default:
+		return rs.InputMetricsCount
+	}
+}
+
+func perItemSuffixLabel(kind string) string {
+	switch kind {
+	case "extractor":
+		return "ns/log"
+	case "correlator":
+		return "ns/anomaly"
+	default:
+		return "ns/point"
+	}
 }
 
 // RunSendAnomalyEvents loads a scenario, waits for correlators to finish, then

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -460,9 +460,13 @@ func (api *TestBenchAPI) handleSeriesList(w http.ResponseWriter, _ *http.Request
 	for _, ns := range storage.Namespaces() {
 		metas := storage.ListSeriesMetadata(ns)
 		for _, m := range metas {
-			aggs := []Aggregate{AggregateAverage, AggregateCount}
+			var aggs []Aggregate
 			if m.Namespace == "telemetry" && telHandler != nil && telHandler.isCounterMetric(m.Name) {
-				aggs = append(aggs, AggregateSum)
+				// Counters are per-bucket deltas; exposing avg/count/sum as three API series
+				// with the same tags produced three indistinguishable "untagged" lines in the UI.
+				aggs = []Aggregate{AggregateSum}
+			} else {
+				aggs = []Aggregate{AggregateAverage, AggregateCount}
 			}
 			var metricKind string
 			if m.Namespace == "telemetry" {

--- a/comp/observer/impl/testbench_api.go
+++ b/comp/observer/impl/testbench_api.go
@@ -1227,12 +1227,12 @@ func (api *TestBenchAPI) writeJSON(w http.ResponseWriter, data interface{}) {
 	}
 }
 
-// handleBenchmark returns per-detector processing-time statistics (avg/median/p99)
-// computed from the last replay run.
+// handleBenchmark returns replay statistics (per-detector processing times and
+// input volume counts) computed from the last replay run.
 func (api *TestBenchAPI) handleBenchmark(w http.ResponseWriter, _ *http.Request) {
-	stats := api.tb.GetDetectorProcessingStats()
+	stats := api.tb.GetReplayStats()
 	if stats == nil {
-		api.writeJSON(w, map[string]DetectorProcessingStats{})
+		api.writeJSON(w, &ReplayStats{DetectorStats: map[string]DetectorProcessingStats{}})
 		return
 	}
 	api.writeJSON(w, stats)

--- a/comp/observer/impl/testbench_api_test.go
+++ b/comp/observer/impl/testbench_api_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -129,6 +130,44 @@ func TestHandleSeriesListMarksLogPatternExtractorSeriesAsVirtual(t *testing.T) {
 		}
 	}
 	require.True(t, logPatternSeen, "expected at least one log_pattern_extractor series in /api/series")
+}
+
+// Telemetry counters used to be listed as avg+count+sum with identical tags, which produced three
+// duplicate "untagged" lines in the metrics UI for metrics like observer.input_logs.count.
+func TestHandleSeriesListTelemetryCountersSingleAggregate(t *testing.T) {
+	tb, err := NewTestBench(TestBenchConfig{ScenariosDir: t.TempDir()})
+	require.NoError(t, err)
+	api := NewTestBenchAPI(tb)
+
+	tb.engine.Storage().Add(observerdef.TelemetryNamespace, telemetryTbInputLogsCount, 1, 100, nil)
+	tb.engine.Storage().Add(observerdef.TelemetryNamespace, telemetryDetectorProcessingTimeNs, 1e6, 100, []string{"detector:rrcf"})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/series", nil)
+	api.handleSeriesList(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var body []struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+
+	var counterSuffixes []string
+	var gaugeTelemetryNames []string
+	for _, s := range body {
+		if s.Namespace != observerdef.TelemetryNamespace {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(s.Name, telemetryTbInputLogsCount+":"):
+			counterSuffixes = append(counterSuffixes, strings.TrimPrefix(s.Name, telemetryTbInputLogsCount+":"))
+		case strings.HasPrefix(s.Name, telemetryDetectorProcessingTimeNs+":"):
+			gaugeTelemetryNames = append(gaugeTelemetryNames, s.Name)
+		}
+	}
+	require.ElementsMatch(t, []string{"sum"}, counterSuffixes)
+	require.Len(t, gaugeTelemetryNames, 2)
 }
 
 func TestHandleNumericSeriesDataRejectsUnknownAggregation(t *testing.T) {

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -15,7 +15,9 @@ import (
 // detector (or extractor / correlator) across all advance calls during a replay.
 // Times are in nanoseconds.
 type DetectorProcessingStats struct {
-	Name     string  `json:"name"`
+	Name string `json:"name"`
+	// Kind is the component kind: "detector", "correlator", or "extractor".
+	Kind     string  `json:"kind"`
 	Count    int     `json:"count"`
 	AvgNs    float64 `json:"avg_ns"`
 	MedianNs float64 `json:"median_ns"`
@@ -33,6 +35,30 @@ type ReplayStats struct {
 	InputMetricsCardinality int `json:"input_metrics_cardinality"`
 	// InputLogsCount is the number of raw log entries present in the scenario.
 	InputLogsCount int `json:"input_logs_count"`
+}
+
+// enrichDetectorStatsKind sets the Kind field on each DetectorProcessingStats entry.
+// It builds a reverse map from instance.Name() → kind, because a component's runtime
+// Name() (e.g. "bocpd_detector") may differ from its catalog key (e.g. "bocpd").
+func enrichDetectorStatsKind(stats map[string]DetectorProcessingStats, components map[string]*componentInstance) {
+	kindStr := map[componentKind]string{
+		componentDetector:   "detector",
+		componentCorrelator: "correlator",
+		componentExtractor:  "extractor",
+	}
+	type namer interface{ Name() string }
+	nameToKind := make(map[string]string, len(components))
+	for _, ci := range components {
+		if n, ok := ci.instance.(namer); ok {
+			nameToKind[n.Name()] = kindStr[ci.entry.kind]
+		}
+	}
+	for name, s := range stats {
+		if kind, ok := nameToKind[name]; ok {
+			s.Kind = kind
+			stats[name] = s
+		}
+	}
 }
 
 // sumTelemetryCounter returns the total value of all counter telemetry events

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -23,6 +23,16 @@ type DetectorProcessingStats struct {
 	TotalNs  float64 `json:"total_ns"` // sum of all individual call durations
 }
 
+// ReplayStats aggregates all statistics produced during a replay run.
+type ReplayStats struct {
+	// DetectorStats holds per-detector processing-time statistics keyed by detector name.
+	DetectorStats map[string]DetectorProcessingStats `json:"detector_stats,omitempty"`
+	// InputMetricsCount is the number of unique metric series present in the scenario.
+	InputMetricsCount int `json:"input_metrics_count"`
+	// InputLogsCount is the number of raw log entries present in the scenario.
+	InputLogsCount int `json:"input_logs_count"`
+}
+
 // computeDetectorProcessingStats groups telemetry samples for
 // telemetryDetectorProcessingTimeNs by detector name and computes
 // avg / median / p99 for each.

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -27,8 +27,10 @@ type DetectorProcessingStats struct {
 type ReplayStats struct {
 	// DetectorStats holds per-detector processing-time statistics keyed by detector name.
 	DetectorStats map[string]DetectorProcessingStats `json:"detector_stats,omitempty"`
-	// InputMetricsCount is the number of unique metric series present in the scenario.
+	// InputMetricsCount is the total number of metric data points (samples) in the scenario.
 	InputMetricsCount int `json:"input_metrics_count"`
+	// InputMetricsCardinality is the number of unique metric series (name + tag combinations).
+	InputMetricsCardinality int `json:"input_metrics_cardinality"`
 	// InputLogsCount is the number of raw log entries present in the scenario.
 	InputLogsCount int `json:"input_logs_count"`
 }

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -31,7 +31,7 @@ type ReplayStats struct {
 	// DetectorStats holds per-detector processing-time statistics keyed by detector name.
 	DetectorStats map[string]DetectorProcessingStats `json:"detector_stats,omitempty"`
 	// InputMetricsCount is the total number of metric data points (samples) in the scenario.
-	InputMetricsCount int `json:"input_metrics_count"`
+	InputMetricsCount int64 `json:"input_metrics_count"`
 	// InputMetricsCardinality is the number of unique metric series (name + tag combinations).
 	InputMetricsCardinality int `json:"input_metrics_cardinality"`
 	// InputLogsCount is the number of raw log entries present in the scenario.

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -6,6 +6,7 @@
 package observerimpl
 
 import (
+	"math"
 	"sort"
 
 	observerdef "github.com/DataDog/datadog-agent/comp/observer/def"
@@ -64,16 +65,20 @@ func enrichDetectorStatsKind(stats map[string]DetectorProcessingStats, component
 	}
 }
 
-// sumTelemetryCounter returns the total value of all counter telemetry events
-// matching the given metric name.
-func sumTelemetryCounter(telemetry []observerdef.ObserverTelemetry, name string) int {
+// sumStoredTelemetryCounter returns the total value of a telemetry counter metric
+// by summing all matching telemetry series in storage.
+func sumStoredTelemetryCounter(storage *timeSeriesStorage, name string) int {
 	total := 0.0
-	for _, t := range telemetry {
-		if t.Kind != observerdef.MetricKindCounter || t.Metric == nil {
+	for _, m := range storage.ListSeriesMetadata(observerdef.TelemetryNamespace) {
+		if m.Name != name {
 			continue
 		}
-		if t.Metric.GetName() == name {
-			total += t.Metric.GetValue()
+		s := storage.GetSeriesByNumericID(m.Handle, AggregateSum)
+		if s == nil {
+			continue
+		}
+		for _, p := range s.Points {
+			total += p.Value
 		}
 	}
 	return int(total)
@@ -82,18 +87,41 @@ func sumTelemetryCounter(telemetry []observerdef.ObserverTelemetry, name string)
 // computeDetectorProcessingStats groups telemetry samples for
 // telemetryDetectorProcessingTimeNs by detector name and computes
 // avg / median / p99 for each.
-func computeDetectorProcessingStats(telemetry []observerdef.ObserverTelemetry) map[string]DetectorProcessingStats {
+func computeDetectorProcessingStatsFromStorage(storage *timeSeriesStorage) map[string]DetectorProcessingStats {
 	byDetector := make(map[string][]float64)
 
-	for _, t := range telemetry {
-		if t.Metric == nil || t.Metric.GetName() != telemetryDetectorProcessingTimeNs {
+	for _, m := range storage.ListSeriesMetadata(observerdef.TelemetryNamespace) {
+		if m.Name != telemetryDetectorProcessingTimeNs {
 			continue
 		}
-		name := t.DetectorName
+
+		avgSeries := storage.GetSeriesByNumericID(m.Handle, AggregateAverage)
+		countSeries := storage.GetSeriesByNumericID(m.Handle, AggregateCount)
+		if avgSeries == nil || countSeries == nil {
+			continue
+		}
+
+		name := detectorNameFromTags(m.Tags)
 		if name == "" {
 			continue
 		}
-		byDetector[name] = append(byDetector[name], t.Metric.GetValue())
+
+		n := len(avgSeries.Points)
+		if len(countSeries.Points) < n {
+			n = len(countSeries.Points)
+		}
+		for i := 0; i < n; i++ {
+			// Storage keeps avg+count per bucket. Rehydrate bucket observations
+			// as repeated avg values to compute summary percentiles consistently.
+			sampleCount := int(math.Round(countSeries.Points[i].Value))
+			if sampleCount <= 0 {
+				continue
+			}
+			v := avgSeries.Points[i].Value
+			for j := 0; j < sampleCount; j++ {
+				byDetector[name] = append(byDetector[name], v)
+			}
+		}
 	}
 
 	result := make(map[string]DetectorProcessingStats, len(byDetector))

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -33,6 +33,21 @@ type ReplayStats struct {
 	InputLogsCount int `json:"input_logs_count"`
 }
 
+// sumTelemetryCounter returns the total value of all counter telemetry events
+// matching the given metric name.
+func sumTelemetryCounter(telemetry []observerdef.ObserverTelemetry, name string) int {
+	total := 0.0
+	for _, t := range telemetry {
+		if t.Kind != observerdef.MetricKindCounter || t.Metric == nil {
+			continue
+		}
+		if t.Metric.GetName() == name {
+			total += t.Metric.GetValue()
+		}
+	}
+	return int(total)
+}
+
 // computeDetectorProcessingStats groups telemetry samples for
 // telemetryDetectorProcessingTimeNs by detector name and computes
 // avg / median / p99 for each.

--- a/comp/observer/impl/testbench_detector_stats.go
+++ b/comp/observer/impl/testbench_detector_stats.go
@@ -35,6 +35,9 @@ type ReplayStats struct {
 	InputMetricsCardinality int `json:"input_metrics_cardinality"`
 	// InputLogsCount is the number of raw log entries present in the scenario.
 	InputLogsCount int `json:"input_logs_count"`
+	// InputAnomaliesCount is the total number of anomalies produced by detectors,
+	// which is the input volume processed by correlators.
+	InputAnomaliesCount int `json:"input_anomalies_count"`
 }
 
 // enrichDetectorStatsKind sets the Kind field on each DetectorProcessingStats entry.


### PR DESCRIPTION
Adds telemetry about number of metric samples / unique metrics / logs into the observer and updates testbench UI to display cost-per-item metrics and detector statistics.

Adds:
- Telemetry for input number
- Updated headless report
- UI components to display cost-per-item metrics and correlator information
- Some updates related to counter telemetry type

<img width="297" height="103" alt="Screenshot 2026-03-25 at 14 49 24" src="https://github.com/user-attachments/assets/97950fe3-4435-4ba5-ba3a-034265c15ff8" />

<img width="2209" height="324" alt="Screenshot 2026-03-25 at 14 49 19" src="https://github.com/user-attachments/assets/60d17fff-f262-4913-9fb7-afe8dd398f00" />

<img width="2206" height="580" alt="Screenshot 2026-03-26 at 11 41 05" src="https://github.com/user-attachments/assets/c5519ae8-49cc-4eba-9b95-09afd8adc268" />

```
Processing time per item (total ÷ items processed — same as benchmark "Cost per Item"):
  log_pattern_extractor                       52.9µs  ns/log     (19763 items)
  bocpd_detector                              8.10µs  ns/point   (495867 items)
  rrcf                                        5.70µs  ns/point   (495867 items)
  time_cluster_correlator                     4.90µs  ns/anomaly (138 items)
  log_metrics_extractor                       4.24µs  ns/log     (19763 items)
  connection_error_extractor                  0.57µs  ns/log     (19763 items)
```
