### PR TITLE
[CWS] fix fargate e2e: don't assert hostname when none is expected

### DIFF
--- a/test/new-e2e/tests/cws/common.go
+++ b/test/new-e2e/tests/cws/common.go
@@ -58,6 +58,10 @@ func (a *agentSuite) Hostname() string {
 	return a.Env().Agent.Client.Hostname()
 }
 
+func (a *agentSuite) InstanceID() string {
+	return ""
+}
+
 func (a *agentSuite) Client() *api.Client {
 	return a.apiClient
 }
@@ -240,6 +244,7 @@ func (a *agentSuite) Test99CWSEnabled() {
 type testSuite interface {
 	Hostname() string
 	Client() *api.Client
+	InstanceID() string
 }
 
 type eventValidationCb[T any] func(e T)
@@ -261,7 +266,13 @@ func testRulesetLoaded(t assert.TestingT, ts testSuite, policySource string, pol
 }
 
 func testRuleEvent(t assert.TestingT, ts testSuite, ruleID string, extraValidations ...eventValidationCb[*api.RuleEvent]) {
-	query := fmt.Sprintf("rule_id:%s host:%s", ruleID, ts.Hostname())
+	query := "rule_id:" + ruleID
+	if hostname := ts.Hostname(); hostname != "" {
+		query = fmt.Sprintf("%s host:%s", query, hostname)
+	}
+	if instanceID := ts.InstanceID(); instanceID != "" {
+		query = fmt.Sprintf("%s instance_id:%s", query, instanceID)
+	}
 	ruleEvent, err := api.GetAppEvent[api.RuleEvent](ts.Client(), query)
 	if !assert.NoErrorf(t, err, "could not get %s event for host %s", ruleID, ts.Hostname()) {
 		return

--- a/test/new-e2e/tests/cws/common.go
+++ b/test/new-e2e/tests/cws/common.go
@@ -250,7 +250,13 @@ type testSuite interface {
 type eventValidationCb[T any] func(e T)
 
 func testRulesetLoaded(t assert.TestingT, ts testSuite, policySource string, policyName string, extraValidations ...eventValidationCb[*api.RulesetLoadedEvent]) {
-	query := fmt.Sprintf("rule_id:ruleset_loaded host:%s @policies.source:%s @policies.name:%s", ts.Hostname(), policySource, policyName)
+	query := fmt.Sprintf("rule_id:ruleset_loaded @policies.source:%s @policies.name:%s", policySource, policyName)
+	if hostname := ts.Hostname(); hostname != "" {
+		query = fmt.Sprintf("%s host:%s", query, hostname)
+	}
+	if instanceID := ts.InstanceID(); instanceID != "" {
+		query = fmt.Sprintf("%s instance_id:%s", query, instanceID)
+	}
 	rulesetLoaded, err := api.GetAppEvent[api.RulesetLoadedEvent](ts.Client(), query)
 	if !assert.NoErrorf(t, err, "could not get %s/%s ruleset_loaded event for host %s", policySource, policyName, ts.Hostname()) {
 		return
@@ -334,7 +340,13 @@ func testCwsEnabled(t assert.TestingT, ts testSuite) {
 }
 
 func testSelftestsEvent(t assert.TestingT, ts testSuite, extraValidations ...eventValidationCb[*api.SelftestsEvent]) {
-	query := "rule_id:self_test host:" + ts.Hostname()
+	query := "rule_id:self_test"
+	if hostname := ts.Hostname(); hostname != "" {
+		query = fmt.Sprintf("%s host:%s", query, hostname)
+	}
+	if instanceID := ts.InstanceID(); instanceID != "" {
+		query = fmt.Sprintf("%s instance_id:%s", query, instanceID)
+	}
 	selftestsEvent, err := api.GetAppEvent[api.SelftestsEvent](ts.Client(), query)
 	if !assert.NoErrorf(t, err, "could not get selftests event for host %s", ts.Hostname()) {
 		return

--- a/test/new-e2e/tests/cws/fargate_test.go
+++ b/test/new-e2e/tests/cws/fargate_test.go
@@ -31,12 +31,12 @@ import (
 )
 
 const (
-	ecsFgHostnamePrefix = "cws-e2e-ecs-fg-task"
-	selfTestsPolicyName = "selftests.policy"
-	execRuleID          = "selftest_exec"
-	openRuleID          = "selftest_open"
-	execFilePath        = "/usr/bin/date"
-	openFilePath        = "/tmp/open.test"
+	ecsFgInstanceIDPrefix = "cws-e2e-ecs-fg-task"
+	selfTestsPolicyName   = "selftests.policy"
+	execRuleID            = "selftest_exec"
+	openRuleID            = "selftest_open"
+	execFilePath          = "/usr/bin/date"
+	openFilePath          = "/tmp/open.test"
 )
 
 // this env struct is empty for now but will eventually contain a component for an ECS test environment
@@ -44,8 +44,8 @@ type ecsFargateEnv struct{}
 
 type ecsFargateSuite struct {
 	e2e.BaseSuite[ecsFargateEnv]
-	apiClient  *api.Client
-	ddHostname string
+	apiClient    *api.Client
+	ddInstanceID string
 }
 
 func TestECSFargate(t *testing.T) {
@@ -62,9 +62,9 @@ func TestECSFargate(t *testing.T) {
 	policy, err := getPolicyContent(ruleDefs)
 	require.NoErrorf(t, err, "failed generate policy from test rules: %v", err)
 
-	ddHostname := fmt.Sprintf("%s-%s", ecsFgHostnamePrefix, uuid.NewString()[:4])
+	ddInstanceID := fmt.Sprintf("%s-%s", ecsFgInstanceIDPrefix, uuid.NewString()[:4])
 
-	e2e.Run[ecsFargateEnv](t, &ecsFargateSuite{ddHostname: ddHostname},
+	e2e.Run[ecsFargateEnv](t, &ecsFargateSuite{ddInstanceID: ddInstanceID},
 		e2e.WithUntypedPulumiProvisioner(func(ctx *pulumi.Context) error {
 			awsEnv, err := awsResources.NewEnvironment(ctx)
 			if err != nil {
@@ -108,8 +108,8 @@ func TestECSFargate(t *testing.T) {
 						Essential: pulumi.BoolPtr(true),
 						Environment: ecsx.TaskDefinitionKeyValuePairArray{
 							ecsx.TaskDefinitionKeyValuePairArgs{
-								Name:  pulumi.StringPtr("DD_HOSTNAME"),
-								Value: pulumi.StringPtr(ddHostname),
+								Name:  pulumi.StringPtr("DD_EXTRA_TAGS"),
+								Value: pulumi.StringPtr(fmt.Sprintf(`["instance_id:%s"]`, ddInstanceID)),
 							},
 							ecsx.TaskDefinitionKeyValuePairArgs{
 								Name:  pulumi.StringPtr("ECS_FARGATE"),
@@ -117,10 +117,6 @@ func TestECSFargate(t *testing.T) {
 							},
 							ecsx.TaskDefinitionKeyValuePairArgs{
 								Name:  pulumi.StringPtr("DD_RUNTIME_SECURITY_CONFIG_ENABLED"),
-								Value: pulumi.StringPtr("true"),
-							},
-							ecsx.TaskDefinitionKeyValuePairArgs{
-								Name:  pulumi.StringPtr("DD_RUNTIME_SECURITY_CONFIG_EBPFLESS_ENABLED"),
 								Value: pulumi.StringPtr("true"),
 							},
 							ecsx.TaskDefinitionKeyValuePairArgs{
@@ -141,7 +137,7 @@ func TestECSFargate(t *testing.T) {
 							Interval:    pulumi.IntPtr(30),
 							Timeout:     pulumi.IntPtr(5),
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("datadog-agent"), pulumi.String(ecsFgInstanceIDPrefix), apiKeyParam.Name),
 					},
 					"ubuntu-with-tracer": {
 						Cpu:       pulumi.IntPtr(0),
@@ -185,7 +181,7 @@ func TestECSFargate(t *testing.T) {
 								ReadOnly:      pulumi.Bool(true),
 							},
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("ubuntu-with-tracer"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("ubuntu-with-tracer"), pulumi.String(ecsFgInstanceIDPrefix), apiKeyParam.Name),
 					},
 					"cws-instrumentation-init": {
 						Cpu:       pulumi.IntPtr(0),
@@ -205,7 +201,7 @@ func TestECSFargate(t *testing.T) {
 								ReadOnly:      pulumi.Bool(false),
 							},
 						},
-						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("cws-instrumentation-init"), pulumi.String(ecsFgHostnamePrefix), apiKeyParam.Name),
+						LogConfiguration: ecsResources.GetFirelensLogConfiguration(pulumi.String("cws-instrumentation-init"), pulumi.String(ecsFgInstanceIDPrefix), apiKeyParam.Name),
 						User:             pulumi.StringPtr("0"),
 					},
 					"log_router": *ecsResources.FargateFirelensContainerDefinition(),
@@ -236,7 +232,7 @@ func TestECSFargate(t *testing.T) {
 			return nil
 		}, nil),
 	)
-	t.Logf("Running testsuite with DD_HOSTNAME=%s", ddHostname)
+	t.Logf("Running testsuite with instance_id=%s", ddInstanceID)
 }
 
 func (s *ecsFargateSuite) SetupSuite() {
@@ -245,7 +241,11 @@ func (s *ecsFargateSuite) SetupSuite() {
 }
 
 func (s *ecsFargateSuite) Hostname() string {
-	return s.ddHostname
+	return ""
+}
+
+func (s *ecsFargateSuite) InstanceID() string {
+	return s.ddInstanceID
 }
 
 func (s *ecsFargateSuite) Client() *api.Client {

--- a/test/new-e2e/tests/cws/kind_test.go
+++ b/test/new-e2e/tests/cws/kind_test.go
@@ -98,6 +98,10 @@ func (s *kindSuite) Hostname() string {
 	return s.ddHostname
 }
 
+func (s *kindSuite) InstanceID() string {
+	return ""
+}
+
 func (s *kindSuite) Client() *api.Client {
 	return s.apiClient
 }

--- a/test/new-e2e/tests/cws/windows_test.go
+++ b/test/new-e2e/tests/cws/windows_test.go
@@ -82,6 +82,10 @@ func (a *agentSuiteWindows) Hostname() string {
 	return a.Env().Agent.Client.Hostname()
 }
 
+func (a *agentSuiteWindows) InstanceID() string {
+	return ""
+}
+
 func (a *agentSuiteWindows) Client() *api.Client {
 	return a.apiClient
 }


### PR DESCRIPTION
On Fargate, containers do not have a hostname, so e2e tests should not force or assert a specific hostname value. Updated tests to handle the absence of hostname gracefully instead of requiring it.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
