### PR TITLE
[auto-jira][AGENTCFG-70] display uptime in days when >= 24h

### DIFF
--- a/comp/core/status/render_helpers.go
+++ b/comp/core/status/render_helpers.go
@@ -256,7 +256,12 @@ func mkHumanDuration(i interface{}, unit string) string {
 		duration = time.Duration(int64(f)) * time.Second
 	}
 
-	return duration.String()
+	if duration < 24*time.Hour {
+		return duration.String()
+	}
+	days := int(duration.Hours()) / 24
+	remaining := duration - time.Duration(days)*24*time.Hour
+	return fmt.Sprintf("%dd%s", days, remaining)
 }
 
 func stringLength(s string) int {

--- a/comp/core/status/render_helpers_test.go
+++ b/comp/core/status/render_helpers_test.go
@@ -30,6 +30,27 @@ func TestMkHuman(t *testing.T) {
 	assert.Equal(t, "1.5", mkHuman(float32(1.5)))
 }
 
+func TestMkHumanDuration(t *testing.T) {
+	cases := []struct {
+		value    interface{}
+		unit     string
+		expected string
+	}{
+		{30, "s", "30s"},
+		{90, "s", "1m30s"},
+		{3600, "s", "1h0m0s"},
+		{86399, "s", "23h59m59s"},
+		{86400, "s", "1d0s"},
+		{86401, "s", "1d1s"},
+		{199199, "s", "2d7h19m59s"},
+		{1997699, "s", "23d2h54m59s"},
+	}
+
+	for _, tc := range cases {
+		assert.Equal(t, tc.expected, mkHumanDuration(tc.value, tc.unit))
+	}
+}
+
 func TestParseUnixTime(t *testing.T) {
 	cases := []struct {
 		value          any

--- a/releasenotes/notes/[agent]-humanize-duration-days-5d033c55fe812cdc.yaml
+++ b/releasenotes/notes/[agent]-humanize-duration-days-5d033c55fe812cdc.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    The ``agent status`` output now displays uptime values greater than 24 hours in a
+    days-based format (e.g., ``23d2h54m59s``) instead of the raw hour count (e.g., ``554h54m59s``).


### PR DESCRIPTION
### What does this PR do?

Updates `mkHumanDuration` in `comp/core/status/render_helpers.go` to format durations >= 24 hours using a days-based representation.

Before: `554h54m59s`
After: `23d2h54m59s`

### Motivation

Fixes https://datadoghq.atlassian.net/browse/AGENTCFG-70

The `datadog-agent status` output uses `mkHumanDuration` to display uptime. For long-running agents, Go's default `Duration.String()` produces output like `554h54m59s`, which is hard to read. This change adds a days component when the duration is >= 24 hours.

### Describe how you validated your changes

Added unit tests covering sub-day durations, exact 24h boundary, and multi-day durations including the example from the ticket (554h54m59s → 23d2h54m59s).

### Additional Notes

_Created by [Auto-JIRA](https://github.com/DataDog/datadog-agent/blob/main/.claude/skills/auto-jira/SKILL.md)._