### PR TITLE
remove agent-build as an owner of cmd/agent/install_mac_os.sh

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -234,7 +234,7 @@
 /cmd/agent/dist/conf.d/win32_event_log.d/ @DataDog/windows-products
 /cmd/agent/dist/conf.d/windows_certificate.d/ @DataDog/windows-products
 /cmd/agent/install*.sh                  @DataDog/agent-build
-/cmd/agent/install_mac_os.sh            @DataDog/agent-build @DataDog/windows-products
+/cmd/agent/install_mac_os.sh            @DataDog/windows-products
 /cmd/cluster-agent/                     @DataDog/container-platform
 /cmd/cluster-agent/subcommands/autoscalerlist   @DataDog/container-autoscaling @DataDog/container-integrations
 /cmd/cluster-agent-cloudfoundry/        @DataDog/agent-integrations


### PR DESCRIPTION
### What does this PR do?

Gives windows-products full ownership of cmd/agent/install_mac_os.sh

### Motivation

Reduce review request noise and false gating