### PR TITLE
[Backport 7.78.x] [[WP] Fix register ptr overridden by an Imm for raw paquets]

### DIFF
--- a/pkg/security/ebpf/probes/rawpacket/pcap.go
+++ b/pkg/security/ebpf/probes/rawpacket/pcap.go
@@ -167,8 +167,8 @@ func FilterToInsts(index int, filter Filter, opts ProgOpts) (asm.Instructions, e
 			*/
 
 			// check the cgroup id
-			asm.LoadImm(asm.R8, int64(filter.CGroupPathKey.Inode), asm.DWord),
-			asm.JEq.Reg(asm.R7, asm.R8, opts.onMatchLabel),
+			asm.LoadImm(asm.R4, int64(filter.CGroupPathKey.Inode), asm.DWord),
+			asm.JEq.Reg(asm.R7, asm.R4, opts.onMatchLabel),
 			asm.Mov.Imm(asm.R4, 0).WithSymbol(mismatchLabel), // nop instruction, just hold the symbol
 		)
 	} else {

--- a/pkg/security/tests/network_test.go
+++ b/pkg/security/tests/network_test.go
@@ -688,9 +688,13 @@ func TestRawPacketFilter(t *testing.T) {
 		},
 		{
 			BPFFilter: "tcp[((tcp[12:1] & 0xf0) >> 2):4] = 0x47455420",
+			CGroupPathKey: model.PathKey{
+				Inode: 1234,
+			},
 		},
 		{
 			BPFFilter: "icmp[icmptype] != icmp-echo and icmp[icmptype] != icmp-echoreply",
+			Pid:       123,
 		},
 		{
 			BPFFilter: "port ftp or ftp-data",

--- a/releasenotes/notes/fix-asm-ptr-overridden-486c2ca6b2f0007d.yaml
+++ b/releasenotes/notes/fix-asm-ptr-overridden-486c2ca6b2f0007d.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes Workload Protection raw-packet eBPF programs when multiple packet filters are
+    compiled together. The generated assembly reused register R8 both as the event
+    pointer expected by the filter chain and to hold immediate values, which corrupted the pointer 
+    and caused the kernel BPF verifier to reject the program. 
+    The code now uses a separate register for those
+    immediates so the pointer is preserved across filters.


### PR DESCRIPTION
### What does this PR do?
Backport PR #48429