### PR TITLE
fix(gpu): retry collector status flakes in k8s e2e

### DIFF
--- a/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
+++ b/test/e2e-framework/testing/utils/e2e/client/agent_commands.go
@@ -52,12 +52,16 @@ func (agent *agentCommandRunner) executeCommand(command string, commandArgs ...a
 func (agent *agentCommandRunner) executeCommandWithError(command string, commandArgs ...agentclient.AgentArgsOption) (string, error) {
 	if !agent.isReady {
 		err := agent.waitForReadyTimeout(1 * time.Minute)
-		require.NoErrorf(agent.t, err, "the agent is not ready")
+		if err != nil {
+			return "", fmt.Errorf("the agent is not ready: %w", err)
+		}
 		agent.isReady = true
 	}
 
 	args, err := optional.MakeParams(commandArgs...)
-	require.NoError(agent.t, err)
+	if err != nil {
+		return "", fmt.Errorf("could not build agent command arguments: %w", err)
+	}
 
 	arguments := []string{command}
 	arguments = append(arguments, args.Args...)

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -296,19 +296,28 @@ func (v *gpuBaseSuite[Env]) TestGPUCheckIsEnabled() {
 
 	// Note that the GPU check should be enabled by autodiscovery, so it can take some time to be enabled
 	v.EventuallyWithT(func(c *assert.CollectT) {
-		statusOutput := v.caps.Agent().Status(agentclient.WithArgs([]string{"collector", "--json"}))
+		statusOutput, err := v.caps.Agent().StatusWithError(agentclient.WithArgs([]string{"collector", "--json"}))
+		if !assert.NoError(c, err, "failed to get agent collector status") {
+			return
+		}
 
 		// Keep only the second-to-last line of the output, which is the JSON status. The rest is standard error
 		// TODO: Make the status command return stdout/stderr separately
 		statusLines := strings.Split(statusOutput.Content, "\n")
-		assert.Greater(c, len(statusLines), 1, "status output should have at least 2 lines")
+		if !assert.Greater(c, len(statusLines), 1, "status output should have at least 2 lines") {
+			return
+		}
 		jsonStatus := statusLines[len(statusLines)-2]
 
 		var status collectorStatus
-		err := json.Unmarshal([]byte(jsonStatus), &status)
+		err = json.Unmarshal([]byte(jsonStatus), &status)
 
-		assert.NoError(c, err, "failed to unmarshal agent status")
-		assert.Contains(c, status.RunnerStats.Checks, "gpu", "gpu check should be enabled")
+		if !assert.NoError(c, err, "failed to unmarshal agent status") {
+			return
+		}
+		if !assert.Contains(c, status.RunnerStats.Checks, "gpu", "gpu check should be enabled") {
+			return
+		}
 
 		v.T().Logf("gpu check status: %+v", status.RunnerStats.Checks["gpu"])
 

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -315,7 +315,7 @@ func (v *gpuBaseSuite[Env]) TestGPUCheckIsEnabled() {
 
 		gpuCheckStatus := status.RunnerStats.Checks["gpu"]
 		require.Equal(c, gpuCheckStatus.LastError, "")
-	}, 2*time.Minute, 10*time.Second)
+	}, 5*time.Minute, 10*time.Second)
 }
 
 func (v *gpuBaseSuite[Env]) TestGPUSysprobeEndpointIsResponding() {

--- a/test/new-e2e/tests/gpu/gpu_test.go
+++ b/test/new-e2e/tests/gpu/gpu_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/test/e2e-framework/components/os"
 
@@ -297,32 +298,23 @@ func (v *gpuBaseSuite[Env]) TestGPUCheckIsEnabled() {
 	// Note that the GPU check should be enabled by autodiscovery, so it can take some time to be enabled
 	v.EventuallyWithT(func(c *assert.CollectT) {
 		statusOutput, err := v.caps.Agent().StatusWithError(agentclient.WithArgs([]string{"collector", "--json"}))
-		if !assert.NoError(c, err, "failed to get agent collector status") {
-			return
-		}
+		require.NoError(c, err, "failed to get agent collector status")
 
 		// Keep only the second-to-last line of the output, which is the JSON status. The rest is standard error
 		// TODO: Make the status command return stdout/stderr separately
 		statusLines := strings.Split(statusOutput.Content, "\n")
-		if !assert.Greater(c, len(statusLines), 1, "status output should have at least 2 lines") {
-			return
-		}
+		require.Greater(c, len(statusLines), 1, "status output should have at least 2 lines")
 		jsonStatus := statusLines[len(statusLines)-2]
 
 		var status collectorStatus
 		err = json.Unmarshal([]byte(jsonStatus), &status)
-
-		if !assert.NoError(c, err, "failed to unmarshal agent status") {
-			return
-		}
-		if !assert.Contains(c, status.RunnerStats.Checks, "gpu", "gpu check should be enabled") {
-			return
-		}
+		require.NoError(c, err, "failed to unmarshal agent status")
+		require.Contains(c, status.RunnerStats.Checks, "gpu", "gpu check should be enabled")
 
 		v.T().Logf("gpu check status: %+v", status.RunnerStats.Checks["gpu"])
 
 		gpuCheckStatus := status.RunnerStats.Checks["gpu"]
-		assert.Equal(c, gpuCheckStatus.LastError, "")
+		require.Equal(c, gpuCheckStatus.LastError, "")
 	}, 2*time.Minute, 10*time.Second)
 }
 


### PR DESCRIPTION
### What does this PR do?

Makes the GPU Kubernetes E2E collector status check retry transient agent status failures instead of failing the test immediately.

The `executeCommandWithError` function was changed to return the error and not use `require.NoError` if the agent failed to connect.  

### Motivation

`TestGPUCheckIsEnabled` was flaking when `agent status collector --json` failed transiently during an `EventuallyWithT` retry, which prevented the assertion loop from continuing.

### Describe how you validated your changes

CI passing

### Additional Notes