### PR TITLE
Fix v0.5 invalid dictionary acceptance

### DIFF
--- a/pkg/proto/pbgo/trace/idx/span_v05.go
+++ b/pkg/proto/pbgo/trace/idx/span_v05.go
@@ -8,6 +8,7 @@ package idx
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/tinylib/msgp/msgp"
 )
@@ -64,6 +65,7 @@ func (tp *InternalTracerPayload) UnmarshalMsgDictionary(bts []byte) error {
 		}
 		dict[i] = str
 	}
+	dictSize := sz
 	stringTable, newZeroRef := buildStringTable(dict)
 	tp.Strings = stringTable
 	// read num chunks
@@ -95,7 +97,7 @@ func (tp *InternalTracerPayload) UnmarshalMsgDictionary(bts []byte) error {
 			if tp.Chunks[i].Spans[j] == nil {
 				tp.Chunks[i].Spans[j] = NewInternalSpan(stringTable, &Span{})
 			}
-			if bts, err = tp.Chunks[i].Spans[j].UnmarshalMsgDictionaryConverted(bts, convertedFields, newZeroRef); err != nil {
+			if bts, err = tp.Chunks[i].Spans[j].UnmarshalMsgDictionaryConverted(bts, convertedFields, dictSize, newZeroRef); err != nil {
 				return err
 			}
 		}
@@ -109,12 +111,15 @@ func (tp *InternalTracerPayload) UnmarshalMsgDictionary(bts []byte) error {
 // has.
 const spanPropertyCount = 12
 
-func readV05StringRef(newZeroRef uint32, bts []byte) (uint32, []byte, error) {
+func readV05StringRef(dictSize uint32, newZeroRef uint32, bts []byte) (uint32, []byte, error) {
 	var parsedRef uint32
 	var err error
 	parsedRef, bts, err = msgp.ReadUint32Bytes(bts)
 	if err != nil {
 		return 0, bts, err
+	}
+	if parsedRef >= dictSize {
+		return 0, bts, fmt.Errorf("dictionary index %d out of range", parsedRef)
 	}
 	if parsedRef == 0 && newZeroRef != 0 {
 		// This string was moved from index 0 to index newZeroRef, so we return the new index
@@ -127,7 +132,7 @@ func readV05StringRef(newZeroRef uint32, bts []byte) (uint32, []byte, error) {
 // in pkg/trace/api/version.go
 // The provided InternalSpan must have a pre-populated Strings field
 // newZeroRef is the new location for string ref `0` (0 if unchanged) see buildStringTable for more details
-func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFields *SpanConvertedFields, newZeroRef uint32) ([]byte, error) {
+func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFields *SpanConvertedFields, dictSize uint32, newZeroRef uint32) ([]byte, error) {
 	var (
 		sz  uint32
 		err error
@@ -140,17 +145,17 @@ func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFiel
 		return bts, errors.New("encoded span needs exactly 12 elements in array")
 	}
 	// Service (0)
-	s.span.ServiceRef, bts, err = readV05StringRef(newZeroRef, bts)
+	s.span.ServiceRef, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 	if err != nil {
 		return bts, err
 	}
 	// Name (1)
-	s.span.NameRef, bts, err = readV05StringRef(newZeroRef, bts)
+	s.span.NameRef, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 	if err != nil {
 		return bts, err
 	}
 	// Resource (2)
-	s.span.ResourceRef, bts, err = readV05StringRef(newZeroRef, bts)
+	s.span.ResourceRef, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 	if err != nil {
 		return bts, err
 	}
@@ -201,11 +206,11 @@ func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFiel
 	for sz > 0 {
 		sz--
 		var key, val uint32
-		key, bts, err = readV05StringRef(newZeroRef, bts)
+		key, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 		if err != nil {
 			return bts, err
 		}
-		val, bts, err = readV05StringRef(newZeroRef, bts)
+		val, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 		if err != nil {
 			return bts, err
 		}
@@ -230,7 +235,7 @@ func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFiel
 			key uint32
 			val float64
 		)
-		key, bts, err = readV05StringRef(newZeroRef, bts)
+		key, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 		if err != nil {
 			return bts, err
 		}
@@ -246,7 +251,7 @@ func (s *InternalSpan) UnmarshalMsgDictionaryConverted(bts []byte, convertedFiel
 		}
 	}
 	// Type (11)
-	s.span.TypeRef, bts, err = readV05StringRef(newZeroRef, bts)
+	s.span.TypeRef, bts, err = readV05StringRef(dictSize, newZeroRef, bts)
 	if err != nil {
 		return bts, err
 	}

--- a/pkg/proto/pbgo/trace/idx/span_v05_test.go
+++ b/pkg/proto/pbgo/trace/idx/span_v05_test.go
@@ -231,3 +231,9 @@ func TestUnmarshalMsgDictionaryLimitsSize(t *testing.T) {
 		})
 	}
 }
+
+func TestUnmarshalMsgDictionaryRejectsInvalidStringRef(t *testing.T) {
+	var tp InternalTracerPayload
+	err := tp.UnmarshalMsgDictionary([]byte("\x91\x90\x91\x91\x9c\x0000000000\x80\x800"))
+	assert.EqualError(t, err, "dictionary index 0 out of range")
+}

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -805,6 +805,30 @@ func TestReceiverUnexpectedEOF(t *testing.T) {
 	assert.Contains(respBody, "too few bytes left to read")
 }
 
+func TestHandleTracesV05RejectsInvalidDictionaryIndex(t *testing.T) {
+	assert := assert.New(t)
+	conf := newTestReceiverConfig()
+	r := newTestReceiverFromConfig(conf)
+	server := httptest.NewServer(r.handleWithVersion(v05, r.handleTraces))
+	defer server.Close()
+
+	data := []byte("\x91\x90\x91\x91\x9c\x0000000000\x80\x800")
+	var decoded pb.Traces
+	decodeErr := decoded.UnmarshalMsgDictionary(data)
+	assert.ErrorContains(decodeErr, "dictionary index 0 out of range")
+
+	var client http.Client
+	req, err := http.NewRequest("POST", server.URL, bytes.NewBuffer(data))
+	assert.NoError(err)
+	req.Header.Set("Content-Type", "application/msgpack")
+	req.Header.Set(header.TraceCount, "1")
+
+	resp, err := client.Do(req)
+	assert.NoError(err)
+	resp.Body.Close()
+	assert.Equal(http.StatusBadRequest, resp.StatusCode)
+}
+
 func TestTraceCount(t *testing.T) {
 	req, err := http.NewRequest("GET", "/", nil)
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4aa386a3-0453-4b21-9c34-835297180bc9","source":"chat","resourceId":"56960c8c-27e5-4425-9208-77d023f3e091","workflowId":"9f233463-de73-4595-b91a-4cf027d8c011","codeChangeId":"9f233463-de73-4595-b91a-4cf027d8c011","sourceType":"action_platform_workflows"} -->
### What does this PR do?

Workflow Automation • [View in Workflow Automation](https://app.datadoghq.com/workflow/6c444a5c-2025-4f04-9d80-27cd665246c5)

Ensures v0.5 trace payloads with invalid dictionary indexes are rejected with HTTP 400 when `convert-traces` is enabled, while keeping decoding on the direct `InternalTracerPayload` conversion path.

### Motivation
A fuzz-discovered payload (`[]byte("\x91\x90\x91\x91\x9c\x0000000000\x80\x800")`) decoded as invalid in the legacy v0.5 decoder (`dictionary index 0 out of range`) but was accepted (HTTP 200) in the convert-traces path. We need consistent rejection of malformed payloads without adding an intermediate decode-to-pb conversion step.

### Describe how you validated your changes
- Reproducer test in API layer:
  - `TestHandleTracesV05RejectsInvalidDictionaryIndex` in `pkg/trace/api/api_test.go`
- Added direct decoder validation test:
  - `TestUnmarshalMsgDictionaryRejectsInvalidStringRef` in `pkg/proto/pbgo/trace/idx/span_v05_test.go`
- Ran targeted tests:
  - `go test ./pkg/proto/pbgo/trace/idx -run 'TestUnmarshalMsgDictionaryRejectsInvalidStringRef|TestUnmarshalMsgDictionary' -count=1`
  - `go test -tags test ./pkg/trace/api -run TestHandleTracesV05RejectsInvalidDictionaryIndex -count=1`
  - `go test -tags test ./pkg/trace/api -run '^$' -fuzz FuzzHandleTracesV05 -fuzztime=1x`
- Ran formatter tool (no additional changes needed).
- Linting tool limitation in environment:
  - `golangci-lint` binary is built with go1.24 while repository targets go1.25.7.

### Additional Notes
The final fix stays on the direct v0.5 conversion path by hardening `InternalTracerPayload.UnmarshalMsgDictionary` validation:
- v0.5 string references are now bounds-checked against the original dictionary size.
- Out-of-range refs return `dictionary index <n> out of range`, preventing malformed payloads from being accepted in the v0.5 convert-traces path.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/56960c8c-27e5-4425-9208-77d023f3e091)

Comment @datadog to request changes