### PR TITLE
re-enable dependabot with 14-day cooldown

### DIFF
--- a/github/dependabot.yaml
+++ b/github/dependabot.yaml
@@ -1,0 +1,212 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/triage
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/spf13/cast
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  groups:
+    franz-go:
+      patterns:
+      - github.com/twmb/franz-go*
+    bun:
+      patterns:
+      - github.com/uptrace/bun*
+    aws-sdk-go-v2:
+      patterns:
+      - github.com/aws/aws-sdk-go-v2*
+    k8s-io:
+      patterns:
+      - k8s.io/*
+      update-types:
+      - patch
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /pkg/trace
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-apm
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: github.com/mailru/easyjson
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  - dependency-name: github.com/open-telemetry/opentelemetry-collector-contrib/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /pkg/gohai
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-configuration
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: github.com/mailru/easyjson
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /pkg/obfuscate
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-apm
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: github.com/mailru/easyjson
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /pkg/security/secl
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-security
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /internal/tools
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - dependencies-go-tools
+  - dev/tooling
+  - team/agent-delivery
+  - changelog/no-changelog
+  - qa/no-code-change
+  schedule:
+    interval: monthly
+  ignore:
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /pkg/networkdevice/profile
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/network-device-monitoring-core
+  - changelog/no-changelog
+  ignore:
+  - dependency-name: github.com/DataDog/datadog-agent/*
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /test/new-e2e
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-e2e-test
+  - changelog/no-changelog
+  - qa/no-code-change
+  - dev/testing
+  ignore:
+  - dependency-name: github.com/DataDog/test-infra-definitions
+  - dependency-name: github.com/pulumi*
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  groups:
+    aws-sdk-go-v2:
+      patterns:
+      - github.com/aws/aws-sdk-go-v2*
+    k8s-io:
+      patterns:
+      - k8s.io/*
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  cooldown:
+    default-days: 14
+- package-ecosystem: gomod
+  directory: /test/fakeintake
+  rebase-strategy: disabled
+  labels:
+  - dependencies
+  - dependencies-go
+  - team/agent-e2e-test
+  - changelog/no-changelog
+  - qa/no-code-change
+  - dev/testing
+  schedule:
+    interval: weekly
+    day: saturday
+  open-pull-requests-limit: 100
+  ignore:
+  - dependency-name: golang.org/x/*
+  - dependency-name: go.opentelemetry.io/*
+  cooldown:
+    default-days: 14
+- package-ecosystem: maven
+  directory: Dockerfiles/agent/bouncycastle-fips
+  labels:
+  - dependencies
+  - team/agent-metric-pipelines
+  - changelog/no-changelog
+  schedule:
+    interval: weekly
+    day: saturday
+  ignore:
+  - dependency-name: org.bouncycaslte:*
+    versions:
+    - '[2.1,)'
+  cooldown:
+    default-days: 14


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a mandatory 14-day cooldown on dependencies to reduce the risk of zero-day vulnerabilities.

This PR re-enables your Dependabot configuration and introduces the cooldown setting. If you notice any other Dependabot configurations in your repo that are missing the cooldown, please ensure it is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.