### PR TITLE
[observer] Rename metadata.json to episode.json

### DIFF
--- a/cmd/observer-scorer/main.go
+++ b/cmd/observer-scorer/main.go
@@ -7,7 +7,7 @@
 // It has two mutually exclusive scoring modes:
 //
 //   - Default (F1 scoring): Reads a headless output JSON produced with time_cluster,
-//     resolves ground truth timestamps from the scenario's metadata.json, and computes
+//     resolves ground truth timestamps from the scenario's episode.json, and computes
 //     a Gaussian F1 score measuring whether the disruption was detected at the right time.
 //
 //   - --score-tp (TP metric scoring): Reads a headless output JSON produced with the
@@ -29,8 +29,8 @@ import (
 
 func main() {
 	outputPath := flag.String("input", "", "Path to headless output JSON to score (required)")
-	scenariosDir := flag.String("scenarios-dir", "./comp/observer/scenarios", "Directory containing scenario subdirectories (for metadata.json lookup)")
-	groundTruthTS := flag.Int64("ground-truth-ts", 0, "Ground truth disruption onset timestamp in unix seconds (overrides metadata.json)")
+	scenariosDir := flag.String("scenarios-dir", "./comp/observer/scenarios", "Directory containing scenario subdirectories (for episode.json lookup)")
+	groundTruthTS := flag.Int64("ground-truth-ts", 0, "Ground truth disruption onset timestamp in unix seconds (overrides episode.json)")
 	sigma := flag.Float64("sigma", 30.0, "Gaussian width in seconds")
 	jsonOutput := flag.Bool("json", false, "Output result as JSON")
 	scoreTP := flag.Bool("score-tp", false, "Score true positive detection using metric ground truth from ground_truth.json. Requires passthrough correlator output.")

--- a/comp/observer/impl/score.go
+++ b/comp/observer/impl/score.go
@@ -209,7 +209,7 @@ func scoreGaussianPDF(x, sigma float64) float64 {
 	return math.Exp(-x*x/(2*sigma*sigma)) / (sigma * math.Sqrt(2*math.Pi))
 }
 
-// scenarioMetadata is the subset of metadata.json fields the scorer needs.
+// scenarioMetadata is the subset of episode.json fields the scorer needs.
 type scenarioMetadata struct {
 	Baseline struct {
 		Start string `json:"start"`
@@ -219,27 +219,27 @@ type scenarioMetadata struct {
 	} `json:"disruption"`
 }
 
-// scoringMetadata holds timestamps extracted from a scenario's metadata.json.
+// scoringMetadata holds timestamps extracted from a scenario's episode.json.
 type scoringMetadata struct {
 	groundTruthTimestamps []int64
 	baselineStart         int64 // 0 if not available
 }
 
-// loadScoringMetadata reads disruption.start and baseline.start from a scenario's metadata.json.
+// loadScoringMetadata reads disruption.start and baseline.start from a scenario's episode.json.
 func loadScoringMetadata(scenariosDir, scenarioName string) (*scoringMetadata, error) {
-	path := filepath.Join(scenariosDir, scenarioName, "metadata.json")
+	path := filepath.Join(scenariosDir, scenarioName, "episode.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("reading metadata %s: %w", path, err)
+		return nil, fmt.Errorf("reading episode %s: %w", path, err)
 	}
 
 	var meta scenarioMetadata
 	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, fmt.Errorf("parsing metadata JSON: %w", err)
+		return nil, fmt.Errorf("parsing episode JSON: %w", err)
 	}
 
 	if meta.Disruption.Start == "" {
-		return nil, errors.New("metadata.json missing disruption.start")
+		return nil, errors.New("episode.json missing disruption.start")
 	}
 
 	dt, err := time.Parse(time.RFC3339, meta.Disruption.Start)
@@ -265,8 +265,8 @@ func loadScoringMetadata(scenariosDir, scenarioName string) (*scoringMetadata, e
 // ScoreOutputFile loads a headless output JSON file, extracts prediction timestamps,
 // and scores them against the given ground truth.
 // If groundTruthTimestamps is nil and scenariosDir is non-empty, ground truth is
-// inferred from the scenario's metadata.json (using the scenario name from the output).
-// Explicit groundTruthTimestamps override metadata inference.
+// inferred from the scenario's episode.json (using the scenario name from the output).
+// Explicit groundTruthTimestamps override episode.json inference.
 func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenariosDir string, sigma float64) (*ScoreResult, error) {
 	if sigma <= 0 {
 		return nil, fmt.Errorf("sigma must be positive, got %f", sigma)
@@ -299,7 +299,7 @@ func ScoreOutputFile(outputPath string, groundTruthTimestamps []int64, scenarios
 	}
 
 	if len(groundTruthTimestamps) == 0 {
-		return nil, errors.New("no ground truth: provide --ground-truth-ts or --scenarios-dir with metadata.json")
+		return nil, errors.New("no ground truth: provide --ground-truth-ts or --scenarios-dir with episode.json")
 	}
 
 	// Filter warmup predictions (before baseline.start).

--- a/comp/observer/impl/score_test.go
+++ b/comp/observer/impl/score_test.go
@@ -255,13 +255,13 @@ func TestScoreOutputFile_PostOnsetIgnored(t *testing.T) {
 }
 
 func TestScoreOutputFile_MetadataInference(t *testing.T) {
-	// Set up a fake scenario dir with metadata.json
+	// Set up a fake scenario dir with episode.json
 	scenariosDir := t.TempDir()
 	scenarioDir := filepath.Join(scenariosDir, "test_scenario")
 	require.NoError(t, os.MkdirAll(scenarioDir, 0755))
 
 	metadata := `{"baseline": {"start": "2026-03-03T12:39:35Z"}, "disruption": {"start": "2026-03-03T12:49:35Z"}}`
-	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "metadata.json"), []byte(metadata), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "episode.json"), []byte(metadata), 0644))
 
 	// Output JSON references "test_scenario"
 	output := ObserverOutput{
@@ -287,15 +287,15 @@ func TestScoreOutputFile_MetadataInference(t *testing.T) {
 }
 
 func TestScoreOutputFile_ExplicitOverridesMetadata(t *testing.T) {
-	// Set up metadata — disruption.start is at 12:49:35, but we override GT to 12:45:00
+	// Set up episode.json — disruption.start is at 12:49:35, but we override GT to 12:45:00
 	scenariosDir := t.TempDir()
 	scenarioDir := filepath.Join(scenariosDir, "test_scenario")
 	require.NoError(t, os.MkdirAll(scenarioDir, 0755))
 
 	metadata := `{"baseline": {"start": "2026-03-03T12:39:35Z"}, "disruption": {"start": "2026-03-03T12:49:35Z"}}`
-	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "metadata.json"), []byte(metadata), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "episode.json"), []byte(metadata), 0644))
 
-	// Prediction matches our explicit GT (12:45:00 = 1772541900), not metadata's disruption.start
+	// Prediction matches our explicit GT (12:45:00 = 1772541900), not episode.json's disruption.start
 	explicitGT := int64(1772541900)
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{Scenario: "test_scenario"},
@@ -309,11 +309,11 @@ func TestScoreOutputFile_ExplicitOverridesMetadata(t *testing.T) {
 	outputPath := filepath.Join(t.TempDir(), "output.json")
 	require.NoError(t, os.WriteFile(outputPath, data, 0644))
 
-	// Explicit ground truth should override metadata's disruption.start
+	// Explicit ground truth should override episode.json's disruption.start
 	result, err := ScoreOutputFile(outputPath, []int64{explicitGT}, scenariosDir, 30.0)
 	require.NoError(t, err)
 
-	assert.InDelta(t, 1.0, result.F1, 0.05, "explicit GT should be used, not metadata")
+	assert.InDelta(t, 1.0, result.F1, 0.05, "explicit GT should be used, not episode.json")
 }
 
 func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
@@ -323,7 +323,7 @@ func TestScoreOutputFile_WarmupFiltering(t *testing.T) {
 	require.NoError(t, os.MkdirAll(scenarioDir, 0755))
 
 	metadata := `{"baseline": {"start": "1970-01-01T00:01:40Z"}, "disruption": {"start": "1970-01-01T00:03:20Z"}}`
-	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "metadata.json"), []byte(metadata), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scenarioDir, "episode.json"), []byte(metadata), 0644))
 
 	output := ObserverOutput{
 		Metadata: ObserverMetadata{Scenario: "test_scenario"},

--- a/comp/observer/impl/score_tp.go
+++ b/comp/observer/impl/score_tp.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-// MetricGroundTruth holds the TP/FP metric lists from a scenario's metadata.json.
+// MetricGroundTruth holds the TP/FP metric lists from a scenario's episode.json.
 type MetricGroundTruth struct {
 	TruePositives  []MetricGroundTruthEntry `json:"true_positives"`
 	FalsePositives []MetricGroundTruthEntry `json:"false_positives"`
@@ -65,7 +65,7 @@ type MetricScoreResult struct {
 
 // LoadMetricGroundTruth reads TP metric lists from ground_truth.json in the
 // scenarios directory. This file is committed and keyed by scenario name,
-// separate from metadata.json which is downloaded from S3.
+// separate from episode.json which is downloaded from S3.
 func LoadMetricGroundTruth(scenariosDir, scenarioName string) (*MetricGroundTruth, error) {
 	path := filepath.Join(scenariosDir, "ground_truth.json")
 	data, err := os.ReadFile(path)
@@ -87,7 +87,7 @@ func LoadMetricGroundTruth(scenariosDir, scenarioName string) (*MetricGroundTrut
 }
 
 // LoadDisruptionStartUnix returns the disruption start timestamp in unix seconds
-// from a scenario's metadata.json, or 0 if unavailable.
+// from a scenario's episode.json, or 0 if unavailable.
 func LoadDisruptionStartUnix(scenariosDir, scenarioName string) int64 {
 	sm, err := loadScoringMetadata(scenariosDir, scenarioName)
 	if err != nil || len(sm.groundTruthTimestamps) == 0 {

--- a/comp/observer/scenarios/.gitignore
+++ b/comp/observer/scenarios/.gitignore
@@ -1,3 +1,3 @@
 # Parquet data is fetched from S3 on demand (dda inv q.eval-scenarios)
 */parquet/
-*/metadata.json
+*/episode.json

--- a/tasks/q.py
+++ b/tasks/q.py
@@ -357,7 +357,7 @@ def _ensure_parquets(ctx, name, parquet_dir):
                         with zf.open(member) as src, open(os.path.join(parquet_dir, filename), "wb") as dst:
                             dst.write(src.read())
                     elif member.startswith("tmp/gensim-archive/results/") and member.endswith(".json"):
-                        with zf.open(member) as src, open(os.path.join(scenario_dir, "metadata.json"), "wb") as dst:
+                        with zf.open(member) as src, open(os.path.join(scenario_dir, "episode.json"), "wb") as dst:
                             dst.write(src.read())
         except (zipfile.BadZipFile, OSError) as e:
             print(color_message(f"Failed to extract {zip_key}: {e}", Color.RED))


### PR DESCRIPTION
## Summary

The scorer read `metadata.json`; the testbench read `episode.json` to draw the disruption onset line. Same data, different files. If both existed, the disruption line in the UI could fail to appear because it wouldn't match the parquet files.

`q.pull` downloads scenario metadata from S3 and now writes it as `episode.json` locally.