### PR TITLE
Fix ebpf unit tests failing when files were already created

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -1220,11 +1220,16 @@ def bazel_build_ebpf(ctx: Context, arch: Arch, build_dir: str, strip: bool = Tru
 
         if os.path.exists(src_o):
             dst = os.path.join(dest_dir, f"{name}.o")
+            # Destination may be read-only (e.g. 0o444 after build_cws_object_files); copy2 needs write access.
+            if os.path.exists(dst):
+                os.chmod(dst, 0o644)
             shutil.copy2(src_o, dst)
             os.chmod(dst, 0o644)
             copied_files.append(dst)
         elif os.path.exists(src_bin):
             dst = os.path.join(dest_dir, name)
+            if os.path.exists(dst):
+                os.chmod(dst, 0o755)
             shutil.copy2(src_bin, dst)
             os.chmod(dst, 0o755)
             copied_files.append(dst)


### PR DESCRIPTION
### What does this PR do?
Do chmod on ebpf files when they already exist
### Motivation
When we re run `dda inv security-agent.run-ebpf-unit-tests` we could get an error because the file were created with incorrect perms.

`PermissionError: [Errno 13] Permission denied: 'pkg/ebpf/bytecode/build/arm64/runtime-security.o'`
