### PR TITLE
chore(codeowners): replace @iglendd with @DataDog/agent-health for agenttelemetry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -395,8 +395,7 @@
 /comp/workloadselection @DataDog/injection-platform
 # END COMPONENTS
 
-# Additional notification to  @iglendd about Agent Telemetry changes for optional approval and governance acknowledgement
-/comp/core/agenttelemetry               @DataDog/agent-runtimes @iglendd
+/comp/core/agenttelemetry               @DataDog/agent-health
 
 # trace-agent logging implementation should also notify agent-apm
 /comp/core/log/impl-trace @DataDog/agent-apm


### PR DESCRIPTION
### What does this PR do?
Updates the CODEOWNERS entry for `/comp/core/agenttelemetry` to replace the individual `@iglendd` with the `@DataDog/agent-health` team, and removes the previous `@DataDog/agent-runtimes` co-owner so that only `@DataDog/agent-health` owns this path.

### Motivation
Ownership should be assigned to a team rather than an individual for better coverage and governance.

### Describe how you validated your changes
CODEOWNERS-only change, no code modified.

### Additional Notes
N/A