### PR TITLE
Resolve `bazel` binary path _before_ `sudo` invocation

### DIFF
--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -20,10 +20,10 @@ def bazel_not_found_message(color: str) -> str:
 def bazel(ctx: Context, *args: str, capture_output: bool = False, sudo: bool = False) -> None | str:
     """Execute a bazel command. Returns the captured standard output as string if capture_output=True."""
 
-    if not shutil.which("bazel"):
+    if not (resolved_bazel := shutil.which("bazel")):
         raise Exit(bazel_not_found_message("red"))
     result = (ctx.sudo if sudo else ctx.run)(
-        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(("bazel", *args)),
+        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)((resolved_bazel, *args)),
         echo=True,
         in_stream=False,
         **({"hide": "out"} if capture_output else {"pty": sys.stdout.isatty() and sys.platform != "win32"}),  # type: ignore[dict-item]


### PR DESCRIPTION
### What does this PR do?
Use the resolved path from `shutil.which("bazel")` in the command rather than the bare string `"bazel"`, so that the original user's path is used regardless of the impersonated user.

### Motivation
When `sudo=True`, the `root` user's `PATH` may not include the user-installed `bazel` binary.

### Additional Notes
Credits to @theop-dd for [reporting](https://dd.slack.com/archives/C08SK4B0FK8/p1774453654960739).