### PR TITLE
[AGTHEAL-135] feat(healthplatform): add AWS IMDSv2 hop limit detection and remediation

### DIFF
--- a/comp/healthplatform/BUILD.bazel
+++ b/comp/healthplatform/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//comp/healthplatform/forwarder/fx",
         "//comp/healthplatform/issues/admisconfig",
         "//comp/healthplatform/issues/admissionprobe",
+        "//comp/healthplatform/issues/awsimds",
         "//comp/healthplatform/issues/checkfailure",
         "//comp/healthplatform/issues/dockerpermissions",
         "//comp/healthplatform/issues/rofspermissions",

--- a/comp/healthplatform/bundle.go
+++ b/comp/healthplatform/bundle.go
@@ -23,6 +23,7 @@ import (
 	// must not import other impl packages.
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admisconfig"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/admissionprobe"
+	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/awsimds"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/checkfailure"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/dockerpermissions"
 	_ "github.com/DataDog/datadog-agent/comp/healthplatform/issues/rofspermissions"

--- a/comp/healthplatform/issues/awsimds/BUILD.bazel
+++ b/comp/healthplatform/issues/awsimds/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "awsimds",
+    srcs = [
+        "check.go",
+        "check_noop.go",
+        "issue.go",
+        "module.go",
+    ],
+    embedsrcs = [
+        "fix-aws-imds-hop-limit.sh",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/comp/healthplatform/issues/awsimds",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//comp/core/config",
+        "//comp/healthplatform/issues",
+        "@com_github_datadog_agent_payload_v5//healthplatform",
+        "@org_golang_google_protobuf//types/known/structpb",
+    ],
+)

--- a/comp/healthplatform/issues/awsimds/check.go
+++ b/comp/healthplatform/issues/awsimds/check.go
@@ -1,0 +1,66 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build linux
+
+package awsimds
+
+import (
+	"errors"
+	"net"
+	"os"
+	"time"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+const dialTimeout = 1 * time.Second
+
+// Check detects if the AWS IMDSv2 endpoint is unreachable from inside a container
+// due to the default hop limit of 1. The check works by attempting a TCP connection
+// to the metadata endpoint: a timeout (as opposed to "no route to host") indicates
+// that a route exists but packets are dropped by the EC2 hypervisor because the TTL
+// expires after the container-to-host hop.
+func Check() (*healthplatform.IssueReport, error) {
+	// Only relevant when running inside a container
+	if !isContainerized() {
+		return nil, nil
+	}
+
+	conn, err := net.DialTimeout("tcp", imdsAddress, dialTimeout)
+	if err == nil {
+		// Connection succeeded - IMDS is reachable, no hop limit issue
+		conn.Close()
+		return nil, nil
+	}
+
+	// A timeout indicates the address is routable (i.e. we are on AWS) but packets
+	// are being dropped before reaching the endpoint - the classic hop limit symptom.
+	// Other errors (EHOSTUNREACH, ENETUNREACH, ECONNREFUSED) mean IMDS is simply not
+	// present on this host, so we do not report an issue.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &healthplatform.IssueReport{
+			IssueId: IssueID,
+			Context: map[string]string{
+				"imds_address": imdsAddress,
+			},
+			Tags: []string{"aws", "imds", "hop-limit", "container"},
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// isContainerized checks if the agent is running inside a container
+func isContainerized() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/run/.containerenv"); err == nil {
+		return true
+	}
+	return false
+}

--- a/comp/healthplatform/issues/awsimds/check_noop.go
+++ b/comp/healthplatform/issues/awsimds/check_noop.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+//go:build !linux
+
+package awsimds
+
+import (
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+)
+
+// Check is a noop on non-Linux platforms
+func Check() (*healthplatform.IssueReport, error) {
+	return nil, nil
+}

--- a/comp/healthplatform/issues/awsimds/fix-aws-imds-hop-limit.sh
+++ b/comp/healthplatform/issues/awsimds/fix-aws-imds-hop-limit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Fix AWS IMDSv2 hop limit for containerized Datadog Agent
+# Run this script on the EC2 host (not inside the container).
+# Increases the IMDSv2 hop limit from 1 to 2 so that containers can reach
+# the instance metadata service at 169.254.169.254.
+
+set -e
+
+echo "Fetching EC2 instance ID..."
+INSTANCE_ID=$(curl -s --max-time 5 http://169.254.169.254/latest/meta-data/instance-id 2>/dev/null || true)
+
+if [ -z "$INSTANCE_ID" ]; then
+    echo "ERROR: Could not fetch EC2 instance ID. Ensure this script is run on the EC2 host, not inside a container."
+    exit 1
+fi
+
+echo "Instance ID: $INSTANCE_ID"
+echo "Updating IMDSv2 hop limit to 2..."
+aws ec2 modify-instance-metadata-options \
+    --instance-id "$INSTANCE_ID" \
+    --http-put-response-hop-limit 2 \
+    --http-endpoint enabled
+
+echo "Done! IMDSv2 hop limit set to 2."
+echo "Restart the Datadog Agent container to pick up the correct EC2 hostname."

--- a/comp/healthplatform/issues/awsimds/issue.go
+++ b/comp/healthplatform/issues/awsimds/issue.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+package awsimds
+
+import (
+	_ "embed"
+	"fmt"
+
+	"github.com/DataDog/agent-payload/v5/healthplatform"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+//go:embed fix-aws-imds-hop-limit.sh
+var fixScript string
+
+const imdsAddress = "169.254.169.254:80"
+
+// AWSIMDSIssue provides the complete issue template for AWS IMDS hop limit problems
+type AWSIMDSIssue struct{}
+
+// NewAWSIMDSIssue creates a new AWS IMDS issue template
+func NewAWSIMDSIssue() *AWSIMDSIssue {
+	return &AWSIMDSIssue{}
+}
+
+// BuildIssue creates a complete issue with metadata and remediation
+func (t *AWSIMDSIssue) BuildIssue(context map[string]string) (*healthplatform.Issue, error) {
+	imdsAddr := context["imds_address"]
+	if imdsAddr == "" {
+		imdsAddr = imdsAddress
+	}
+
+	issueExtra, err := structpb.NewStruct(map[string]any{
+		"imds_address": imdsAddr,
+		"impact":       "The agent cannot determine the EC2 instance hostname, which prevents proper host-level data correlation in Datadog",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create issue extra: %v", err)
+	}
+
+	return &healthplatform.Issue{
+		Id:          IssueID,
+		IssueName:   "aws_imds_hop_limit",
+		Title:       "AWS IMDSv2 Unreachable from Container (Hop Limit Too Low)",
+		Description: "The Datadog Agent is running inside a container on AWS EC2 but cannot reach the instance metadata service (IMDS) at 169.254.169.254. This is typically caused by the default IMDSv2 hop limit of 1: the metadata request needs to traverse an extra network hop from the container to the host, but the packet's TTL expires before it arrives. As a result, the agent cannot resolve the EC2 hostname, which breaks host-level data correlation in Datadog.",
+		Category:    "connectivity",
+		Location:    "core-agent",
+		Severity:    "high",
+		DetectedAt:  "", // Filled by health platform
+		Source:      "core",
+		Extra:       issueExtra,
+		Remediation: t.buildRemediation(),
+		Tags:        []string{"aws", "ec2", "imds", "hop-limit", "container", "hostname"},
+	}, nil
+}
+
+func (t *AWSIMDSIssue) buildRemediation() *healthplatform.Remediation {
+	return &healthplatform.Remediation{
+		Summary: "Increase the EC2 IMDSv2 hop limit to 2, or configure the hostname explicitly in the agent",
+		Steps: []*healthplatform.RemediationStep{
+			{Order: 1, Text: "RECOMMENDED: Increase the IMDSv2 hop limit to 2 on the EC2 instance (run on the host, not inside the container):"},
+			{Order: 2, Text: "INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"},
+			{Order: 3, Text: "aws ec2 modify-instance-metadata-options --instance-id \"$INSTANCE_ID\" --http-put-response-hop-limit 2 --http-endpoint enabled"},
+			{Order: 4, Text: "Restart the Datadog Agent container to pick up the correct EC2 hostname."},
+			{Order: 5, Text: "ALTERNATIVE: Set DD_HOSTNAME explicitly in the container to bypass IMDS entirely:"},
+			{Order: 6, Text: "For Kubernetes, inject the node name via the Downward API:\n  env:\n    - name: DD_HOSTNAME\n      valueFrom:\n        fieldRef:\n          fieldPath: spec.nodeName"},
+			{Order: 7, Text: "ALTERNATIVE: For Agent 7.42+, trust the in-container UTS hostname by setting DD_HOSTNAME_TRUST_UTS_NAMESPACE=true (only use if the container hostname is meaningful)."},
+		},
+		Script: &healthplatform.Script{
+			Language:        "bash",
+			LanguageVersion: "4.0+",
+			Filename:        "fix-aws-imds-hop-limit.sh",
+			RequiresRoot:    false,
+			Content:         fixScript,
+		},
+	}
+}

--- a/comp/healthplatform/issues/awsimds/module.go
+++ b/comp/healthplatform/issues/awsimds/module.go
@@ -58,5 +58,6 @@ func (m *awsIMDSModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
 		ID:      CheckID,
 		Name:    CheckName,
 		CheckFn: Check,
+		Once:    true,
 	}
 }

--- a/comp/healthplatform/issues/awsimds/module.go
+++ b/comp/healthplatform/issues/awsimds/module.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2025-present Datadog, Inc.
+
+// Package awsimds provides a complete issue module for AWS IMDSv2 hop limit problems.
+// It detects when the agent running in a container cannot reach the AWS instance
+// metadata service due to the default IMDSv2 hop limit of 1, which prevents
+// container traffic from traversing the extra network hop to the metadata endpoint.
+package awsimds
+
+import (
+	"github.com/DataDog/datadog-agent/comp/core/config"
+	"github.com/DataDog/datadog-agent/comp/healthplatform/issues"
+)
+
+func init() {
+	issues.RegisterModuleFactory(NewModule)
+}
+
+const (
+	// IssueID is the unique identifier for AWS IMDS hop limit issues
+	IssueID = "aws-imds-hop-limit"
+
+	// CheckID is the unique identifier for the built-in health check
+	CheckID = "aws-imds-connectivity"
+
+	// CheckName is the human-readable name for the health check
+	CheckName = "AWS IMDS Connectivity"
+)
+
+// awsIMDSModule implements issues.Module
+type awsIMDSModule struct {
+	template *AWSIMDSIssue
+}
+
+// NewModule creates a new AWS IMDS hop limit issue module
+func NewModule(_ config.Component) issues.Module {
+	return &awsIMDSModule{
+		template: NewAWSIMDSIssue(),
+	}
+}
+
+// IssueID returns the unique identifier for this issue type
+func (m *awsIMDSModule) IssueID() string {
+	return IssueID
+}
+
+// IssueTemplate returns the template for building complete issues
+func (m *awsIMDSModule) IssueTemplate() issues.IssueTemplate {
+	return m.template
+}
+
+// BuiltInHealthCheck returns the built-in health check configuration
+// Interval is 0 to use the default (15 minutes)
+func (m *awsIMDSModule) BuiltInHealthCheck() *issues.BuiltInHealthCheck {
+	return &issues.BuiltInHealthCheck{
+		ID:      CheckID,
+		Name:    CheckName,
+		CheckFn: Check,
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Adds a new health platform issue module (`awsimds`) that detects when the Datadog Agent is running inside a container on AWS EC2 and cannot reach the instance metadata service (IMDS) at `169.254.169.254` due to the default IMDSv2 hop limit of 1.

The check runs **once at agent startup**. It fires only when:
1. Running inside a container (detected via `/.dockerenv` or `/run/.containerenv`)
2. A TCP dial to `169.254.169.254:80` returns a **timeout**

A timeout (vs `EHOSTUNREACH` / `ENETUNREACH`) indicates the address is routable but packets are dropped by the EC2 hypervisor due to TTL expiry — the classic hop limit symptom. Non-AWS hosts return an immediate "no route to host" error, so there are no false positives on non-AWS deployments.

**New files:**
- `comp/healthplatform/issues/awsimds/module.go` — registers the module via `init()`, `Once: true`
- `comp/healthplatform/issues/awsimds/check.go` (Linux) — TCP probe to detect the hop limit issue
- `comp/healthplatform/issues/awsimds/check_noop.go` (non-Linux) — no-op stub
- `comp/healthplatform/issues/awsimds/issue.go` — issue template with three remediation alternatives
- `comp/healthplatform/issues/awsimds/fix-aws-imds-hop-limit.sh` — embedded fix script

### Motivation

When the Datadog Agent runs inside a container on AWS EC2, the default IMDSv2 hop limit of 1 prevents the container from reaching the metadata service. This means the agent cannot resolve the EC2 hostname, breaking host-level data correlation in Datadog. See: https://docs.datadoghq.com/agent/troubleshooting/hostname_containers/?tab=datadogoperator

### Describe how you validated your changes

- `go build ./comp/healthplatform/...` passes cleanly
- `go test ./comp/healthplatform/...` passes (all existing tests still green)
- `shellcheck` passes on the embedded fix script

### QA Plan

#### Prerequisites

- An EC2 instance with the IMDSv2 hop limit set to **1** (the AWS default):
  ```bash
  INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
  aws ec2 modify-instance-metadata-options \
    --instance-id "$INSTANCE_ID" \
    --http-put-response-hop-limit 1 \
    --http-endpoint enabled
  ```
- The Datadog Agent running **inside a container** on that instance (Docker or Kubernetes pod without host networking).

#### Verify the issue is detected

1. Start the agent in a container on the EC2 instance with hop limit = 1.
2. At startup, the IMDS check fires once. Confirm the issue is reported to the health platform (check agent logs or the health platform store).
3. The reported issue should have:
   - `issue_id: "aws-imds-hop-limit"`
   - `severity: "high"`
   - `category: "connectivity"`
   - `tags: ["aws", "imds", "hop-limit", "container"]`

#### Verify the issue is not reported in the happy path

Each of the following should produce **no** reported issue:

| Scenario | Expected |
|---|---|
| Hop limit set to **2** on the EC2 instance | No issue |
| Agent running with **host networking** (not inside a container) | No issue |
| Agent running on a **non-AWS** host (no route to 169.254.169.254) | No issue — `EHOSTUNREACH` is not a timeout |
| Agent running on a **non-Linux** platform | No issue — `check_noop.go` returns nil |

To set the hop limit to 2 for the happy-path test:
```bash
aws ec2 modify-instance-metadata-options \
  --instance-id "$INSTANCE_ID" \
  --http-put-response-hop-limit 2 \
  --http-endpoint enabled
```

#### Verify remediation content

Confirm the issue template surfaces three remediation options:
1. Increase the hop limit via AWS CLI (with the embedded `fix-aws-imds-hop-limit.sh` script).
2. Set `DD_HOSTNAME` explicitly via the Kubernetes Downward API (`spec.nodeName`).
3. Enable `DD_HOSTNAME_TRUST_UTS_NAMESPACE=true` (Agent 7.42+).

### Additional Notes

**Why TCP dial instead of HTTP?** A raw TCP connection to port 80 is sufficient to detect the hop limit issue without needing IMDSv2 token exchange. The timeout is deterministic: the EC2 hypervisor drops packets whose TTL expires at the host-to-IMDS hop, so the dial always times out (1 s) rather than failing fast.

**Remediation options surfaced to the user:**
1. Increase the EC2 IMDSv2 hop limit to 2 via AWS CLI (+ embedded `fix-aws-imds-hop-limit.sh` script)
2. Set `DD_HOSTNAME` explicitly via the Kubernetes Downward API (`spec.nodeName`)
3. Enable `DD_HOSTNAME_TRUST_UTS_NAMESPACE=true` (Agent 7.42+)