### PR TITLE
doc(ec2): clarify intentional isEC2UUID() side-effect calls in getInstanceIDFromDMI

### DIFF
--- a/pkg/util/ec2/dmi.go
+++ b/pkg/util/ec2/dmi.go
@@ -41,13 +41,13 @@ func getInstanceIDFromDMI() (string, error) {
 	}
 
 	if !isBoardVendorEC2() {
-		isEC2UUID()
+		isEC2UUID() // called for side effect: sets MetadataSourceUUID if UUID identifies this host as EC2
 		return "", errors.New("board vendor is not AWS")
 	}
 
 	boardAssetTag := dmi.GetBoardAssetTag()
 	if !strings.HasPrefix(boardAssetTag, "i-") {
-		isEC2UUID()
+		isEC2UUID() // called for side effect: sets MetadataSourceUUID if UUID identifies this host as EC2
 		return "", fmt.Errorf("invalid board_asset_tag: '%s'", boardAssetTag)
 	}
 	ec2internal.SetCloudProviderSource(ec2internal.MetadataSourceDMI)


### PR DESCRIPTION
### What does this PR do?

Adds comments to the two `isEC2UUID()` calls in `getInstanceIDFromDMI()` that have their return value discarded.

### Motivation

`isEC2UUID()` is named like a predicate, so calling it and ignoring the return value looks like a bug. The comments clarify these are intentional side-effect calls.

### Describe how you validated your changes

No behavior change, documentation only.

### Additional Notes
