### PR TITLE
bazel: migrate more modules to bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -318,7 +318,10 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/networkdevice/metadata
 # gazelle:exclude pkg/networkdevice/testutils
 # gazelle:exclude pkg/networkpath
-# gazelle:exclude pkg/opentelemetry-mapping-go
+# gazelle:exclude pkg/opentelemetry-mapping-go/inframetadata
+# gazelle:exclude pkg/opentelemetry-mapping-go/otlp/attributes
+# gazelle:exclude pkg/opentelemetry-mapping-go/otlp/logs
+# gazelle:exclude pkg/opentelemetry-mapping-go/otlp/metrics
 # gazelle:exclude pkg/orchestrator/config
 # gazelle:exclude pkg/orchestrator/model
 # gazelle:exclude pkg/persistentcache

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,7 +52,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/profiler
 # gazelle:exclude comp/core/remoteagent
 # gazelle:exclude comp/core/remoteagentregistry
-# gazelle:exclude comp/core/secrets
 # gazelle:exclude comp/core/settings
 # gazelle:exclude comp/core/status
 # gazelle:exclude comp/core/sysprobeconfig
@@ -146,12 +145,12 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/core/profiler
 # gazelle:exclude comp/core/remoteagent
 # gazelle:exclude comp/core/remoteagentregistry
+# gazelle:exclude comp/core/secrets/def
 # gazelle:exclude comp/core/secrets/fx-noop
 # gazelle:exclude comp/core/secrets/fx
 # gazelle:exclude comp/core/secrets/impl
 # gazelle:exclude comp/core/secrets/mock
 # gazelle:exclude comp/core/secrets/noop-impl
-# gazelle:exclude comp/core/secrets/utils
 # gazelle:exclude comp/core/settings
 # gazelle:exclude comp/core/status
 # gazelle:exclude comp/core/sysprobeconfig

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -401,7 +401,6 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude pkg/util/atomicstats
 # gazelle:exclude pkg/util/aws
 # gazelle:exclude pkg/util/aws/creds
-# gazelle:exclude pkg/util/cache
 # gazelle:exclude pkg/util/cachedfetch
 # gazelle:exclude pkg/util/cgroups
 # gazelle:exclude pkg/util/cli

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -114,7 +114,15 @@ ALL_BUILD_TAGS = [
 # gazelle:exclude comp/syntheticstestscheduler
 # gazelle:exclude comp/systray
 # gazelle:exclude comp/trace-telemetry
-# gazelle:exclude comp/trace
+# gazelle:exclude comp/trace/agent
+# gazelle:exclude comp/trace/config
+# gazelle:exclude comp/trace/etwtracer
+# gazelle:exclude comp/trace/payload-modifier
+# gazelle:exclude comp/trace/status
+# gazelle:exclude comp/trace/compression/fx-gzip
+# gazelle:exclude comp/trace/compression/fx-zstd
+# gazelle:exclude comp/trace/compression/impl-gzip
+# gazelle:exclude comp/trace/compression/impl-zstd
 # gazelle:exclude comp/updater
 # gazelle:exclude comp/workloadselection
 # gazelle:exclude comp/core/agenttelemetry

--- a/comp/core/secrets/utils/BUILD.bazel
+++ b/comp/core/secrets/utils/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "utils",
+    srcs = ["utils.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/core/secrets/utils",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "utils_test",
+    srcs = [
+        "utils_test.go",
+        "walker_test.go",
+    ],
+    embed = [":utils"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@in_yaml_go_yaml_v2//:yaml",
+    ],
+)

--- a/comp/trace/BUILD.bazel
+++ b/comp/trace/BUILD.bazel
@@ -1,0 +1,1 @@
+# gazelle:ignore

--- a/comp/trace/compression/def/BUILD.bazel
+++ b/comp/trace/compression/def/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "def",
+    srcs = ["component.go"],
+    importpath = "github.com/DataDog/datadog-agent/comp/trace/compression/def",
+    visibility = ["//visibility:public"],
+)

--- a/pkg/opentelemetry-mapping-go/otlp/rum/BUILD.bazel
+++ b/pkg/opentelemetry-mapping-go/otlp/rum/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "rum",
+    srcs = [
+        "constants.go",
+        "doc.go",
+        "mapping.go",
+        "rum.go",
+        "rum_logs.go",
+        "rum_traces.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/opentelemetry-mapping-go/otlp/rum",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_opentelemetry_go_collector_pdata//pcommon",
+        "@io_opentelemetry_go_collector_pdata//plog",
+        "@io_opentelemetry_go_collector_pdata//ptrace",
+        "@io_opentelemetry_go_otel//semconv/v1.5.0:v1_5_0",
+        "@org_uber_go_zap//:zap",
+    ],
+)
+
+go_test(
+    name = "rum_test",
+    srcs = [
+        "rum_logs_test.go",
+        "rum_test.go",
+        "rum_traces_test.go",
+    ],
+    embed = [":rum"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_opentelemetry_go_collector_pdata//pcommon",
+        "@io_opentelemetry_go_collector_pdata//ptrace",
+        "@io_opentelemetry_go_otel//semconv/v1.5.0:v1_5_0",
+        "@org_uber_go_zap//:zap",
+    ],
+)

--- a/pkg/util/cache/BUILD.bazel
+++ b/pkg/util/cache/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "cache",
+    srcs = [
+        "basic_cache.go",
+        "cache.go",
+    ],
+    importpath = "github.com/DataDog/datadog-agent/pkg/util/cache",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_patrickmn_go_cache//:go-cache"],
+)
+
+go_test(
+    name = "cache_test",
+    srcs = ["basic_cache_test.go"],
+    embed = [":cache"],
+    deps = ["@com_github_stretchr_testify//assert"],
+)


### PR DESCRIPTION
### What does this PR do?

Migrate:
* `pkg/util/cache`
* `comp/core/secrets/utils`
* `comp/trace/compression/def`
* `pkg/opentelemetry-mappin-go/otlp/rum`

to bazel

### Motivation

https://datadoghq.atlassian.net/browse/ABLD-408

### Describe how you validated your changes

### Additional Notes
