### PR TITLE
[autoscaling] Fix scaling happening when out of boundaries and preview mode

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal.go
@@ -112,6 +112,12 @@ func (hr *horizontalController) performScaling(ctx context.Context, podAutoscale
 		return autoscaling.NoRequeue, nil
 	}
 
+	// Final gate: check if the apply mode allows this action
+	if allowed, reason := isApplyModeAllowed(autoscalerSpec, scalingValues.Horizontal.Source); !allowed {
+		autoscalerInternal.UpdateFromHorizontalAction(nil, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonPolicyRestricted, "%s", reason))
+		return autoscaling.NoRequeue, nil
+	}
+
 	scale.Spec.Replicas = horizontalAction.ToReplicas
 	_, err = hr.scaler.update(ctx, gr, scale)
 	if err != nil {
@@ -216,6 +222,20 @@ func (hr *horizontalController) computeScaleAction(
 		}
 	}
 
+	// Check if the scaling direction is explicitly disabled by strategy
+	if scaleDirection != common.NoScale && autoscalerSpec.ApplyPolicy != nil {
+		if scaleDirection == common.ScaleUp && autoscalerSpec.ApplyPolicy.ScaleUp != nil && autoscalerSpec.ApplyPolicy.ScaleUp.Strategy != nil {
+			if *autoscalerSpec.ApplyPolicy.ScaleUp.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
+				return nil, 0, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonPolicyRestricted, "upscaling disabled by strategy")
+			}
+		}
+		if scaleDirection == common.ScaleDown && autoscalerSpec.ApplyPolicy.ScaleDown != nil && autoscalerSpec.ApplyPolicy.ScaleDown.Strategy != nil {
+			if *autoscalerSpec.ApplyPolicy.ScaleDown.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
+				return nil, 0, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonPolicyRestricted, "downscaling disabled by strategy")
+			}
+		}
+	}
+
 	// If we need to scale, we apply scaling rules if any
 	if scaleDirection != common.NoScale {
 		// Applying scaling rules if any
@@ -248,13 +268,6 @@ func (hr *horizontalController) computeScaleAction(
 		horizontalAction.LimitedReason = pointer.Ptr(limitReason)
 	}
 
-	// Finally checking if scaling is allowed
-	allowed, reason := isScalingAllowed(autoscalerSpec, source, scaleDirection)
-	if !allowed {
-		log.Debugf("Scaling not allowed for autoscaler id: %s, scale direction: %s, scale reason: %s (would have scaled to %d replicas)", autoscalerInternal.ID(), scaleDirection, reason, horizontalAction.ToReplicas)
-		return nil, 0, autoscaling.NewConditionErrorf(autoscaling.ConditionReasonPolicyRestricted, "%s", reason)
-	}
-
 	return horizontalAction, evalAfter, nil
 }
 
@@ -276,41 +289,27 @@ func isFallbackScalingDirectionEnabled(fallbackEnabledDirection datadoghq.Datado
 	return false
 }
 
-func isScalingAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source datadoghqcommon.DatadogPodAutoscalerValueSource, direction common.ScaleDirection) (bool, string) {
-	// If we don't have spec, we cannot take decisions, should not happen.
+// isApplyModeAllowed checks if the apply mode allows scaling actions.
+// This is the final gate applied after the action has been computed,
+// ensuring modes like Preview can never be bypassed regardless of the code path.
+func isApplyModeAllowed(autoscalerSpec *datadoghq.DatadogPodAutoscalerSpec, source datadoghqcommon.DatadogPodAutoscalerValueSource) (bool, string) {
 	if autoscalerSpec == nil {
 		return false, "pod autoscaling hasn't been initialized yet"
 	}
 
-	// By default, policy is to allow all
 	if autoscalerSpec.ApplyPolicy == nil {
 		return true, ""
 	}
 
-	// Default apply mode to All if not set
 	applyMode := autoscalerSpec.ApplyPolicy.Mode
 	if applyMode == "" {
 		applyMode = datadoghq.DatadogPodAutoscalerApplyModeApply
 	}
 
-	// We do have policies, checking if they allow this source
 	if !model.ApplyModeAllowSource(applyMode, source) {
 		return false, fmt.Sprintf("horizontal scaling disabled due to applyMode: %s not allowing recommendations from source: %s", autoscalerSpec.ApplyPolicy.Mode, source)
 	}
 
-	// Check if scaling direction is allowed
-	if direction == common.ScaleUp && autoscalerSpec.ApplyPolicy.ScaleUp != nil && autoscalerSpec.ApplyPolicy.ScaleUp.Strategy != nil {
-		if *autoscalerSpec.ApplyPolicy.ScaleUp.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
-			return false, "upscaling disabled by strategy"
-		}
-	}
-	if direction == common.ScaleDown && autoscalerSpec.ApplyPolicy.ScaleDown != nil && autoscalerSpec.ApplyPolicy.ScaleDown.Strategy != nil {
-		if *autoscalerSpec.ApplyPolicy.ScaleDown.Strategy == datadoghqcommon.DatadogPodAutoscalerDisabledStrategySelect {
-			return false, "downscaling disabled by strategy"
-		}
-	}
-
-	// No specific policy defined, defaulting to allow
 	return true, ""
 }
 

--- a/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_horizontal_test.go
@@ -260,6 +260,26 @@ func TestHorizontalControllerSyncPrerequisites(t *testing.T) {
 	assert.Equal(t, autoscaling.NoRequeue, result)
 	assert.NoError(t, err)
 
+	// Test case: Preview mode blocks scaling even when current replicas are outside boundaries
+	fakePai.Spec.ApplyPolicy = &datadoghq.DatadogPodAutoscalerApplyPolicy{
+		Mode: datadoghq.DatadogPodAutoscalerApplyModePreview,
+	}
+	fakePai.Spec.Constraints = &datadoghqcommon.DatadogPodAutoscalerConstraints{
+		MinReplicas: pointer.Ptr[int32](2),
+		MaxReplicas: pointer.Ptr[int32](8),
+	}
+	result, err = f.testScalingDecision(horizontalScalingTestArgs{
+		fakePai:         fakePai,
+		dataSource:      datadoghqcommon.DatadogPodAutoscalerAutoscalingValueSource,
+		currentReplicas: 10,
+		statusReplicas:  10,
+		recReplicas:     7,
+		scaleReplicas:   10,
+		scaleError:      testutil.NewErrorString("horizontal scaling disabled due to applyMode: Preview not allowing recommendations from source: Autoscaling"),
+	})
+	assert.Equal(t, autoscaling.NoRequeue, result)
+	assert.NoError(t, err)
+
 	// Test case: Fallback scaling direction disabled by policy
 	fakePai.Spec.Fallback = &datadoghq.DatadogFallbackPolicy{
 		Horizontal: datadoghq.DatadogPodAutoscalerHorizontalFallbackPolicy{


### PR DESCRIPTION
### What does this PR do?

Fix an issue where Autoscaling controller would always enforce min/maxReplicas even in Preview mode (unexpected).

### Motivation

Bugfix.

### Describe how you validated your changes

Deploy DCA with Autoscaling enabled. Create an Autoscaler in Preview mode with `minReplicas: 1 / maxReplicas: 2`.
Manually set replicas to 3 with `kubectl scale`. The desired replicas should not be changed by Autoscaler.

### Additional Notes
