### PR TITLE
Make sure we consider not only Go files for unit tests trigger

### DIFF
--- a/tasks/gotest.py
+++ b/tasks/gotest.py
@@ -690,8 +690,9 @@ def get_impacted_packages(ctx, build_tags=None):
     if build_tags is None:
         build_tags = []
     dependencies = create_dependencies(ctx, build_tags)
-    files = get_go_modified_files(ctx)
-
+    base_branch = _get_release_json_value("base_branch")
+    files = get_modified_files(ctx, base_branch=base_branch)
+    print(f"Detected the following modified files: {files}")
     modified_packages = {f"github.com/DataDog/datadog-agent/{os.path.dirname(file)}" for file in files}
 
     # Modification to go.mod and go.sum should force the tests of the whole module to run


### PR DESCRIPTION
### What does this PR do?

Change files we consider, to also consider fixtures file that are not Go files, and count them as a modification to the package they belong to

### Motivation

Should force the test to be executed in the package, for PRs like: https://github.com/DataDog/datadog-agent/pull/46885

### Describe how you validated your changes

### Additional Notes
