### PR TITLE
Don't expose DD_GUI_APP_MENU_ENABLED

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -669,7 +669,7 @@ fi
 # Per-user GUI: plist has --headless by default; optionally strip it and reload launchd here
 user_gui_plist="${install_user_home}/Library/LaunchAgents/com.datadoghq.gui.plist"
 if [ "$systemdaemon_install" = false ] && [ "$gui_app_menu_enabled" = true ] && [ -f "$user_gui_plist" ]; then
-    printf "${BLUE}\n    - Enabling menu bar GUI (DD_GUI_APP_MENU_ENABLED=true)...\n${NC}"
+    printf "${BLUE}\n    - Enabling menu bar GUI...\n${NC}"
     $sudo_cmd sed -i '' '/<string>--headless<\/string>/d' "$user_gui_plist"
     # Restart the GUI so it picks up the updated plist without --headless
     $cmd_launchctl bootout "gui/$user_uid/com.datadoghq.gui" 2>/dev/null || true

--- a/omnibus/package-scripts/agent-dmg/postinst
+++ b/omnibus/package-scripts/agent-dmg/postinst
@@ -216,8 +216,6 @@ else
   echo "=========================================="
   echo "Datadog Agent GUI"
   echo "=========================================="
-  echo "The menu bar icon is hidden by default (headless GUI for WiFi metrics)."
-  echo "When installing via install_mac_os.sh, set DD_GUI_APP_MENU_ENABLED=true to show it."
   echo ""
   echo "To enable WiFi data collection (SSID/BSSID), grant Location permission:"
   echo "  System Settings -> Privacy & Security -> Location Services -> Enable 'Datadog Agent'"


### PR DESCRIPTION
### What does this PR do?
The release process for the macos install script is manual and out of sync with the agent. Currently, we plan to make a new release of the script in https://github.com/DataDog/datadog-agent/pull/48370, however the `DD_GUI_APP_MENU_ENABLED` changes in the agent https://github.com/DataDog/datadog-agent/pull/48240 will get released later. Thus, we should hide outputting `DD_GUI_APP_MENU_ENABLED` to the user. Changes to the script won't break anything in agent install before it gets released. The agent will continue to install as before. We can still backport https://github.com/DataDog/datadog-agent/pull/48240.

### Motivation
https://datadoghq.atlassian.net/browse/WINA-2506

### Describe how you validated your changes

### Additional Notes
