### PR TITLE
[snmp] Fix stale autodiscovery status when device deduplication is enabled

### DIFF
--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -547,19 +547,27 @@ func (l *SNMPListener) registerService(pendingDevice devicededuper.PendingDevice
 		AuthIndex: pendingDevice.AuthIndex,
 		Failures:  pendingDevice.Failures,
 	}
+	if pendingDevice.WriteCache {
+		l.writeCache(svc.subnet)
+	}
 	ipsFound := l.getDevicesFoundInSubnetLocked(*svc.subnet)
 	network := svc.subnet.config.Network
 	index := svc.subnet.index
 	l.Unlock()
 
-	autodiscoveryStatusBySubnetVar.Set(
-		GetSubnetVarKey(network, index),
-		&AutodiscoveryStatus{DevicesFoundList: ipsFound},
-	)
-
-	if pendingDevice.WriteCache {
-		l.writeCache(svc.subnet)
+	// Refresh DevicesFoundList in the expvar while preserving the scan progress
+	// fields (CurrentDevice, DevicesScannedCount) written by checkDevice().
+	subnetKey := GetSubnetVarKey(network, index)
+	var existing AutodiscoveryStatus
+	if v := autodiscoveryStatusBySubnetVar.Get(subnetKey); v != nil {
+		json.Unmarshal([]byte(v.String()), &existing) //nolint:errcheck
 	}
+	autodiscoveryStatusBySubnetVar.Set(subnetKey, &AutodiscoveryStatus{
+		DevicesFoundList:    ipsFound,
+		CurrentDevice:       existing.CurrentDevice,
+		DevicesScannedCount: existing.DevicesScannedCount,
+	})
+
 	l.newService <- svc
 }
 

--- a/comp/core/autodiscovery/listeners/snmp.go
+++ b/comp/core/autodiscovery/listeners/snmp.go
@@ -312,10 +312,9 @@ func (l *SNMPListener) checkDeviceInfo(authentication snmp.Authentication, port 
 	return devicededuper.DeviceInfo{Name: sysName, Description: sysDescr, BootTimeMs: bootTimestamp, SysObjectID: sysObjectID}
 }
 
-func (l *SNMPListener) getDevicesFoundInSubnet(subnet snmpSubnet) []string {
-	l.Lock()
-	defer l.Unlock()
-
+// getDevicesFoundInSubnetLocked returns IPs of non-pending services for a subnet.
+// Caller must hold l.Lock().
+func (l *SNMPListener) getDevicesFoundInSubnetLocked(subnet snmpSubnet) []string {
 	ipsFound := []string{}
 	for _, svc := range l.services {
 		if svc.subnet.cacheKey == subnet.cacheKey && !svc.pending {
@@ -323,6 +322,12 @@ func (l *SNMPListener) getDevicesFoundInSubnet(subnet snmpSubnet) []string {
 		}
 	}
 	return ipsFound
+}
+
+func (l *SNMPListener) getDevicesFoundInSubnet(subnet snmpSubnet) []string {
+	l.Lock()
+	defer l.Unlock()
+	return l.getDevicesFoundInSubnetLocked(subnet)
 }
 
 func (l *SNMPListener) initializeSubnets() []snmpSubnet {
@@ -463,15 +468,16 @@ func (l *SNMPListener) createService(
 	writeCache bool,
 ) {
 	l.Lock()
-	defer l.Unlock()
 
 	if _, present := l.services[entityID]; present {
+		l.Unlock()
 		return
 	}
 
 	config := subnet.config
 	if authIndex < 0 || authIndex >= len(config.Authentications) {
 		log.Errorf("Invalid authentication index %d for device %s (max: %d)", authIndex, deviceIP, len(config.Authentications)-1)
+		l.Unlock()
 		return
 	}
 	authentication := config.Authentications[authIndex]
@@ -507,11 +513,14 @@ func (l *SNMPListener) createService(
 	}
 
 	if deviceInfo == (devicededuper.DeviceInfo{}) {
+		// Release lock before calling registerService, which acquires it internally.
+		l.Unlock()
 		l.registerService(pendingDevice)
 		return
 	}
 
 	l.deviceDeduper.AddPendingDevice(pendingDevice)
+	l.Unlock()
 }
 
 func (l *SNMPListener) registerDedupedDevices() {
@@ -526,17 +535,28 @@ func (l *SNMPListener) registerDedupedDevices() {
 func (l *SNMPListener) registerService(pendingDevice devicededuper.PendingDevice) {
 	entityID := pendingDevice.Config.Digest(pendingDevice.IP)
 
+	l.Lock()
 	svc, ok := l.services[entityID]
 	if !ok {
+		l.Unlock()
 		return
 	}
 	svc.pending = false
-
 	svc.subnet.devices[svc.entityID] = deviceCache{
 		IP:        net.ParseIP(svc.deviceIP),
 		AuthIndex: pendingDevice.AuthIndex,
 		Failures:  pendingDevice.Failures,
 	}
+	ipsFound := l.getDevicesFoundInSubnetLocked(*svc.subnet)
+	network := svc.subnet.config.Network
+	index := svc.subnet.index
+	l.Unlock()
+
+	autodiscoveryStatusBySubnetVar.Set(
+		GetSubnetVarKey(network, index),
+		&AutodiscoveryStatus{DevicesFoundList: ipsFound},
+	)
+
 	if pendingDevice.WriteCache {
 		l.writeCache(svc.subnet)
 	}

--- a/comp/core/autodiscovery/listeners/snmp_test.go
+++ b/comp/core/autodiscovery/listeners/snmp_test.go
@@ -8,16 +8,19 @@ package listeners
 import (
 	"bytes"
 	"encoding/json"
+	"expvar"
 	"fmt"
 	"net"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configmock "github.com/DataDog/datadog-agent/pkg/config/mock"
 	"github.com/DataDog/datadog-agent/pkg/persistentcache"
 	"github.com/DataDog/datadog-agent/pkg/snmp"
+	"github.com/DataDog/datadog-agent/pkg/snmp/devicededuper"
 	"github.com/DataDog/datadog-agent/pkg/snmp/snmpintegration"
 )
 
@@ -677,4 +680,108 @@ func TestMigrateCache(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDedupDeviceRegistrationUpdatesExpvar verifies that when device deduplication is enabled,
+// the autodiscovery status expvar for a subnet is updated once the device is registered through
+// the deduplication path (i.e. after a higher-IP subnet is processed and registerDedupedDevices
+// releases the pending lower-IP device).
+//
+// Without the fix, registerService() did not update the expvar, so the status remained
+// "No IPs found" for the entire scan interval even though the device was actively being collected.
+func TestDedupDeviceRegistrationUpdatesExpvar(t *testing.T) {
+	testDir := t.TempDir()
+	mockConfig := configmock.New(t)
+	mockConfig.SetWithoutSource("run_path", testDir)
+
+	// Two /32 subnets. The deduper releases a device only once all numerically lower
+	// configured IPs have been processed, so 10.0.0.1 will be held as pending until
+	// 10.0.0.5 is marked as processed.
+	configs := []interface{}{
+		map[string]interface{}{
+			"network":   "10.0.0.1/32",
+			"community": "public",
+		},
+		map[string]interface{}{
+			"network":   "10.0.0.5/32",
+			"community": "public",
+		},
+	}
+	mockConfig.SetWithoutSource("network_devices.autodiscovery.configs", configs)
+	mockConfig.SetWithoutSource("network_devices.autodiscovery.use_deduplication", true)
+
+	listener, err := NewSNMPListener(ServiceListernerDeps{})
+	require.NoError(t, err)
+
+	l, ok := listener.(*SNMPListener)
+	require.True(t, ok)
+
+	newSvc := make(chan Service, 10)
+	delSvc := make(chan Service, 10)
+	l.newService = newSvc
+	l.delService = delSvc
+
+	subnets := l.initializeSubnets()
+	require.Len(t, subnets, 2)
+
+	subnet1 := &subnets[0] // 10.0.0.1/32
+	subnet2 := &subnets[1] // 10.0.0.5/32
+
+	subnet1Key := GetSubnetVarKey(subnet1.config.Network, subnet1.index)
+	subnet2Key := GetSubnetVarKey(subnet2.config.Network, subnet2.index)
+
+	// Reset expvars to empty, as checkDevices() does at the start of each scan cycle.
+	autodiscoveryStatusBySubnetVar.Set(subnet1Key, &expvar.String{})
+	autodiscoveryStatusBySubnetVar.Set(subnet2Key, &expvar.String{})
+
+	deviceInfo := devicededuper.DeviceInfo{
+		Name:        "router1",
+		Description: "Cisco IOS",
+		SysObjectID: "1.3.6.1.4.1.9",
+		BootTimeMs:  5000,
+	}
+
+	// Simulate checkDevice() for 10.0.0.1: mark as processed, then create the service.
+	// createService() with non-empty DeviceInfo takes the dedup path (AddPendingDevice),
+	// so the service is created with pending=true.
+	entityID1 := subnet1.config.Digest("10.0.0.1")
+	l.deviceDeduper.MarkIPAsProcessed("10.0.0.1")
+	l.registerDedupedDevices() // nothing to release yet — device not in pending list
+	l.createService(entityID1, subnet1, "10.0.0.1", deviceInfo, 0, 0, false)
+
+	// Simulate the expvar update that checkDevice() would write after creating the service:
+	// the device is still pending, so DevicesFoundList is empty.
+	autodiscoveryStatusBySubnetVar.Set(subnet1Key, &AutodiscoveryStatus{
+		DevicesFoundList:    l.getDevicesFoundInSubnet(*subnet1),
+		CurrentDevice:       "10.0.0.1",
+		DevicesScannedCount: 1,
+	})
+
+	// Confirm the expvar correctly shows no IPs at this point (device is pending).
+	v := autodiscoveryStatusBySubnetVar.Get(subnet1Key)
+	require.NotNil(t, v)
+	var statusBefore AutodiscoveryStatus
+	require.NoError(t, json.Unmarshal([]byte(v.String()), &statusBefore))
+	assert.Empty(t, statusBefore.DevicesFoundList, "device should be pending before dedup releases it")
+
+	// Simulate checkDevice() for 10.0.0.5: mark as processed, then call registerDedupedDevices.
+	// Now that all configured IPs ≤ 10.0.0.1 have been processed (counter=0),
+	// the deduper releases 10.0.0.1 and registerService() is called for it.
+	l.deviceDeduper.MarkIPAsProcessed("10.0.0.5")
+	l.registerDedupedDevices()
+
+	// The fix: registerService() must now update the expvar for subnet1 to reflect the
+	// registered device. Without the fix the expvar would remain empty until the next scan cycle.
+	v = autodiscoveryStatusBySubnetVar.Get(subnet1Key)
+	require.NotNil(t, v)
+	var statusAfter AutodiscoveryStatus
+	require.NoError(t, json.Unmarshal([]byte(v.String()), &statusAfter))
+	assert.Equal(t, []string{"10.0.0.1"}, statusAfter.DevicesFoundList,
+		"expvar for subnet 10.0.0.1/32 must show the registered device IP after dedup registration")
+
+	// The service must have been forwarded to the autodiscovery pipeline.
+	require.Len(t, newSvc, 1)
+	registeredSvc := (<-newSvc).(*SNMPService)
+	assert.Equal(t, "10.0.0.1", registeredSvc.deviceIP)
+	assert.False(t, registeredSvc.pending)
 }


### PR DESCRIPTION
## What does this PR do?

When `use_deduplication: true` is set in the SNMP autodiscovery config, the autodiscovery section of `agent status` incorrectly shows "No IPs found" for subnets whose devices are actively being collected. This is a display-only bug — data collection is unaffected.

### Root cause

When a device is discovered through the deduplication path, it is initially created with `pending=true`. The status expvar for its subnet is written at this point, showing no devices found. Later, `registerService()` is called (triggered by a subsequent IP being processed) which sets `pending=false` — but the expvar was never refreshed. It would only update on the next full scan cycle (up to 24 hours later with a non-default `discovery_interval`).

Additionally, `registerService()` was previously called from `createService()` while holding the listener's mutex, and from `registerDedupedDevices()` without holding it — creating an unprotected write to `svc.pending`.

### Fix

- `registerService()` now acquires the mutex itself, sets `pending=false` under the lock, and immediately refreshes the status expvar for the affected subnet.
- `createService()` releases the lock before calling `registerService()` to avoid a deadlock (since `registerService()` now locks independently).
- `getDevicesFoundInSubnet()` is split into a locked and an unlocked variant so the inner logic can be reused safely from within already-locked sections.

## Test

`TestDedupDeviceRegistrationUpdatesExpvar` simulates the exact scenario: two `/32` subnets with dedup enabled, the lower-IP device held pending, then released when the higher-IP subnet is processed. Asserts the expvar is updated immediately after registration. Confirmed to fail on the old code and pass on the new code.

## Scope

Only affects users who have explicitly set `use_deduplication: true` (non-default). No impact on data collection.

Closes AGENT-15863