### PR TITLE
[WP] Fix register ptr overridden by an Imm for raw paquets

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -167,8 +167,8 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 			*/
 
 			// check the cgroup id
-			asm.LoadImm(asm.R8, int64(filter.CGroupPathKey.Inode), asm.DWord),
-			asm.JEq.Reg(asm.R7, asm.R8, opts.onMatchLabel),
+			asm.LoadImm(asm.R4, int64(filter.CGroupPathKey.Inode), asm.DWord),
+			asm.JEq.Reg(asm.R7, asm.R4, opts.onMatchLabel),
 			asm.Mov.Imm(asm.R4, 0).WithSymbol(mismatchLabel), // nop instruction, just hold the symbol
 		)
 	} else {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -688,9 +688,13 @@ func TestRawPacketFilter(t *testing.T) {
 		},
 		{
 			BPFFilter: "tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x47455420",
+			CGroupPathKey: model.PathKey{
+				Inode: 1234,
+			},
 		},
 		{
 			BPFFilter: "icmp[icmptype] != icmp-echo and icmp[icmptype] != icmp-echoreply",
+			Pid:       123,
 		},
 		{
 			BPFFilter: "port ftp or ftp-data",


### PR DESCRIPTION
### What does this PR do?
Use another register to avoid an override.
### Motivation
R8 is supposed to be a pointer for raw paquet filter but was overridden by an Imm (the PID or the Cgroup inode), causing the next filter to be rejected by the approver.
