### PR TITLE
feat(inventory-agent): add fips_flavor metadata field

### DIFF
--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent.go
@@ -267,11 +267,18 @@ func (ia *inventoryagent) fetchCoreAgentMetadata() {
 	}
 
 	// FIPS mode
-	if val, err := fips.Enabled(); err == nil {
-		ia.data["fips_mode"] = val
+	fipsEnabled, fipsErr := fips.Enabled()
+	if fipsErr == nil {
+		ia.data["fips_mode"] = fipsEnabled
 	} else {
 		ia.data["fips_mode"] = false
-		ia.log.Warnf("could not check if fips is enabled: %s", err)
+		ia.log.Warnf("could not check if fips is enabled: %s", fipsErr)
+		fipsEnabled = false
+	}
+	if fipsEnabled {
+		ia.data["fips_flavor"] = "agent"
+	} else if ia.conf.GetBool("fips.enabled") {
+		ia.data["fips_flavor"] = "proxy"
 	}
 }
 

--- a/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
+++ b/comp/metadata/inventoryagent/inventoryagentimpl/inventoryagent_test.go
@@ -188,10 +188,16 @@ func TestInitData(t *testing.T) {
 	assert.Nil(t, err)
 
 	expected := map[string]any{
-		"agent_version":                    version.AgentVersion,
-		"agent_startup_time_ms":            pkgconfigsetup.StartTime.UnixMilli(),
-		"flavor":                           flavor.GetFlavor(),
-		"fips_mode":                        isFips,
+		"agent_version":         version.AgentVersion,
+		"agent_startup_time_ms": pkgconfigsetup.StartTime.UnixMilli(),
+		"flavor":                flavor.GetFlavor(),
+		"fips_mode":             isFips,
+		"fips_flavor": func() string {
+			if isFips {
+				return "agent"
+			}
+			return "proxy" // fips.enabled=true in test overrides
+		}(),
 		"config_apm_dd_url":                "http://name:********@someintake.example.com/",
 		"config_dd_url":                    "http://name:********@someintake.example.com/",
 		"config_site":                      "test",


### PR DESCRIPTION
### What does this PR do?

Adds a new `fips_flavor` field to the inventory agent metadata payload (`datadog_agent`) to distinguish between the two FIPS modes:

- `"agent"` — the agent binary was compiled with FIPS-native crypto (`goexperiment.boringcrypto`)
- `"proxy"` — the agent is using the FIPS proxy (`fips.enabled: true` in config, regular build)
- field is omitted when FIPS is not in use

The existing `fips_mode` boolean is kept unchanged for backward compatibility.

### Motivation

`fips_mode: true` does not distinguish between FIPS proxy mode and native FIPS agent mode. This new field makes it possible to slice inventory data by FIPS implementation type.

### Describe how you validated your changes

Updated the existing unit test in `inventoryagentimpl` to assert the correct `fips_flavor` value based on the build type (`"agent"` for FIPS builds, `"proxy"` when `fips.enabled=true` on a regular build).

### Additional Notes

The logic mirrors what is already used in `comp/core/status/statusimpl/common_header_provider.go` (`populateFIPSStatus` and `fips_proxy_enabled`).