### PR TITLE
Remove unneeded strict dependency on go mod tidy check

### DIFF
--- a/.gitlab/build/binary_build/cluster_agent.yml
+++ b/.gitlab/build/binary_build/cluster_agent.yml
@@ -4,7 +4,7 @@
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:

--- a/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/build/binary_build/cluster_agent_cloudfoundry.yml
@@ -6,7 +6,7 @@ cluster_agent_cloudfoundry-build_amd64:
   stage: binary_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/build/binary_build/cws_instrumentation.yml
+++ b/.gitlab/build/binary_build/cws_instrumentation.yml
@@ -1,7 +1,7 @@
 ---
 .cws_instrumentation-build_common:
   stage: binary_build
-  needs: ["go_mod_tidy_check"]
+  needs: []
   script:
     - dda inv -- check-go-version
     - dda inv -- -e cws-instrumentation.build --arch-suffix
@@ -14,7 +14,7 @@
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: amd64
   before_script:
@@ -25,7 +25,7 @@
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: arm64
   before_script:
@@ -41,7 +41,7 @@ cws_instrumentation-build_arm64:
 
 .cws_instrumentation-build_injector_common:
   stage: binary_build
-  needs: ["go_mod_tidy_check"]
+  needs: []
   script:
     - dda inv -- check-go-version
     - dda inv -- -e cws-instrumentation.build --arch-suffix --injector-only

--- a/.gitlab/build/package_build/heroku.yml
+++ b/.gitlab/build/package_build/heroku.yml
@@ -6,7 +6,7 @@
     - when: on_success
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.cache_omnibus_ruby_deps, setup]

--- a/.gitlab/build/package_build/installer.yml
+++ b/.gitlab/build/package_build/installer.yml
@@ -43,7 +43,6 @@ datadog-agent-oci-x64-a7:
   tags: ["arch:amd64", "specific:true"]
   needs:
     [
-      "go_mod_tidy_check",
       "build_system-probe-x64",
       "go_deps",
       "generate_minimized_btfs_x64",
@@ -63,7 +62,6 @@ datadog-agent-oci-arm64-a7:
   tags: ["arch:arm64", "specific:true"]
   needs:
     [
-      "go_mod_tidy_check",
       "build_system-probe-arm64",
       "go_deps",
       "generate_minimized_btfs_arm64",
@@ -85,7 +83,6 @@ installer-install-scripts:
   tags: ["arch:amd64", "specific:true"]
   needs:
     [
-      "go_mod_tidy_check",
       "go_deps",
       "installer-amd64-oci",
       "installer-arm64-oci",
@@ -148,7 +145,7 @@ installer-amd64:
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:amd64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   variables:
     PACKAGE_ARCH: amd64
     DESTINATION_FILE: "datadog-installer_7-amd64.tar.xz"
@@ -163,7 +160,7 @@ installer-arm64:
   stage: package_build
   image: registry.ddbuild.io/ci/datadog-agent-buildimages/linux$CI_IMAGE_LINUX_SUFFIX:$CI_IMAGE_LINUX
   tags: ["arch:arm64", "specific:true"]
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   variables:
     PACKAGE_ARCH: arm64
     DESTINATION_FILE: "datadog-installer_7-arm64.tar.xz"

--- a/.gitlab/build/package_build/linux.yml
+++ b/.gitlab/build/package_build/linux.yml
@@ -104,7 +104,7 @@ datadog-agent-7-arm64-fips:
 
 .iot-agent-common:
   extends: .agent_build_common
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   script:
     - !reference [.retrieve_linux_go_deps]
     - !reference [.cache_omnibus_ruby_deps, setup]
@@ -141,7 +141,7 @@ iot-agent-armhf:
 
 .dogstatsd_build_common:
   extends: .bazel:defs:cache:omnibus-transition
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success
@@ -177,7 +177,7 @@ dogstatsd-arm64:
 
 .otel_build_common:
   extends: .bazel:defs:cache:omnibus-transition
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   rules:
     - !reference [.except_mergequeue]
     - when: on_success

--- a/.gitlab/windows/build/package_build/windows.yml
+++ b/.gitlab/windows/build/package_build/windows.yml
@@ -87,7 +87,7 @@ windows_msi_and_bosh_zip_x64-a7-fips:
     - !reference [.except_mergequeue]
     - when: on_success
   extends: .windows_docker_default
-  needs: ["go_mod_tidy_check", "go_deps"]
+  needs: ["go_deps"]
   variables:
     ARCH: "x64"
   script:


### PR DESCRIPTION
### What does this PR do?

`go_mod_tidy_check` is not producing any artifact, so it is not required for any job that needs it to succeed.
Removing that dependency allows us to cut between few minutes in the critical path for some pipelines

### Motivation

### Describe how you validated your changes

### Additional Notes
