### PR TITLE
Reference RUST.md to make it visible in the doc portal

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
   - Documentation: guidelines/docs.md
   - Languages:
     - Go: guidelines/languages/go.md
+    - Rust: guidelines/languages/RUST.md
   - Testing:
     - Test categories: guidelines/testing/test-categories.md
   - Conventions:


### PR DESCRIPTION
### What does this PR do?
I have noticed that even though `RUST.md` is available through Search on the Agent's documentation portal it is not visible in the left side menu.
