### PR TITLE
Work around `ctx.sudo` failing to grab password on some distros

### DIFF
--- a/tasks/libs/build/bazel.py
+++ b/tasks/libs/build/bazel.py
@@ -22,10 +22,16 @@ def bazel(ctx: Context, *args: str, capture_output: bool = False, sudo: bool = F
 
     if not (resolved_bazel := shutil.which("bazel")):
         raise Exit(bazel_not_found_message("red"))
-    result = (ctx.sudo if sudo else ctx.run)(
-        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)((resolved_bazel, *args)),
+    cmd = ("sudo", resolved_bazel) if sudo else ("bazel",)
+    kwargs = {}
+    if capture_output:
+        kwargs["hide"] = "out"
+    elif not sudo and sys.stdout.isatty() and sys.platform != "win32":
+        kwargs["pty"] = True
+    result = ctx.run(
+        (subprocess.list2cmdline if sys.platform == "win32" else shlex.join)(cmd + args),
         echo=True,
         in_stream=False,
-        **({"hide": "out"} if capture_output else {"pty": sys.stdout.isatty() and sys.platform != "win32"}),  # type: ignore[dict-item]
+        **kwargs,
     )
     return result.stdout if capture_output else None


### PR DESCRIPTION
### What does this PR do?
`ctx.sudo("...")` doesn't seem to behave consistently on all Linux distros.
I initially thought it was because `stdin` was not exposed, but changing it didn't work for me (Ubuntu laptop) since the password is gotten through TTY.
I also gave a try removing the allocated PTY as it worked for @gjulianm, but no further luck.
The only consistently working solution I found that worked on the 3 distros I tested (Ubuntu host, Alpine and Fedora containers) is: `ctx.run("sudo ...")`

### Motivation
```
dda inv system-probe.build
checking for invalid inline usage...
sudo -S -p '[sudo] password: ' /home/user/go/bin/bazel run -- @llvm_bpf//:install --destdir=/opt/datadog-agent
[sudo] password:
Sorry, try again.
[sudo] password:
Sorry, try again.
[sudo] password:
sudo: 3 incorrect password attempts
```

### Additional Notes
Credits to @gjulianm for reporting the [issue](https://dd.slack.com/archives/C08SK4B0FK8/p1774460061650269)!
