### PR TITLE
Migrate pkg/fips & pkg/version tests to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -71,7 +71,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude pkg/dyninst/uprobe
 # gazelle:exclude pkg/errors
 # gazelle:exclude pkg/eventmonitor
-# gazelle:exclude pkg/fips
 # gazelle:exclude pkg/flare
 # gazelle:exclude pkg/fleet
 # gazelle:exclude pkg/gohai

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -197,7 +197,6 @@ package(default_visibility = ["//visibility:public"])
 # gazelle:exclude pkg/util/winutil
 # gazelle:exclude pkg/util/workqueue
 # gazelle:exclude pkg/util/xc
-# gazelle:exclude pkg/version
 # gazelle:exclude pkg/windowsdriver
 # TODO(agent-build): This exclusion is ready for removal, blocked by issues caused by the interaction of
 # Bazel with directories named `build` created by the CMake builds. We can remove this once we remove CMake

--- a/pkg/fips/BUILD.bazel
+++ b/pkg/fips/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "fips",
+    srcs = [
+        "fips.go",
+        "fips_goboring.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/fips",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "fips_test",
+    srcs = ["fips_test.go"],
+    embed = [":fips"],
+)

--- a/pkg/version/BUILD.bazel
+++ b/pkg/version/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "version",
+    srcs = [
+        "base.go",
+        "version.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/version",
+    visibility = ["//visibility:public"],
+    # TODO(agent-build): replace with proper per-binary stamping at final link time.
+    # Full stamping (--stamp) is intentionally avoid systematic cache invalidation
+    x_defs = {
+        "github.com/DataDog/datadog-agent/pkg/version.Commit": "dev",
+        "github.com/DataDog/datadog-agent/pkg/version.AgentVersion": "0.0.0-dev",
+        "github.com/DataDog/datadog-agent/pkg/version.AgentVersionURLSafe": "0.0.0-dev",
+        "github.com/DataDog/datadog-agent/pkg/version.AgentPackageVersion": "0.0.0-dev",
+        "github.com/DataDog/datadog-agent/pkg/version.AgentPayloadVersion": "0.0.0-dev",
+    },
+)
+
+go_test(
+    name = "version_test",
+    srcs = [
+        "base_test.go",
+        "version_test.go",
+    ],
+    embed = [":version"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)


### PR DESCRIPTION
### What does this PR do?

Migrate a couple module tests to bazel

### Motivation

Ongoing migration to bazel

### Describe how you validated your changes

### Additional Notes

For `/pkg/version` we are currently using a hardcoded place holder instead of the actual information, in order to avoid invalidating the cache on each build.
Correctly stamping the build is scheduled for later and is tracked as https://datadoghq.atlassian.net/browse/ABLD-422
