### PR TITLE
Add iot flavor for bazel builds.

### DIFF
--- a/packages/agent/BUILD.bazel
+++ b/packages/agent/BUILD.bazel
@@ -13,6 +13,7 @@ string_flag(
         "base",
         "fips",
         "heroku",
+        "iot",
     ],
 )
 
@@ -36,6 +37,11 @@ config_setting(
     flag_values = {"@@//packages/agent:flavor": "heroku"},
 )
 
+config_setting(
+    name = "iot_flavor",
+    flag_values = {"@@//packages/agent:flavor": "iot"},
+)
+
 selects.config_setting_group(
     name = "linux_default",
     match_all = [
@@ -56,6 +62,14 @@ selects.config_setting_group(
     name = "linux_heroku",
     match_all = [
         ":heroku_flavor",
+        "@platforms//os:linux",
+    ],
+)
+
+selects.config_setting_group(
+    name = "linux_iot",
+    match_all = [
+        ":iot_flavor",
         "@platforms//os:linux",
     ],
 )


### PR DESCRIPTION
As we discussed in the standup today, we will need this for differentiating package contents.
