### PR TITLE
Trigger Windows E2E tests on windows/common changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -910,8 +910,16 @@ workflow:
       compare_to: $COMPARE_TO_BRANCH
     when: on_success
 
+.on_windows_e2e_changes:
+  - changes:
+      paths:
+        - test/new-e2e/tests/windows/common/**/*
+      compare_to: $COMPARE_TO_BRANCH
+    when: on_success
+
 .on_e2e_or_windows_installer_changes:
   - !reference [.on_e2e_main_release_or_rc]
+  - !reference [.on_windows_e2e_changes]
   - <<: *if_windows_installer_changes
     when: on_success
 
@@ -1113,10 +1121,12 @@ workflow:
 
 .on_installer_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
+  - !reference [.on_windows_e2e_changes]
   - changes:
       paths:
         - .gitlab/deploy/**/*
         - .gitlab/test/e2e_install_packages/**/*
+        - .gitlab/windows/test/e2e_install_packages/windows.yml
         - .gitlab/test/e2e/e2e.yml
         - omnibus/config/**/*
         - pkg/fleet/**/*
@@ -1219,6 +1229,7 @@ workflow:
 
 .on_windows_service_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
+  - !reference [.on_windows_e2e_changes]
   - changes:
       paths:
         - cmd/agent/**/*
@@ -1236,6 +1247,7 @@ workflow:
 
 .on_windows_certificate_or_e2e_changes:
   - !reference [.on_e2e_main_release_or_rc]
+  - !reference [.on_windows_e2e_changes]
   - changes:
       paths:
         - test/new-e2e/tests/windows/windows-certificate/**/*


### PR DESCRIPTION
### What does this PR do?

Add shared `.on_windows_e2e_changes` CI rule so changes to `test/new-e2e/tests/windows/common/` trigger all Windows E2E suites. Also adds missing `.gitlab/windows/` path to `.on_installer_or_e2e_changes`.

### Motivation

Shared helper changes don't trigger E2E tests (e.g. #48412). Jira: [WINA-2528](https://datadoghq.atlassian.net/browse/WINA-2528)

### Describe how you validated your changes

Windows E2E tests run in CI.

[WINA-2528]: https://datadoghq.atlassian.net/browse/WINA-2528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ