### PR TITLE
Remove the notion of windows 32 bit from the omnibus scripts

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -194,14 +194,10 @@ end
 
 # Windows .zip specific flags
 package :zip do
-  if windows_arch_i386?
-    skip_packager true
-  else
-    # noinspection RubyLiteralArrayInspection
-    extra_package_dirs [
-      "#{Omnibus::Config.source_dir()}\\cf-root"
-    ]
-  end
+  # noinspection RubyLiteralArrayInspection
+  extra_package_dirs [
+    "#{Omnibus::Config.source_dir()}\\cf-root"
+  ]
 end
 
 package :msi do
@@ -314,7 +310,7 @@ if windows_target?
     GO_BINARIES << "#{install_dir}\\bin\\agent\\privateactionrunner.exe"
   end
 
-  if not windows_arch_i386? and ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?
+  if ENV['WINDOWS_DDPROCMON_DRIVER'] and not ENV['WINDOWS_DDPROCMON_DRIVER'].empty?
     GO_BINARIES << "#{install_dir}\\bin\\agent\\security-agent.exe"
   end
 

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -162,6 +162,7 @@ package :msi do
 
   # For a consistent package management, please NEVER change this code
   arch = "x64"
+  # NOTE: We no longer build for 32 bit windows, so we always take the x64 path.
   if windows_arch_i386?
     upgrade_code 'a8c5b8ae-ac27-4d66-b63f-edba0e5ea477'
     arch = "x86"

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -161,14 +161,10 @@ end
 package :msi do
 
   # For a consistent package management, please NEVER change this code
+  # NOTE: We no longer build for 32 bit windows, so we always use the x64 code.
+  # x86 32 bit upgrade_code 'a8c5b8ae-ac27-4d66-b63f-edba0e5ea477'
   arch = "x64"
-  # NOTE: We no longer build for 32 bit windows, so we always take the x64 path.
-  if windows_arch_i386?
-    upgrade_code 'a8c5b8ae-ac27-4d66-b63f-edba0e5ea477'
-    arch = "x86"
-  else
-    upgrade_code 'dd60e9df-487b-415c-ba2f-dba19ddc7ebd'
-  end
+  upgrade_code 'dd60e9df-487b-415c-ba2f-dba19ddc7ebd'
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -179,6 +179,7 @@ package :msi do
 
   # For a consistent package management, please NEVER change this code
   arch = "x64"
+  # NOTE: We no longer build for 32 bit windows, so we always take the x64 path.
   if windows_arch_i386?
     full_agent_upgrade_code = '2497f989-f07e-4e8c-9e05-841ad3d4405f'
     upgrade_code '6f7ac237-334c-44c8-9fec-ec8f3459db37'

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -75,9 +75,8 @@ build do
 
   # we assume the go deps are already installed before running omnibus
   if windows_target?
-    platform = windows_arch_i386? ? "x86" : "x64"
     do_windows_sysprobe = ""
-    if not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
+    if ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
     command_on_repo_root "bazelisk run #{bazel_flags} -- //rtloader:install --destdir=\"#{install_dir}"
@@ -125,7 +124,6 @@ build do
     mkdir Omnibus::Config.package_dir() unless Dir.exists?(Omnibus::Config.package_dir())
   end
 
-  platform = windows_arch_i386? ? "x86" : "x64"
   command "dda inv -- -e trace-agent.build --install-path=#{install_dir} --flavor #{flavor_arg}", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
   # Build the installer

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -60,7 +60,6 @@ build do
     if windows_target?
       # just builds the trace-agent, this should be moved to a separate package as it's not related to the iot agent
 
-      platform = windows_arch_i386? ? "x86" : "x64"
       command "invoke trace-agent.build", :env => env, :live_stream => Omnibus.logger.live_stream(:info)
 
       mkdir "#{Omnibus::Config.source_dir()}/datadog-iot-agent/src/github.com/DataDog/datadog-agent/bin/agent"


### PR DESCRIPTION
### What does this PR do?

Removes the conditionals involving building for windows 32 bit.

### Motivation

To make reasoning about the correctness of bazel replacements for omnibus builds easier.

### Describe how you validated your changes

Got Claude to analyze all our pipelines to show we do not use windows 32 bit

### Additional Notes
