### PR TITLE
Silence `gazelle` embed warnings for `pkg/dyninst/testdata`

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,7 +65,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude pkg/dyninst/procsubscribe
 # gazelle:exclude pkg/dyninst/symbol
 # gazelle:exclude pkg/dyninst/symdb
-# gazelle:exclude pkg/dyninst/testdata
 # gazelle:exclude pkg/dyninst/testprogs
 # gazelle:exclude pkg/dyninst/trietest
 # gazelle:exclude pkg/dyninst/uploader


### PR DESCRIPTION
### What does this PR do?
Remove `gazelle:exclude pkg/dyninst/testdata` from `BUILD.bazel`.

### Motivation
`pkg/dyninst` is processed by `gazelle`, and its test files use `//go:embed testdata/...` directives.
With `testdata` excluded, `gazelle` cannot resolve those patterns and emits spurious "matched no files" warnings:
```
INFO: Running command line: bazel-bin/gazelle
gazelle: /dda/pkg/dyninst/end_to_end_test.go:98:2: pattern testdata/e2e/rc_tester.json: matched no files
gazelle: /dda/pkg/dyninst/end_to_end_test.go:98:30: pattern testdata/e2e/rc_tester_v1.json: matched no files
gazelle: /dda/pkg/dyninst/integration_test.go:55:2: pattern testdata/decoded: matched no files
```
Since `testdata` holds only JSON files (no Go sources), `gazelle` generates no `BUILD.bazel` there regardless, making the exclusion both redundant and noisy.

### Describe how you validated your changes
`bazel run //:gazelle` no longer emits the three warnings.

### Additional Notes
Credits go to @jeremy-hanna for reporting the issue.