### PR TITLE
[CWS] fix race in GetNodesInProcessCache by using Walk instead of Resolve

### DIFF
--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -701,7 +701,7 @@ func (m *Manager) GetNodesInProcessCache() map[activity_tree.ImageProcessKey]boo
 		imageTag  string
 	}
 
-	pids := make(map[imageTagKey][]uint32)
+	pidToImageTag := make(map[uint32]imageTagKey)
 
 	result := make(map[activity_tree.ImageProcessKey]bool)
 
@@ -731,33 +731,24 @@ func (m *Manager) GetNodesInProcessCache() map[activity_tree.ImageProcessKey]boo
 			imageTag = "latest"
 		}
 
-		imageTagKey := imageTagKey{
-			imageName: imageName,
-			imageTag:  imageTag,
+		k := imageTagKey{imageName: imageName, imageTag: imageTag}
+		for _, pid := range cgce.GetPIDs() {
+			pidToImageTag[pid] = k
 		}
-		pids[imageTagKey] = append(pids[imageTagKey], cgce.GetPIDs()...)
 
 		return false
 	})
 
 	// we do the resolution of filepaths here so that we can release the cgroup resolver lock before acquiring the process resolver lock
-	for k, pids := range pids {
-
-		key := activity_tree.ImageProcessKey{
-			ImageName: k.imageName,
-			ImageTag:  k.imageTag,
-			Filepath:  "",
+	pr.Walk(func(pce *model.ProcessCacheEntry) {
+		if k, ok := pidToImageTag[pce.Pid]; ok {
+			result[activity_tree.ImageProcessKey{
+				ImageName: k.imageName,
+				ImageTag:  k.imageTag,
+				Filepath:  pce.FileEvent.PathnameStr,
+			}] = true
 		}
-
-		pr.Walk(func(pce *model.ProcessCacheEntry) {
-			if slices.ContainsFunc(pids, func(pid uint32) bool {
-				return pce.Pid == pid
-			}) {
-				key.Filepath = pce.FileEvent.PathnameStr
-				result[key] = true
-			}
-		})
-	}
+	})
 
 	return result
 }

--- a/pkg/security/security_profile/manager.go
+++ b/pkg/security/security_profile/manager.go
@@ -749,16 +749,14 @@ func (m *Manager) GetNodesInProcessCache() map[activity_tree.ImageProcessKey]boo
 			Filepath:  "",
 		}
 
-		for _, pid := range pids {
-			pce := pr.Resolve(pid, pid, 0, true, nil)
-			if pce == nil {
-				seclog.Warnf("couldn't resolve process cache entry for pid %d, this process may have exited", pid)
-				continue
+		pr.Walk(func(pce *model.ProcessCacheEntry) {
+			if slices.ContainsFunc(pids, func(pid uint32) bool {
+				return pce.Pid == pid
+			}) {
+				key.Filepath = pce.FileEvent.PathnameStr
+				result[key] = true
 			}
-
-			key.Filepath = pce.FileEvent.PathnameStr
-			result[key] = true
-		}
+		})
 	}
 
 	return result


### PR DESCRIPTION
Replace the per-pid `Resolve()` loop in `GetNodesInProcessCache` with `Walk()`, which holds the process cache lock internally. The previous code called `Resolve()` without holding the lock, causing a data race when the process cache was concurrently modified.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
