### PR TITLE
Port post-python-build sysconfigdata fixes to a Python script

### DIFF
--- a/deps/cpython.BUILD.bazel
+++ b/deps/cpython.BUILD.bazel
@@ -163,22 +163,6 @@ python_deps = {
     "liblzma": "-llzma",
 }
 
-# The list of build tools we want to override in sysconfigdata.py
-# as they will not be available when building custom integrations without bazel
-to_override_build_tools = [
-    "ar",
-    "gcc",
-    "g++",
-    "ld",
-]
-
-to_override_flags = [
-    "CFLAGS",
-    "CXXFLAGS",
-    "LDFLAGS",
-    "CPPFLAGS",
-]
-
 configure_make(
     name = "python_unix",
     configure_options = [
@@ -226,6 +210,8 @@ configure_make(
     }),
     build_data = [
         ":redacted_compat.h",
+        "@@//deps/cpython:fix_sysconfigdata.py",
+        "@python_3_12//:python3",
     ],
     lib_source = ":all_srcs",
     out_binaries = UNIX_BINS,
@@ -284,26 +270,11 @@ configure_make(
     # This is later used to build extensions with the same tools/compiler/flags/config as the interpreter
     # However, in our case, that means using tools that are stored in the build sandbox, so they aren't
     # usable when building an extension, causing all builds to fail.
-    # Ideally we would want to explicitly replace bazel paths with known alternatives, but we don't
-    # have an environment variable holding the value we want to replace so we have to resort to
-    # a regular expression replacing paths to tools.
-    # We also unset the flags listed in to_override_flags.
-    # If we start using some specific build flags that need to be propagated, we will need to include
-    # them here instead of replacing them by an empty string.
-    postfix_script = " && ".join([
-                         "perl -i -pe 's/(:?[a-zA-Z0-9_+.\\/-]+)\\/{tool}\\b/{tool}/g' $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py".format(
-                             tool = tool,
-                             version = VERSION_STR,
-                         )
-                         for tool in to_override_build_tools
-                     ]) + " && " +
-                     " && ".join([
-                         "perl -i -pe \"s/\'{flag}\': \'.*\',$$/\'{flag}\': \'\',/g\" $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py".format(
-                             flag = flag,
-                             version = VERSION_STR,
-                         )
-                         for flag in to_override_flags
-                     ]),
+    # fix_sysconfigdata.py strips sandbox-absolute paths from known tool entries (leaving just the
+    # basename so they can be found on PATH) and clears build flags that are Bazel-specific.
+    postfix_script = "$(execpath @python_3_12//:python3) $(execpath @@//deps/cpython:fix_sysconfigdata.py) $$INSTALLDIR/lib/python{version}/_sysconfigdata__*.py".format(
+        version = VERSION_STR,
+    ),
 )
 
 foreign_cc_shared_wrapper(

--- a/deps/cpython/BUILD.bazel
+++ b/deps/cpython/BUILD.bazel
@@ -1,1 +1,3 @@
 """Package delimiter."""
+
+exports_files(["fix_sysconfigdata.py"])

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -1,0 +1,80 @@
+"""Fix sandbox-absolute tool paths in Python's _sysconfigdata__*.py.
+
+Replaces tool paths recorded by CPython's build system with just the
+tool's basename (stripping Bazel sandbox prefixes), and clears build
+flags that are meaningless outside of Bazel.
+
+The resulting file will lose original formatting and comments, but this
+is acceptable given the file's usage.
+"""
+
+import argparse
+import ast
+import os
+import sys
+
+# Names of tool to strip to their basenames
+TOOL_BASENAMES = frozenset(
+    [
+        "ar",
+        "gcc",
+        "g++",
+        "ld",
+    ]
+)
+
+# Build-environment flags that are meaningless outside of Bazel
+FLAGS_TO_CLEAR = frozenset(
+    [
+        "CFLAGS",
+        "CPPFLAGS",
+        "CXXFLAGS",
+        "LDFLAGS",
+    ]
+)
+
+
+def _fix_value(key, value):
+    if key in FLAGS_TO_CLEAR:
+        return ""
+    if isinstance(value, str) and os.path.basename(value) in TOOL_BASENAMES:
+        return os.path.basename(value)
+    return value
+
+
+def fix_file(path):
+    with open(path) as f:
+        source = f.read()
+
+    tree = ast.parse(source)
+
+    # Walk the AST and edit the "build_time_vars" dictionary in-place with
+    # the "fixed" values.
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "build_time_vars" for t in node.targets
+        ):
+            build_time_vars = ast.literal_eval(node.value)
+            fixed = {k: _fix_value(k, v) for k, v in build_time_vars.items()}
+            node.value = ast.Dict(
+                keys=[ast.Constant(value=k) for k in fixed],
+                values=[ast.Constant(value=v) for v in fixed.values()],
+            )
+            break
+    else:
+        sys.exit(f"error: build_time_vars not found in {path}")
+
+    with open(path, "w") as f:
+        f.write(ast.unparse(tree) + "\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", nargs="+", metavar="FILE", help="_sysconfigdata__*.py file(s) to fix")
+    args = parser.parse_args()
+    for path in args.files:
+        fix_file(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -35,6 +35,7 @@ FLAGS_TO_CLEAR = frozenset(
 )
 
 # Regexp to split into alternating path candidates and other tokens
+# Needs to account for paths being preceded by `=` or quotes.
 _PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
 
 

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -37,8 +37,12 @@ FLAGS_TO_CLEAR = frozenset(
 def _fix_value(key, value):
     if key in FLAGS_TO_CLEAR:
         return ""
-    if isinstance(value, str) and os.path.basename(value) in TOOL_BASENAMES:
-        return os.path.basename(value)
+    if isinstance(value, str):
+        # Replace tool name references with their basename anywhere they occur
+        tokens = value.split()
+        new_tokens = [os.path.basename(t) if os.path.basename(t) in TOOL_BASENAMES else t for t in tokens]
+        if new_tokens != tokens:
+            return " ".join(new_tokens)
     return value
 
 

--- a/deps/cpython/fix_sysconfigdata.py
+++ b/deps/cpython/fix_sysconfigdata.py
@@ -11,6 +11,7 @@ is acceptable given the file's usage.
 import argparse
 import ast
 import os
+import re
 import sys
 
 # Names of tool to strip to their basenames
@@ -33,16 +34,22 @@ FLAGS_TO_CLEAR = frozenset(
     ]
 )
 
+# Regexp to split into alternating path candidates and other tokens
+_PATH_SPLITTER_RE = re.compile(r"""(/[^\s='"]+)""")
+
+
+def _fix_tool_path(segment):
+    basename = os.path.basename(segment)
+    return basename if basename in TOOL_BASENAMES else segment
+
 
 def _fix_value(key, value):
     if key in FLAGS_TO_CLEAR:
         return ""
     if isinstance(value, str):
-        # Replace tool name references with their basename anywhere they occur
-        tokens = value.split()
-        new_tokens = [os.path.basename(t) if os.path.basename(t) in TOOL_BASENAMES else t for t in tokens]
-        if new_tokens != tokens:
-            return " ".join(new_tokens)
+        parts = _PATH_SPLITTER_RE.split(value)
+        # The split leaves path-candidates (non-separators) at odd-indexed positions
+        return "".join(_fix_tool_path(p) if i % 2 == 1 else p for i, p in enumerate(parts))
     return value
 
 


### PR DESCRIPTION
### What does this PR do?

It changes python unix post-fix script perl inline (regex-based) calls to a python script that manipulates the sysconfigdata content directly.

### Motivation

Improve maintainability in the face of recent changes that I've been wanting to apply:
- https://github.com/DataDog/datadog-agent/pull/48352
- https://github.com/DataDog/datadog-agent/pull/42894#discussion_r2989677961

ad-hoc constructed perl one-liners and regular expressions can only take us so far. The resulting code is more verbose but easier to comprehend and to extend. This is also more hermetic thanks to the use of the rules_python managed python (instead of relying on system perl).

### Describe how you validated your changes

Apart from passing CI, I also manually confirmed the effect of it in the local build, comparing previous and current input (with some claude help).

Running test suite on integrations-core, which is known to catch issues with this (notably the MapR e2e test install python extensions that exercise these variables): https://github.com/DataDog/integrations-core/actions/runs/23602123088

### Additional Notes

The change should be nearly no-op, except that it will not keep the formatting and comments from the original file. Given that this file is a code file to only be really read by programs, this is arguably a positive change (even saving a few more bytes in the process).

There are a few other small behavior variations, like no longer replacing cases where the toolname wasn't in the basename (such as `.../lib/gcc/...`, which accounts for the slight size increase).

The way the new script operates should also perform significantly worse than the perl regex substitution, but this is not in a noticeable scale.