### PR TITLE
[NETPATH-671][e2e tests] Add check on hosts between network path and agent

### DIFF
--- a/test/new-e2e/tests/netpath/network-path-integration/common_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/common_test.go
@@ -58,7 +58,7 @@ func assertMetrics(fakeIntake *components.FakeIntake, c *assert.CollectT, metric
 	}
 }
 
-func (s *baseNetworkPathIntegrationTestSuite) findNetpath(isMatch func(*aggregator.Netpath) bool) (*aggregator.Netpath, error) {
+func (s *baseNetworkPathIntegrationTestSuite) findNetpath(agentHostname string, isMatch func(*aggregator.Netpath) bool) (*aggregator.Netpath, error) {
 	nps, err := s.Env().FakeIntake.Client().GetLatestNetpathEvents()
 	if err != nil {
 		return nil, err
@@ -69,14 +69,15 @@ func (s *baseNetworkPathIntegrationTestSuite) findNetpath(isMatch func(*aggregat
 
 	var match *aggregator.Netpath
 	for _, np := range nps {
-		if isMatch(np) {
+		if np.Source.Hostname == agentHostname && isMatch(np) {
+			fmt.Printf("findNetpath: matched event from host %q, dest=%s protocol=%s\n", np.Source.Hostname, np.Destination.Hostname, np.Protocol)
 			match = np
 		}
 	}
 	return match, nil
 }
-func (s *baseNetworkPathIntegrationTestSuite) expectNetpath(c *assert.CollectT, isMatch func(*aggregator.Netpath) bool) *aggregator.Netpath {
-	np, err := s.findNetpath(isMatch)
+func (s *baseNetworkPathIntegrationTestSuite) expectNetpath(c *assert.CollectT, agentHostname string, isMatch func(*aggregator.Netpath) bool) *aggregator.Netpath {
+	np, err := s.findNetpath(agentHostname, isMatch)
 	require.NoError(c, err)
 
 	require.NotNil(c, np, "could not find matching netpath")
@@ -104,7 +105,7 @@ func assertPayloadBase(c *assert.CollectT, np *aggregator.Netpath, hostname stri
 }
 
 func (s *baseNetworkPathIntegrationTestSuite) checkDatadogEUTCP(c *assert.CollectT, agentHostname string) {
-	np := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+	np := s.expectNetpath(c, agentHostname, func(np *aggregator.Netpath) bool {
 		return np.Destination.Hostname == "api.datadoghq.eu" && np.Protocol == "TCP"
 	})
 	assert.Equal(c, uint16(443), np.Destination.Port)
@@ -116,7 +117,7 @@ func (s *baseNetworkPathIntegrationTestSuite) checkDatadogEUTCP(c *assert.Collec
 }
 
 func (s *baseNetworkPathIntegrationTestSuite) checkGoogleDNSUDP(c *assert.CollectT, agentHostname string) {
-	np := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+	np := s.expectNetpath(c, agentHostname, func(np *aggregator.Netpath) bool {
 		return np.Destination.Hostname == "8.8.8.8" && np.Protocol == "UDP"
 	})
 	assertPayloadBase(c, np, agentHostname)
@@ -126,7 +127,7 @@ func (s *baseNetworkPathIntegrationTestSuite) checkGoogleDNSUDP(c *assert.Collec
 }
 
 func (s *baseNetworkPathIntegrationTestSuite) checkGoogleTCPSocket(c *assert.CollectT, agentHostname string) {
-	np := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+	np := s.expectNetpath(c, agentHostname, func(np *aggregator.Netpath) bool {
 		return np.Destination.Hostname == "8.8.8.8" && np.Protocol == "TCP"
 	})
 
@@ -149,7 +150,7 @@ func (s *baseNetworkPathIntegrationTestSuite) checkGoogleTCPSocket(c *assert.Col
 }
 
 func (s *baseNetworkPathIntegrationTestSuite) checkGoogleTCPDisableWindowsDriver(c *assert.CollectT, agentHostname string) {
-	np := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+	np := s.expectNetpath(c, agentHostname, func(np *aggregator.Netpath) bool {
 		return np.Destination.Hostname == "1.1.1.1" && np.Protocol == "TCP"
 	})
 

--- a/test/new-e2e/tests/netpath/network-path-integration/common_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/common_test.go
@@ -70,7 +70,6 @@ func (s *baseNetworkPathIntegrationTestSuite) findNetpath(agentHostname string, 
 	var match *aggregator.Netpath
 	for _, np := range nps {
 		if np.Source.Hostname == agentHostname && isMatch(np) {
-			fmt.Printf("findNetpath: matched event from host %q, dest=%s protocol=%s\n", np.Source.Hostname, np.Destination.Hostname, np.Protocol)
 			match = np
 		}
 	}

--- a/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
+++ b/test/new-e2e/tests/netpath/network-path-integration/fake_traceroute_test.go
@@ -118,10 +118,10 @@ func (s *fakeTracerouteTestSuite) TestFakeTraceroute() {
 		assert.NoError(c, err, "GetLatestNetpathEvents() errors")
 		require.NotNil(c, nps, "GetLatestNetpathEvents() returned nil netpaths")
 
-		udpPath := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+		udpPath := s.expectNetpath(c, hostname, func(np *aggregator.Netpath) bool {
 			return np.Destination.Hostname == targetIP.String() && np.Protocol == "UDP"
 		})
-		tcpPath := s.expectNetpath(c, func(np *aggregator.Netpath) bool {
+		tcpPath := s.expectNetpath(c, hostname, func(np *aggregator.Netpath) bool {
 			return np.Destination.Hostname == targetIP.String() && np.Protocol == "TCP"
 		})
 


### PR DESCRIPTION
### What does this PR do?
Adds a check to ensure that the network path's hostname matches the agent hostname on e2e tests. 

### Motivation
In general, the network path's source hostname and the agent hostname should be exactly the same as they come from the same hostname component. However, there was a recent failure where there was a mismatch which indicates that there may have been an scenario where an event was sent to the fakeintake from a different agent with a different hostname. 

https://datadoghq.atlassian.net/browse/NETPATH-671
