### PR TITLE
fix(aggregator): use flavor as authoritative source for IoT agent name

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -301,12 +301,6 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 	bufferSize := pkgconfigsetup.Datadog().GetInt("aggregator_buffer_size")
 
 	agentName := flavor.GetFlavor()
-	if agentName == flavor.IotAgent && !pkgconfigsetup.Datadog().GetBool("iot_host") {
-		agentName = flavor.DefaultAgent
-	} else if pkgconfigsetup.Datadog().GetBool("iot_host") {
-		// Override the agentName if this Agent is configured to report as IotAgent
-		agentName = flavor.IotAgent
-	}
 	if pkgconfigsetup.Datadog().GetBool("heroku_dyno") {
 		// Override the agentName if this Agent is configured to report as Heroku Dyno
 		agentName = flavor.HerokuAgent

--- a/pkg/util/flavor/flavor.go
+++ b/pkg/util/flavor/flavor.go
@@ -69,10 +69,15 @@ func SetFlavor(flavor string) {
 	}
 }
 
-// GetFlavor gets the running Agent flavor
-// it MUST NOT be called before the main package is initialized;
+// GetFlavor gets the running Agent flavor.
+// It returns IotAgent if either the flavor was set to IotAgent at startup or
+// the iot_host config key is true (which allows a non-IoT binary to report as IoT).
+// It MUST NOT be called before the main package is initialized;
 // e.g. in init functions or to initialize package constants or variables.
 func GetFlavor() string {
+	if agentFlavor != IotAgent && pkgconfigsetup.Datadog().GetBool("iot_host") {
+		return IotAgent
+	}
 	return agentFlavor
 }
 

--- a/pkg/util/flavor/flavor_test.go
+++ b/pkg/util/flavor/flavor_test.go
@@ -13,6 +13,40 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestIotAgentNameFromFlavor verifies that GetFlavor returns IotAgent for an IoT agent binary
+// even when iot_host is reset to false by a config re-initialization (regression introduced in 7.76.0).
+// The agentFlavor package variable is authoritative and is not affected by InitConfigObjects.
+func TestIotAgentNameFromFlavor(t *testing.T) {
+	// configmock.New must be called first so it captures the original global config before
+	// SetFlavor modifies it (SetFlavor writes iot_host=true to the global config).
+	mockConfig := configmock.New(t)
+
+	originalFlavor := agentFlavor
+	t.Cleanup(func() { agentFlavor = originalFlavor })
+
+	SetFlavor(IotAgent)
+
+	// Simulate what happens when InitConfigObjects resets the config: iot_host becomes false.
+	mockConfig.SetWithoutSource("iot_host", false)
+
+	assert.Equal(t, IotAgent, GetFlavor(), "IoT agent must report as iot_agent even when iot_host is false after config re-init")
+}
+
+// TestIotHostOverridePromotesDefaultAgent verifies that setting iot_host=true on a non-IoT agent
+// still promotes it to report as iot_agent.
+func TestIotHostOverridePromotesDefaultAgent(t *testing.T) {
+	// configmock.New must be called before SetFlavor to correctly capture the original config.
+	mockConfig := configmock.New(t)
+
+	originalFlavor := agentFlavor
+	t.Cleanup(func() { agentFlavor = originalFlavor })
+
+	agentFlavor = DefaultAgent
+	mockConfig.SetWithoutSource("iot_host", true)
+
+	assert.Equal(t, IotAgent, GetFlavor(), "iot_host=true must promote a default agent to report as iot_agent")
+}
+
 func TestGetHumanReadableFlavor(t *testing.T) {
 	// NOTE: This constructor is required to setup the global config as
 	// a "mock" config that is using the "dynamic schema". Otherwise the function


### PR DESCRIPTION
## Backport of #47972 to 7.78.x

Cherry-pick of merge commit `712311d790e2f28de36842b85c10b39429f722ed` from #47972.

**Original PR:** https://github.com/DataDog/datadog-agent/pull/47972

fix(aggregator): use flavor as authoritative source for IoT agent name