### PR TITLE
Revert "feat(par): add default restricted shell paths with container-aware prefixing"

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -6,10 +6,8 @@
 package setup
 
 import (
-	"path/filepath"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -38,17 +36,6 @@ const (
 	// Restricted Shell
 	PARRestrictedShellAllowedPaths = "private_action_runner.restricted_shell_allowed_paths"
 )
-
-const (
-	// Default allowed paths for restricted shell
-	defaultLogPath = "/var/log"
-
-	containerizedPathPrefix = "/host"
-)
-
-// parPathExists is the function used to check path existence. It defaults to
-// pathExists and can be overridden in tests.
-var parPathExists = pathExists
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner
 func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
@@ -82,18 +69,12 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	})
 	config.BindEnvAndSetDefault(PARHttpAllowImdsEndpoint, false)
 
-	defaultPaths := []string{defaultLogPath}
-	if env.IsContainerized() {
-		for i, v := range defaultPaths {
-			hostPath := filepath.Join(containerizedPathPrefix, v)
-			defaultPaths[i] = hostPath
-		}
-	}
-	config.BindEnvAndSetDefault(PARRestrictedShellAllowedPaths, defaultPaths)
+	config.BindEnvAndSetDefault(PARRestrictedShellAllowedPaths, []string{"/var/log"})
 	config.ParseEnvAsStringSlice(PARRestrictedShellAllowedPaths, func(s string) []string {
 		if s == "" {
 			return nil
 		}
 		return strings.Split(s, ",")
 	})
+
 }

--- a/pkg/config/setup/privateactionrunner_test.go
+++ b/pkg/config/setup/privateactionrunner_test.go
@@ -6,24 +6,10 @@
 package setup
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
-
-func mockParPathExists(existing map[string]bool) func(string) bool {
-	return func(path string) bool {
-		return existing[path]
-	}
-}
-
-func overrideParPathExists(t *testing.T, fn func(string) bool) {
-	original := parPathExists
-	parPathExists = fn
-	t.Cleanup(func() { parPathExists = original })
-}
 
 func TestPrivateActionRunnerActionsAllowlistFromEnv(t *testing.T) {
 	t.Setenv("DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST", "com.datadoghq.kubernetes.core.listPod,com.datadoghq.script.runPredefinedScript")
@@ -54,7 +40,7 @@ func TestPrivateActionRunnerRestrictedShellAllowedPathsEmptyEnv(t *testing.T) {
 
 	cfg := newTestConf(t)
 
-	assert.Equal(t, []string{defaultLogPath}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+	assert.Equal(t, []string{"/var/log"}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }
 
 func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
@@ -62,41 +48,5 @@ func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
 
 	assert.Empty(t, cfg.GetStringSlice(PARActionsAllowlist))
 	assert.Empty(t, cfg.GetStringSlice(PARHttpAllowlist))
-	assert.Equal(t, []string{defaultLogPath}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
-}
-
-func TestPrivateActionRunnerAllowedPathsBareMetal(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
-	os.Unsetenv("DOCKER_DD_AGENT")
-
-	cfg := newTestConf(t)
-
-	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
-	assert.Equal(t, []string{defaultLogPath}, paths)
-}
-
-func TestPrivateActionRunnerAllowedPathsContainerizedWithHostMounts(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "true")
-	overrideParPathExists(t, mockParPathExists(map[string]bool{
-		"/host/var/log": true,
-	}))
-
-	cfg := newTestConf(t)
-
-	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
-	assert.Equal(t, []string{"/host/var/log"}, paths)
-}
-
-func TestPrivateActionRunnerAllowedPathsContainerizedWithoutHostMounts(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "true")
-	overrideParPathExists(t, mockParPathExists(map[string]bool{}))
-
-	cfg := newTestConf(t)
-
-	// Even without host mounts, containerized paths should use /host prefix
-	// (rshell handles missing paths at runtime; config logs a warning)
-	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
-	assert.Equal(t, []string{
-		filepath.Join(containerizedPathPrefix, defaultLogPath),
-	}, paths)
+	assert.Equal(t, []string{"/var/log"}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -10,28 +10,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/DataDog/rshell/interp"
 
-	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-const (
-	defaultProcPath         = "/proc"
-	containerizedPathPrefix = "/host"
-)
-
-// statFn is the function used to check path existence. It defaults to os.Stat
-// and can be overridden in tests.
-var statFn = os.Stat
 
 // RunCommandHandler implements the runCommand action.
 type RunCommandHandler struct {
@@ -81,11 +69,6 @@ func (h *RunCommandHandler) Run(
 		return nil, fmt.Errorf("failed to parse command: %w", err)
 	}
 
-	for _, p := range h.allowedPaths {
-		if _, err := statFn(p); err != nil {
-			log.Warnf("path %q not found, rshell may fail to execute commands", p)
-		}
-	}
 	var stdout, stderr bytes.Buffer
 	cmdOpt := interp.AllowAllCommands()
 	if len(inputs.AllowedCommands) > 0 {
@@ -94,7 +77,6 @@ func (h *RunCommandHandler) Run(
 	runner, err := interp.New(
 		interp.StdIO(nil, &stdout, &stderr),
 		interp.AllowedPaths(h.allowedPaths),
-		interp.ProcPath(resolveProcPath()),
 		cmdOpt,
 	)
 	if err != nil {
@@ -118,17 +100,4 @@ func (h *RunCommandHandler) Run(
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 	}, nil
-}
-
-// resolveProcPath returns the proc filesystem path appropriate for the current
-// environment. In containerized deployments with host mounts, it returns
-// /host/proc; otherwise it falls back to /proc.
-func resolveProcPath() string {
-	if env.IsContainerized() {
-		hostProc := filepath.Join(containerizedPathPrefix, defaultProcPath)
-		if _, err := statFn(hostProc); err == nil {
-			return hostProc
-		}
-	}
-	return defaultProcPath
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -6,8 +6,6 @@
 package com_datadoghq_remoteaction_rshell
 
 import (
-	"errors"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,46 +29,4 @@ func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
 	handler, ok := action.(*RunCommandHandler)
 	require.True(t, ok)
 	assert.Equal(t, paths, handler.allowedPaths)
-}
-
-func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {
-	return func(path string) (os.FileInfo, error) {
-		if existing[path] {
-			return nil, nil
-		}
-		return nil, errors.New("not found")
-	}
-}
-
-func overrideStatFn(t *testing.T, fn func(string) (os.FileInfo, error)) {
-	original := statFn
-	statFn = fn
-	t.Cleanup(func() { statFn = original })
-}
-
-func TestResolveProcPathBareMetal(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "")
-	os.Unsetenv("DOCKER_DD_AGENT")
-
-	result := resolveProcPath()
-
-	assert.Equal(t, "/proc", result)
-}
-
-func TestResolveProcPathContainerizedWithHostMount(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "true")
-	overrideStatFn(t, mockStatFn(map[string]bool{"/host/proc": true}))
-
-	result := resolveProcPath()
-
-	assert.Equal(t, "/host/proc", result)
-}
-
-func TestResolveProcPathContainerizedWithoutHostMount(t *testing.T) {
-	t.Setenv("DOCKER_DD_AGENT", "true")
-	overrideStatFn(t, mockStatFn(map[string]bool{}))
-
-	result := resolveProcPath()
-
-	assert.Equal(t, "/proc", result)
 }


### PR DESCRIPTION
Reverts DataDog/datadog-agent#48236

The original PR is causing several windows tests to fail.