### PR TITLE
[workloadmeta] Allow collectors to define a custom pull interval

### DIFF
--- a/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
+++ b/comp/core/workloadmeta/collectors/internal/kubelet/kubelet.go
@@ -42,6 +42,7 @@ type collector struct {
 	catalog                    workloadmeta.AgentType
 	store                      workloadmeta.Component
 	collectEphemeralContainers bool
+	pullInterval               time.Duration
 
 	kubeUtil             kubelet.KubeUtilInterface
 	lastSeenPodUIDs      map[string]time.Time
@@ -58,6 +59,7 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 			id:                         collectorID,
 			catalog:                    workloadmeta.NodeAgent,
 			collectEphemeralContainers: deps.Config.GetBool("include_ephemeral_containers"),
+			pullInterval:               time.Duration(deps.Config.GetInt("kubelet_collector_pull_interval")) * time.Second,
 		},
 	}, nil
 }
@@ -65,6 +67,10 @@ func NewCollector(deps dependencies) (workloadmeta.CollectorProvider, error) {
 // GetFxOptions returns the FX framework options for the collector
 func GetFxOptions() fx.Option {
 	return fx.Provide(NewCollector)
+}
+
+func (c *collector) GetPullInterval() time.Duration {
+	return c.pullInterval
 }
 
 func (c *collector) Start(_ context.Context, store workloadmeta.Component) error {

--- a/comp/core/workloadmeta/def/collectors.go
+++ b/comp/core/workloadmeta/def/collectors.go
@@ -7,6 +7,7 @@ package workloadmeta
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 )
@@ -28,6 +29,12 @@ type Collector interface {
 
 	// GetTargetCatalog gets the expected catalog.
 	GetTargetCatalog() AgentType
+}
+
+// PullCollectorWithCustomInterval is an optional interface that pull collectors
+// can implement to override the default pull interval.
+type PullCollectorWithCustomInterval interface {
+	GetPullInterval() time.Duration
 }
 
 // CollectorProvider is the collector fx value group

--- a/comp/core/workloadmeta/impl/store.go
+++ b/comp/core/workloadmeta/impl/store.go
@@ -27,8 +27,10 @@ import (
 const (
 	retryCollectorInitialInterval = 1 * time.Second
 	retryCollectorMaxInterval     = 30 * time.Second
-	pullCollectorInterval         = 5 * time.Second
+	defaultPullCollectorInterval  = 5 * time.Second
+	minCollectorPullInterval      = 1 * time.Second
 	maxCollectorPullTime          = 1 * time.Minute
+	pullTickerTolerance           = 100 * time.Millisecond
 	eventBundleChTimeout          = 1 * time.Second
 	closeEventBundleChTimeout     = 10 * time.Second
 	eventChBufferSize             = 50
@@ -78,7 +80,7 @@ func (w *workloadmeta) start(ctx context.Context) {
 	}()
 
 	go func() {
-		pullTicker := time.NewTicker(pullCollectorInterval)
+		pullTicker := time.NewTicker(minCollectorPullInterval)
 
 		// Wait for at least one collector or timeout before first pull, so we
 		// don't signal CollectorsInitialized after an empty pull
@@ -695,6 +697,11 @@ func (w *workloadmeta) startCandidates(ctx context.Context) bool {
 		if err == nil {
 			w.log.Infof("workloadmeta collector %q started successfully", id)
 			w.collectors[id] = c
+
+			w.pullsMut.Lock()
+			w.pulls[id] = &pullInfo{interval: resolveCollectorPullInterval(c)}
+			w.pullsMut.Unlock()
+
 			w.firstCollectorReadyOnce.Do(func() {
 				close(w.firstCollectorReady)
 			})
@@ -729,22 +736,36 @@ func (w *workloadmeta) pull(ctx context.Context) {
 	defer w.collectorMut.RUnlock()
 
 	for id, c := range w.collectors {
-		w.ongoingPullsMut.Lock()
-		ongoingPullStartTime := w.ongoingPulls[id]
-		alreadyRunning := !ongoingPullStartTime.IsZero()
+		w.pullsMut.Lock()
+		pullStatus := w.pulls[id]
+		alreadyRunning := !pullStatus.ongoingSince.IsZero()
+
+		// Skip if already running
 		if alreadyRunning {
-			timeRunning := time.Since(ongoingPullStartTime)
+			timeRunning := time.Since(pullStatus.ongoingSince)
 			if timeRunning > maxCollectorPullTime {
 				w.log.Errorf("collector %q has been running for too long (%d seconds)", id, timeRunning/time.Second)
 			} else {
 				w.log.Debugf("collector %q is still running. Will not pull again for now", id)
 			}
-			w.ongoingPullsMut.Unlock()
+			w.pullsMut.Unlock()
 			continue
 		}
 
-		w.ongoingPulls[id] = time.Now()
-		w.ongoingPullsMut.Unlock()
+		// The tolerance accounts for the delay between a tick firing and
+		// lastPullStart being recorded. Without this, some ticks can be skipped
+		// and double the intended pull interval.
+		pullNeeded := pullStatus.lastPullStart.IsZero() ||
+			time.Since(pullStatus.lastPullStart) >= pullStatus.interval-pullTickerTolerance
+		if !pullNeeded {
+			w.pullsMut.Unlock()
+			continue
+		}
+
+		now := time.Now()
+		pullStatus.ongoingSince = now
+		pullStatus.lastPullStart = now
+		w.pullsMut.Unlock()
 
 		// Run each pull in its own separate goroutine to reduce
 		// latency and unlock the main goroutine to do other work.
@@ -758,11 +779,11 @@ func (w *workloadmeta) pull(ctx context.Context) {
 				telemetry.PullErrors.Inc(id)
 			}
 
-			w.ongoingPullsMut.Lock()
-			pullDuration := time.Since(w.ongoingPulls[id])
+			w.pullsMut.Lock()
+			pullDuration := time.Since(pullStatus.ongoingSince)
 			telemetry.PullDuration.Observe(pullDuration.Seconds(), id)
-			w.ongoingPulls[id] = time.Time{}
-			w.ongoingPullsMut.Unlock()
+			pullStatus.ongoingSince = time.Time{}
+			w.pullsMut.Unlock()
 		}(id, c)
 	}
 }
@@ -1047,4 +1068,21 @@ func (w *workloadmeta) isEntityComplete(kind wmdef.Kind, cachedEntity *cachedEnt
 	}
 
 	return true
+}
+
+// resolveCollectorPullInterval returns the pull interval for a collector. If
+// the collector defines a custom pull interval, and it's higher than the
+// minimum accepted, that value is used. Otherwise, the default is used.
+func resolveCollectorPullInterval(c wmdef.Collector) time.Duration {
+	if collectorWithCustomInterval, ok := c.(wmdef.PullCollectorWithCustomInterval); ok {
+		interval := collectorWithCustomInterval.GetPullInterval()
+		if interval >= minCollectorPullInterval {
+			return interval
+		}
+		if interval != 0 { // 0 means apply the default, so it's not an error
+			log.Warnf("collector %q requested pull interval %s which is below minimum %s, using default %s",
+				c.GetID(), interval, minCollectorPullInterval, defaultPullCollectorInterval)
+		}
+	}
+	return defaultPullCollectorInterval
 }

--- a/comp/core/workloadmeta/impl/workloadmeta.go
+++ b/comp/core/workloadmeta/impl/workloadmeta.go
@@ -24,6 +24,13 @@ import (
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 )
 
+// pullInfo holds per-collector pull state.
+type pullInfo struct {
+	ongoingSince  time.Time // zero if not in progress
+	lastPullStart time.Time
+	interval      time.Duration
+}
+
 // store is a central storage of metadata about workloads. A workload is any
 // unit of work being done by a piece of software, like a process, a container,
 // a kubernetes pod, or a task in any cloud provider.
@@ -49,8 +56,8 @@ type workloadmeta struct {
 
 	eventCh chan []wmdef.CollectorEvent
 
-	ongoingPullsMut sync.Mutex
-	ongoingPulls    map[string]time.Time // collector ID => time when last pull started
+	pullsMut sync.Mutex
+	pulls    map[string]*pullInfo
 
 	// expectedSources maps entity kinds to the sources that are expected to
 	// report data for them. This is used to determine if an entity is
@@ -97,7 +104,7 @@ func NewWorkloadMeta(deps Dependencies) Provider {
 		candidates:            candidates,
 		collectors:            make(map[string]wmdef.Collector),
 		eventCh:               make(chan []wmdef.CollectorEvent, eventChBufferSize),
-		ongoingPulls:          make(map[string]time.Time),
+		pulls:                 make(map[string]*pullInfo),
 		collectorsInitialized: wmdef.CollectorsNotStarted,
 		expectedSources:       initExpectedSources(deps.Params.AgentType),
 	}

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -1938,6 +1938,7 @@ func kubernetes(config pkgconfigmodel.Setup) {
 	// used by workloadmeta that already defines its own pull frequency and has
 	// its own storage, so no need for an extra cache.
 	config.BindEnvAndSetDefault("kubelet_cache_pods_duration", 0)
+	config.BindEnvAndSetDefault("kubelet_collector_pull_interval", 0) // not exposed yet. In seconds. 0 means use workloadmeta default
 	config.BindEnvAndSetDefault("kubernetes_collect_metadata_tags", true)
 	config.BindEnvAndSetDefault("kubernetes_use_endpoint_slices", false)
 	config.BindEnvAndSetDefault("kubernetes_metadata_tag_update_freq", 60) // Polling frequency of the Agent to the DCA in seconds (gets the local cache if the DCA is disabled)


### PR DESCRIPTION
### What does this PR do?

This PR changes workloadmeta so that its pull-based collectors can define a custom pull interval. Right now, workloadmeta pulls every 5 seconds for all of them.

The second commit uses this to allow users to configure a custom pull interval for the kubelet collector. This is related to other PRs that try to address the "missing tags" problem. In general, this can be useful for all the components that need the pods/containers discovered by the kubelet or the tags derived from them. For example, this can help autodiscovery, logs, APM traces, etc. This seems particularly important for the APM traces case (@raphaelgavache  can provide more information about this if needed).

This PR introduces a new setting (`kubelet_collector_pull_interval`) to control this. By default it's set to 0, meaning the workloadmeta default applies (5s). For now it's not exposed. Whether we expose it will depend on how effective it is. Decreasing the pull interval is expected to introduce a small CPU usage increase in the kubelet as well as in the Agent itself.


### Describe how you validated your changes

Tested on a local kind cluster. The agent telemetry exposes pull count per collector. I used this to verify that the kubelet collector was pulling at the configured interval while other collectors used the 5s default.

