### PR TITLE
[observer] Optimize log pattern memory

### DIFF
--- a/comp/observer/impl/bench_log_ingestion_test.go
+++ b/comp/observer/impl/bench_log_ingestion_test.go
@@ -10,6 +10,55 @@ import (
 	"testing"
 )
 
+// diverseLogContent returns distinct line shapes (JSON, kv, syslog, plain) for series s
+// so neighboring series exercise different tokenizer / pattern signatures.
+func diverseLogContent(s int) []byte {
+	switch s % 20 {
+	case 0:
+		return []byte(fmt.Sprintf(`{"msg":"log from series %d","level":"info"}`, s))
+	case 1:
+		return []byte(fmt.Sprintf(`{"@timestamp":"2024-01-01T00:00:00Z","message":"evt-%d","severity":"WARN","svc":"api"}`, s))
+	case 2:
+		return []byte(fmt.Sprintf(`{"trace_id":"%08x","span_id":"%08x","msg":"child span","ok":true}`, s, s+1))
+	case 3:
+		return []byte(fmt.Sprintf(`{"nested":{"user":%d,"shard":3},"event":"login","ip":"10.0.0.%d"}`, s, s%255))
+	case 4:
+		return []byte(fmt.Sprintf(`level=INFO ts=1704067200 series=%d msg="request done" duration_ms=12`, s))
+	case 5:
+		return []byte(fmt.Sprintf(`level=ERROR logger=com.example req=%d stack=java.lang.Exception`, s))
+	case 6:
+		return []byte(fmt.Sprintf(`[2024-01-15 14:30:00] INFO  worker-%d  task=flush completed=true`, s))
+	case 7:
+		return []byte(fmt.Sprintf(`<134>1 2024-01-15T14:30:00Z host app-%d - - - msg="syslog style"`, s))
+	case 8:
+		return []byte(fmt.Sprintf(`10.1.2.3 - - [15/Jan/2024:14:30:00 +0000] "GET /api/v%d/items HTTP/1.1" 200 4321`, s%50))
+	case 9:
+		return []byte(fmt.Sprintf(`time="2024-01-15T14:30:00Z" level=debug msg="slow query" series=%d ms=450`, s))
+	case 10:
+		return []byte(fmt.Sprintf(`{"arr":[%d,2,3],"obj":{"k":"v"},"flag":false}`, s))
+	case 11:
+		return []byte(fmt.Sprintf(`ERROR: connection reset by peer series=%d errno=104`, s))
+	case 12:
+		return []byte(fmt.Sprintf(`{"msg":"unicode 测试 %d café","meta":{"region":"eu-west-1"}}`, s))
+	case 13:
+		return []byte(fmt.Sprintf(`kafka: topic=logs partition=%d offset=999 key=null`, s))
+	case 14:
+		return []byte(fmt.Sprintf(`{"a":1,"b":%d,"c":{"d":[1,2]}}`, s))
+	case 15:
+		return []byte(fmt.Sprintf(`[pid=12345] series=%d action=gc pause_ms=3`, s))
+	case 16:
+		return []byte(fmt.Sprintf(`{"http":{"method":"POST","path":"/hook/%d","status":201}}`, s))
+	case 17:
+		return []byte(fmt.Sprintf(`plain text line series=%d no json here`, s))
+	case 18:
+		return []byte(fmt.Sprintf(`{"double":%d.%d,"scientific":1.23e-4}`, s/10, s%10))
+	case 19:
+		return []byte(fmt.Sprintf(`merge key=value series=%d another=42`, s))
+	default:
+		return []byte(fmt.Sprintf(`{"msg":"log from series %d","level":"info"}`, s))
+	}
+}
+
 // BenchmarkLogExtraction_SeriesCount measures raw log ingestion cost with
 // the default catalog extractors across increasing series count.
 func BenchmarkLogExtraction_SeriesCount(b *testing.B) {
@@ -20,6 +69,43 @@ func BenchmarkLogExtraction_SeriesCount(b *testing.B) {
 			for s := 0; s < numSeries; s++ {
 				logs[s] = &logObs{
 					content:     []byte(fmt.Sprintf(`{"msg":"log from series %d","level":"info"}`, s)),
+					status:      "info",
+					tags:        []string{fmt.Sprintf("series:%d", s)},
+					timestampMs: 0,
+				}
+			}
+
+			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				_, _, extractors, _ := defaultCatalog().Instantiate(benchmarkSettings)
+				storage := newTimeSeriesStorage()
+				e := newEngine(engineConfig{
+					storage:    storage,
+					extractors: extractors,
+				})
+				b.StartTimer()
+
+				tsMs := int64(i) * 1000
+				for _, l := range logs {
+					l.timestampMs = tsMs
+					e.IngestLog("ns", l)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkLogExtraction_DiversePatterns is like SeriesCount but assigns each series one
+// of twenty distinct line shapes (JSON, structured kv, syslog, access log, plain text)
+// so ingestion reflects higher pattern cardinality.
+func BenchmarkLogExtraction_DiversePatterns(b *testing.B) {
+	for _, numSeries := range []int{50, 200, 500, 2000} {
+		numSeries := numSeries
+		b.Run(fmt.Sprintf("series=%d", numSeries), func(b *testing.B) {
+			logs := make([]*logObs, numSeries)
+			for s := 0; s < numSeries; s++ {
+				logs[s] = &logObs{
+					content:     diverseLogContent(s),
 					status:      "info",
 					tags:        []string{fmt.Sprintf("series:%d", s)},
 					timestampMs: 0,

--- a/comp/observer/impl/log_pattern_extractor.go
+++ b/comp/observer/impl/log_pattern_extractor.go
@@ -100,8 +100,8 @@ func (e *LogPatternExtractor) GetContextByKey(key string) (observerdef.MetricCon
 func (e *LogPatternExtractor) ProcessLog(log observerdef.LogView) observerdef.LogMetricsExtractorOutput {
 	telemetry := []observerdef.ObserverTelemetry{}
 	message := string(log.GetContent())
-	clusterResult := e.PatternClusterer.Process(message)
-	if clusterResult == nil {
+	clusterResult, ok := e.PatternClusterer.Process(message)
+	if !ok {
 		return observerdef.LogMetricsExtractorOutput{}
 	}
 	if clusterResult.IsNew {

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -326,18 +326,8 @@ func mergeTokenLists(pattern, incoming []Token) {
 	for i := range pattern {
 		if pattern[i].Value != incoming[i].Value {
 			pattern[i].IsWild = true
-			pattern[i].Values = appendUnique(pattern[i].Values, incoming[i].Value)
 		}
 	}
-}
-
-func appendUnique(slice []string, s string) []string {
-	for _, v := range slice {
-		if v == s {
-			return slice
-		}
-	}
-	return append(slice, s)
 }
 
 // Classify returns the cluster matching the given message without modifying any state.

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -123,7 +123,6 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 		Signature: sig,
 		Pattern:   tokens,
 		Count:     1,
-		Tags:      make(map[string]string),
 		Samples:   []string{message},
 		ID:        sc.IDComputeInfo.NextID(),
 	}
@@ -141,7 +140,10 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 func (sc *SignatureClusterer) ProcessDoc(doc map[string]string) *ClusterResult {
 	message := sc.TextGetter(doc)
 	result := sc.Process(message)
-	if result != nil && result.IsNew {
+	if result != nil && result.IsNew && len(sc.TagGetters) > 0 {
+		if result.Cluster.Tags == nil {
+			result.Cluster.Tags = make(map[string]string)
+		}
 		for tagName, getter := range sc.TagGetters {
 			result.Cluster.Tags[tagName] = getter(doc)
 		}
@@ -238,7 +240,6 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 		Signature: sig,
 		Pattern:   tokens,
 		Count:     1,
-		Tags:      make(map[string]string),
 		Samples:   []string{message},
 		ID:        pc.IDComputeInfo.NextID(),
 	}

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -92,21 +92,21 @@ func NewSignatureClusterer(idComputeInfo IDComputeInfo) *SignatureClusterer {
 	}
 }
 
-func (sc *SignatureClusterer) Process(message string) *ClusterResult {
+func (sc *SignatureClusterer) Process(message string) (ClusterResult, bool) {
 	if sc.IgnoreEmpty && strings.TrimSpace(message) == "" {
-		return nil
+		return ClusterResult{}, false
 	}
 
 	tokens := sc.tokenizer.Tokenize(message)
 	return sc.ProcessTokens(tokens, message)
 }
 
-func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *ClusterResult {
+func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) (ClusterResult, bool) {
 	sig := TokenListSignature(tokens)
 
 	if c, ok := sc.clusters[sig]; ok {
 		c.Count++
-		return &ClusterResult{Cluster: c, IsNew: false}
+		return ClusterResult{Cluster: c, IsNew: false}, true
 	}
 
 	c := &Cluster{
@@ -119,13 +119,13 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 	sc.clusters[sig] = c
 	sc.orderedKeys = append(sc.orderedKeys, sig)
 
-	return &ClusterResult{Cluster: c, IsNew: true}
+	return ClusterResult{Cluster: c, IsNew: true}, true
 }
 
-func (sc *SignatureClusterer) ProcessDoc(doc map[string]string) *ClusterResult {
+func (sc *SignatureClusterer) ProcessDoc(doc map[string]string) (ClusterResult, bool) {
 	message := sc.TextGetter(doc)
-	result := sc.Process(message)
-	if result != nil && result.IsNew && len(sc.TagGetters) > 0 {
+	result, ok := sc.Process(message)
+	if ok && result.IsNew && len(sc.TagGetters) > 0 {
 		if result.Cluster.Tags == nil {
 			result.Cluster.Tags = make(map[string]string)
 		}
@@ -133,7 +133,7 @@ func (sc *SignatureClusterer) ProcessDoc(doc map[string]string) *ClusterResult {
 			result.Cluster.Tags[tagName] = getter(doc)
 		}
 	}
-	return result
+	return result, ok
 }
 
 func (sc *SignatureClusterer) GetClusters() []*Cluster {
@@ -167,9 +167,9 @@ func (pc *PatternClusterer) NumClusters() int {
 	return len(pc.allClusters)
 }
 
-func (pc *PatternClusterer) Process(message string) *ClusterResult {
+func (pc *PatternClusterer) Process(message string) (ClusterResult, bool) {
 	if pc.IgnoreEmpty && strings.TrimSpace(message) == "" {
-		return nil
+		return ClusterResult{}, false
 	}
 
 	tokens := pc.tokenizer.Tokenize(message)
@@ -177,7 +177,7 @@ func (pc *PatternClusterer) Process(message string) *ClusterResult {
 	return pc.ProcessTokens(tokens, message)
 }
 
-func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *ClusterResult {
+func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) (ClusterResult, bool) {
 	sig := TokenListSignature(tokens)
 
 	// Try within same signature group first
@@ -186,7 +186,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 		if canMergeTokenLists(c.Pattern, tokens) {
 			mergeTokenLists(c.Pattern, tokens)
 			c.Count++
-			return &ClusterResult{Cluster: c, IsNew: false}
+			return ClusterResult{Cluster: c, IsNew: false}, true
 		}
 	}
 
@@ -200,7 +200,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 			if canMergeTokenLists(c.Pattern, tokens) {
 				mergeTokenLists(c.Pattern, tokens)
 				c.Count++
-				return &ClusterResult{Cluster: c, IsNew: false}
+				return ClusterResult{Cluster: c, IsNew: false}, true
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 	pc.clustersBySignature[sig] = append(pc.clustersBySignature[sig], c)
 	pc.allClusters = append(pc.allClusters, c)
 
-	return &ClusterResult{Cluster: c, IsNew: true}
+	return ClusterResult{Cluster: c, IsNew: true}, true
 }
 
 func (pc *PatternClusterer) GetClusters() []*Cluster {

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -66,10 +66,8 @@ func (c *Cluster) ToClusterInfo() ClusterInfo {
 
 // ClusterResult is returned when processing a new log message.
 type ClusterResult struct {
-	Cluster   *Cluster
-	IsNew     bool
-	Signature string
-	Pattern   string
+	Cluster *Cluster
+	IsNew   bool
 }
 
 // SignatureClusterer groups logs by exact signature match.
@@ -108,12 +106,7 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 
 	if c, ok := sc.clusters[sig]; ok {
 		c.Count++
-		return &ClusterResult{
-			Cluster:   c,
-			IsNew:     false,
-			Signature: sig,
-			Pattern:   c.PatternString(),
-		}
+		return &ClusterResult{Cluster: c, IsNew: false}
 	}
 
 	c := &Cluster{
@@ -126,12 +119,7 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 	sc.clusters[sig] = c
 	sc.orderedKeys = append(sc.orderedKeys, sig)
 
-	return &ClusterResult{
-		Cluster:   c,
-		IsNew:     true,
-		Signature: sig,
-		Pattern:   c.PatternString(),
-	}
+	return &ClusterResult{Cluster: c, IsNew: true}
 }
 
 func (sc *SignatureClusterer) ProcessDoc(doc map[string]string) *ClusterResult {
@@ -198,12 +186,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 		if canMergeTokenLists(c.Pattern, tokens) {
 			mergeTokenLists(c.Pattern, tokens)
 			c.Count++
-			return &ClusterResult{
-				Cluster:   c,
-				IsNew:     false,
-				Signature: sig,
-				Pattern:   c.PatternString(),
-			}
+			return &ClusterResult{Cluster: c, IsNew: false}
 		}
 	}
 
@@ -217,12 +200,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 			if canMergeTokenLists(c.Pattern, tokens) {
 				mergeTokenLists(c.Pattern, tokens)
 				c.Count++
-				return &ClusterResult{
-					Cluster:   c,
-					IsNew:     false,
-					Signature: c.Signature,
-					Pattern:   c.PatternString(),
-				}
+				return &ClusterResult{Cluster: c, IsNew: false}
 			}
 		}
 	}
@@ -237,12 +215,7 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 	pc.clustersBySignature[sig] = append(pc.clustersBySignature[sig], c)
 	pc.allClusters = append(pc.allClusters, c)
 
-	return &ClusterResult{
-		Cluster:   c,
-		IsNew:     true,
-		Signature: sig,
-		Pattern:   c.PatternString(),
-	}
+	return &ClusterResult{Cluster: c, IsNew: true}
 }
 
 func (pc *PatternClusterer) GetClusters() []*Cluster {

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -275,13 +275,13 @@ func canMergeTokens(a, b Token) bool {
 	case TypeNumericValue:
 		return true
 	case TypeDate, TypeLocalTime:
-		return a.DateFormat == b.DateFormat
+		return a.extra.DateFormat == b.extra.DateFormat
 	case TypeIPv4Address:
 		return true
 	case TypeAbsolutePath, TypePathQueryFragment:
-		return sameSegmentCount(a.Segments, b.Segments)
+		return sameSegmentCount(a.extra.Segments, b.extra.Segments)
 	case TypeURI:
-		if a.Scheme != b.Scheme {
+		if a.extra.Scheme != b.extra.Scheme {
 			return false
 		}
 		return true
@@ -296,10 +296,10 @@ func canMergeTokens(a, b Token) bool {
 	case TypeSeverity:
 		return true
 	case TypeHexDump:
-		return a.DispLen == b.DispLen
+		return a.extra.DispLen == b.extra.DispLen
 	case TypeKVSequence:
-		return a.KVSep == b.KVSep && a.KVPairSep == b.KVPairSep &&
-			a.KVQuote == b.KVQuote && sameKeys(a.KVKeys, b.KVKeys)
+		return a.extra.KVSep == b.extra.KVSep && a.extra.KVPairSep == b.extra.KVPairSep &&
+			a.extra.KVQuote == b.extra.KVQuote && sameKeys(a.extra.KVKeys, b.extra.KVKeys)
 	default:
 		return a.Value == b.Value
 	}

--- a/comp/observer/impl/patterns/cluster.go
+++ b/comp/observer/impl/patterns/cluster.go
@@ -108,9 +108,6 @@ func (sc *SignatureClusterer) ProcessTokens(tokens []Token, message string) *Clu
 
 	if c, ok := sc.clusters[sig]; ok {
 		c.Count++
-		if len(c.Samples) < 5 {
-			c.Samples = append(c.Samples, message)
-		}
 		return &ClusterResult{
 			Cluster:   c,
 			IsNew:     false,
@@ -201,9 +198,6 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 		if canMergeTokenLists(c.Pattern, tokens) {
 			mergeTokenLists(c.Pattern, tokens)
 			c.Count++
-			if len(c.Samples) < 5 {
-				c.Samples = append(c.Samples, message)
-			}
 			return &ClusterResult{
 				Cluster:   c,
 				IsNew:     false,
@@ -223,9 +217,6 @@ func (pc *PatternClusterer) ProcessTokens(tokens []Token, message string) *Clust
 			if canMergeTokenLists(c.Pattern, tokens) {
 				mergeTokenLists(c.Pattern, tokens)
 				c.Count++
-				if len(c.Samples) < 5 {
-					c.Samples = append(c.Samples, message)
-				}
 				return &ClusterResult{
 					Cluster:   c,
 					IsNew:     false,

--- a/comp/observer/impl/patterns/cluster_test.go
+++ b/comp/observer/impl/patterns/cluster_test.go
@@ -20,7 +20,7 @@ func TestSignatureClustererSameMessage(t *testing.T) {
 	sc := NewSignatureClusterer(IDComputeInfo{})
 
 	msg := `10.143.180.25 - - [27/Aug/2020:00:27:02 +0000] "POST /api/v1/series HTTP/1.1" 202 16`
-	r1 := sc.Process(msg)
+	r1, _ := sc.Process(msg)
 	if !r1.IsNew {
 		t.Error("first message should create a new cluster")
 	}
@@ -28,7 +28,7 @@ func TestSignatureClustererSameMessage(t *testing.T) {
 		t.Errorf("expected 1 cluster, got %d", len(sc.GetClusters()))
 	}
 
-	r2 := sc.Process(msg)
+	r2, _ := sc.Process(msg)
 	if r2.IsNew {
 		t.Error("same message should not create a new cluster")
 	}
@@ -53,9 +53,9 @@ func TestSignatureClustererDifferentMessages(t *testing.T) {
 
 func TestSignatureClustererIgnoresEmpty(t *testing.T) {
 	sc := NewSignatureClusterer(IDComputeInfo{})
-	result := sc.Process("")
-	if result != nil {
-		t.Error("empty message should return nil")
+	_, ok := sc.Process("")
+	if ok {
+		t.Error("empty message should return no result")
 	}
 	if len(sc.GetClusters()) != 0 {
 		t.Error("empty message should not create a cluster")
@@ -464,17 +464,17 @@ func TestMergeTokensWildcarding(t *testing.T) {
 func TestEndToEndClustering(t *testing.T) {
 	pc := NewPatternClusterer(IDComputeInfo{})
 
-	r1 := pc.Process("user login from 192.168.1.1")
+	r1, _ := pc.Process("user login from 192.168.1.1")
 	if !r1.IsNew {
 		t.Error("first message should be new")
 	}
 
-	r2 := pc.Process("user login from 10.0.0.1")
+	r2, _ := pc.Process("user login from 10.0.0.1")
 	if r2.IsNew {
 		t.Error("similar message should match existing cluster")
 	}
 
-	r3 := pc.Process("server started on port 8080")
+	r3, _ := pc.Process("server started on port 8080")
 	if !r3.IsNew {
 		t.Error("different message should create new cluster")
 	}

--- a/comp/observer/impl/patterns/signature.go
+++ b/comp/observer/impl/patterns/signature.go
@@ -10,57 +10,49 @@ import "strings"
 // TokenListSignature computes the signature of a list of tokens.
 // Sequences of word-like tokens separated by single '.' or ':' are collapsed into "specialWord".
 func TokenListSignature(tokens []Token) string {
-	if len(tokens) == 0 {
+	n := len(tokens)
+	if n == 0 {
 		return ""
 	}
 
-	sigs := make([]string, len(tokens))
+	sigs := make([]string, n)
 	for i, t := range tokens {
 		sigs[i] = t.Signature()
 	}
 
-	return concatSignatures(tokens, sigs)
-}
-
-// concatSignatures concatenates token signatures, collapsing chains of word-like
-// tokens separated by '.' or ':' into a single "specialWord" signature.
-func concatSignatures(tokens []Token, sigs []string) string {
-	n := len(tokens)
-	resultSigs := make([]string, n)
-	copy(resultSigs, sigs)
-
+	// In-place collapse: chains of word-like tokens separated by '.' or ':' become "specialWord".
+	// Reading always moves forward (lookahead at j+1 is never behind any write position),
+	// so mutating sigs in place is safe.
 	i := 0
 	for i < n {
 		if !isWordLikeForConcat(sigs[i]) {
 			i++
 			continue
 		}
-
 		chainStart := i
 		j := i + 1
 		for j+1 < n {
 			if tokens[j].Type == TypeSpecialCharacter &&
 				(tokens[j].Value == "." || tokens[j].Value == ":") &&
-				j+1 < n && isWordLikeForConcat(sigs[j+1]) {
+				isWordLikeForConcat(sigs[j+1]) {
 				j += 2
 			} else {
 				break
 			}
 		}
-
 		if j > chainStart+1 {
-			resultSigs[chainStart] = "specialWord"
+			sigs[chainStart] = "specialWord"
 			for k := chainStart + 1; k < j; k++ {
-				resultSigs[k] = ""
+				sigs[k] = ""
 			}
 		}
 		i = j
 	}
 
 	var b strings.Builder
-	for i := 0; i < n; i++ {
-		if resultSigs[i] != "" {
-			b.WriteString(resultSigs[i])
+	for _, s := range sigs {
+		if s != "" {
+			b.WriteString(s)
 		}
 	}
 	return b.String()

--- a/comp/observer/impl/patterns/token.go
+++ b/comp/observer/impl/patterns/token.go
@@ -76,50 +76,64 @@ func (t TokenType) String() string {
 	}
 }
 
+// Token is the lean, public representation stored in cluster patterns.
+// Simple token types (word, number, special character, whitespace, severity,
+// HTTP method/status, IPv4/IPv6) carry no extra allocation.
+// Complex types (date, path, URI, authority, email, hex-dump, KV) store
+// their type-specific fields in the private tokenExtra pointer.
 type Token struct {
 	Type  TokenType
 	Value string
 
-	// Word-specific
+	// TypeWord: used for signature ("specialWord" vs "word") and merge guard.
 	HasDigits     bool
 	NeverWildcard bool
 
-	// Date-specific
+	// Set by mergeTokenLists when two differing values collapse to a wildcard.
+	IsWild bool
+
+	// Non-nil only for complex token types; nil for word/number/special/whitespace/
+	// severity/http-method/http-status/ipv4/ipv6.
+	extra *tokenExtra
+}
+
+// tokenExtra holds all type-specific fields for complex token types.
+// Keeping them in a separate heap-allocated struct lets the common simple
+// tokens (TypeWord etc.) avoid carrying ~300 bytes of zero-valued fields.
+type tokenExtra struct {
+	// TypeDate, TypeLocalTime
 	DateFormat string
 
-	// Path-specific
+	// TypeAbsolutePath, TypePathQueryFragment, TypeURI
 	Segments []string
 	Query    *string
 	Fragment *string
 
-	// URI-specific
+	// TypeURI
 	Scheme    string
 	Authority *Token
 	Path      *Token
 
-	// Authority-specific
+	// TypeAuthority
 	Host     *Token
 	Port     int
 	HasPort  bool
 	UserInfo string
 	HasUser  bool
 
-	// Email-specific
+	// TypeEmailAddress
 	LocalPart string
 	Domain    string
 
-	// HexDump-specific
+	// TypeHexDump
 	DispLen  int
 	HasASCII bool
 
-	// KV-specific
+	// TypeKVSequence
 	KVKeys    []string
 	KVSep     string
 	KVPairSep string
 	KVQuote   string
-
-	// Merging
-	IsWild bool
 }
 
 func WordToken(text string) Token {
@@ -143,11 +157,11 @@ func WhitespaceToken(count int) Token {
 }
 
 func DateToken(format, rawText string) Token {
-	return Token{Type: TypeDate, Value: rawText, DateFormat: format}
+	return Token{Type: TypeDate, Value: rawText, extra: &tokenExtra{DateFormat: format}}
 }
 
 func LocalTimeToken(format, rawText string) Token {
-	return Token{Type: TypeLocalTime, Value: rawText, DateFormat: format}
+	return Token{Type: TypeLocalTime, Value: rawText, extra: &tokenExtra{DateFormat: format}}
 }
 
 func IPv4Token(text string, _, _, _, _ int) Token {
@@ -156,9 +170,9 @@ func IPv4Token(text string, _, _, _, _ int) Token {
 
 func PathToken(segments []string) Token {
 	return Token{
-		Type:     TypeAbsolutePath,
-		Value:    "/" + strings.Join(segments, "/"),
-		Segments: segments,
+		Type:  TypeAbsolutePath,
+		Value: "/" + strings.Join(segments, "/"),
+		extra: &tokenExtra{Segments: segments},
 	}
 }
 
@@ -171,11 +185,9 @@ func PathQueryFragmentToken(segments []string, query, fragment *string) Token {
 		v += "#" + *fragment
 	}
 	return Token{
-		Type:     TypePathQueryFragment,
-		Value:    v,
-		Segments: segments,
-		Query:    query,
-		Fragment: fragment,
+		Type:  TypePathQueryFragment,
+		Value: v,
+		extra: &tokenExtra{Segments: segments, Query: query, Fragment: fragment},
 	}
 }
 
@@ -194,13 +206,9 @@ func URIToken(scheme string, authority *Token, path *Token, query, fragment *str
 		v += "#" + *fragment
 	}
 	return Token{
-		Type:      TypeURI,
-		Value:     v,
-		Scheme:    scheme,
-		Authority: authority,
-		Path:      path,
-		Query:     query,
-		Fragment:  fragment,
+		Type:  TypeURI,
+		Value: v,
+		extra: &tokenExtra{Scheme: scheme, Authority: authority, Path: path, Query: query, Fragment: fragment},
 	}
 }
 
@@ -216,22 +224,17 @@ func AuthorityToken(host *Token, port int, hasPort bool, userInfo string, hasUse
 		v += fmt.Sprintf(":%d", port)
 	}
 	return Token{
-		Type:     TypeAuthority,
-		Value:    v,
-		Host:     host,
-		Port:     port,
-		HasPort:  hasPort,
-		UserInfo: userInfo,
-		HasUser:  hasUser,
+		Type:  TypeAuthority,
+		Value: v,
+		extra: &tokenExtra{Host: host, Port: port, HasPort: hasPort, UserInfo: userInfo, HasUser: hasUser},
 	}
 }
 
 func EmailToken(localPart, domain string) Token {
 	return Token{
-		Type:      TypeEmailAddress,
-		Value:     localPart + "@" + domain,
-		LocalPart: localPart,
-		Domain:    domain,
+		Type:  TypeEmailAddress,
+		Value: localPart + "@" + domain,
+		extra: &tokenExtra{LocalPart: localPart, Domain: domain},
 	}
 }
 
@@ -249,21 +252,16 @@ func SeverityToken(level string) Token {
 
 func HexDumpToken(text string, dispLen int, hasASCII bool) Token {
 	return Token{
-		Type:     TypeHexDump,
-		Value:    text,
-		DispLen:  dispLen,
-		HasASCII: hasASCII,
+		Type:  TypeHexDump,
+		Value: text,
+		extra: &tokenExtra{DispLen: dispLen, HasASCII: hasASCII},
 	}
 }
 
 func KVSequenceToken(keys []string, sep, pairSep, quote string) Token {
 	return Token{
-		Type:      TypeKVSequence,
-		Value:     "",
-		KVKeys:    keys,
-		KVSep:     sep,
-		KVPairSep: pairSep,
-		KVQuote:   quote,
+		Type:  TypeKVSequence,
+		extra: &tokenExtra{KVKeys: keys, KVSep: sep, KVPairSep: pairSep, KVQuote: quote},
 	}
 }
 
@@ -279,9 +277,9 @@ func (t Token) Signature() string {
 	case TypeWhitespace:
 		return " "
 	case TypeDate:
-		return t.DateFormat
+		return t.extra.DateFormat
 	case TypeLocalTime:
-		return "local-time:" + t.DateFormat
+		return "local-time:" + t.extra.DateFormat
 	case TypeIPv4Address:
 		return "ipv4"
 	case TypeIPv6Address:
@@ -320,41 +318,41 @@ func wordSignature(t Token) string {
 
 func pathQueryFragSignature(t Token) string {
 	sig := "AbsolutePath"
-	if t.Query != nil {
-		sig += "?" + *t.Query
+	if t.extra.Query != nil {
+		sig += "?" + *t.extra.Query
 	}
-	if t.Fragment != nil {
-		sig += "#" + *t.Fragment
+	if t.extra.Fragment != nil {
+		sig += "#" + *t.extra.Fragment
 	}
 	return sig
 }
 
 func uriSignature(t Token) string {
-	sig := t.Scheme + "://"
-	if t.Authority != nil {
-		sig += t.Authority.Signature()
+	sig := t.extra.Scheme + "://"
+	if t.extra.Authority != nil {
+		sig += t.extra.Authority.Signature()
 	}
-	if t.Path != nil {
-		sig += t.Path.Signature()
+	if t.extra.Path != nil {
+		sig += t.extra.Path.Signature()
 	}
-	if t.Query != nil {
-		sig += "?" + *t.Query
+	if t.extra.Query != nil {
+		sig += "?" + *t.extra.Query
 	}
-	if t.Fragment != nil {
-		sig += "#" + *t.Fragment
+	if t.extra.Fragment != nil {
+		sig += "#" + *t.extra.Fragment
 	}
 	return sig
 }
 
 func authoritySignature(t Token) string {
 	sig := ""
-	if t.HasUser {
-		sig += t.UserInfo + "@"
+	if t.extra.HasUser {
+		sig += t.extra.UserInfo + "@"
 	}
-	if t.Host != nil {
-		sig += hostSignature(*t.Host)
+	if t.extra.Host != nil {
+		sig += hostSignature(*t.extra.Host)
 	}
-	if t.HasPort {
+	if t.extra.HasPort {
 		sig += ":port"
 	}
 	return sig
@@ -373,24 +371,24 @@ func hostSignature(t Token) string {
 
 func hexDumpSignature(t Token) string {
 	ascii := "F"
-	if t.HasASCII {
+	if t.extra.HasASCII {
 		ascii = "T"
 	}
-	return fmt.Sprintf("HexDump[dl:%d|ascii:%s]", t.DispLen, ascii)
+	return fmt.Sprintf("HexDump[dl:%d|ascii:%s]", t.extra.DispLen, ascii)
 }
 
 func kvSignature(t Token) string {
-	sorted := make([]string, len(t.KVKeys))
-	copy(sorted, t.KVKeys)
+	sorted := make([]string, len(t.extra.KVKeys))
+	copy(sorted, t.extra.KVKeys)
 	sortStrings(sorted)
 	unique := uniqueStrings(sorted)
 	return fmt.Sprintf("KV%d=[%s][q:%s|s:%s%s|ps:%s]KV",
 		len(unique),
 		strings.Join(unique, ", "),
-		t.KVQuote,
-		t.KVSep,
-		t.KVSep,
-		t.KVPairSep,
+		t.extra.KVQuote,
+		t.extra.KVSep,
+		t.extra.KVSep,
+		t.extra.KVPairSep,
 	)
 }
 

--- a/comp/observer/impl/patterns/token.go
+++ b/comp/observer/impl/patterns/token.go
@@ -120,7 +120,6 @@ type Token struct {
 
 	// Merging
 	IsWild bool
-	Values []string
 }
 
 func WordToken(text string) Token {

--- a/comp/observer/impl/patterns/tokenizer_test.go
+++ b/comp/observer/impl/patterns/tokenizer_test.go
@@ -72,25 +72,25 @@ func TestTokenizePathWithQuery(t *testing.T) {
 	if len(tokens) != 1 || tokens[0].Type != TypePathQueryFragment {
 		t.Errorf("expected PathQueryFragment, got %v", tok(tokens))
 	}
-	if tokens[0].Query == nil {
+	if tokens[0].extra.Query == nil {
 		t.Error("expected non-nil query")
 	}
 
 	tokens = NewTokenizer().Tokenize("/reports/search_by_client?query")
-	if tokens[0].Query == nil || *tokens[0].Query != "query" {
-		t.Errorf("expected query='query', got %v", tokens[0].Query)
+	if tokens[0].extra.Query == nil || *tokens[0].extra.Query != "query" {
+		t.Errorf("expected query='query', got %v", tokens[0].extra.Query)
 	}
 
 	tokens = NewTokenizer().Tokenize("/reports/search_by_client#fragment")
-	if tokens[0].Fragment == nil || *tokens[0].Fragment != "fragment" {
-		t.Errorf("expected fragment='fragment', got %v", tokens[0].Fragment)
+	if tokens[0].extra.Fragment == nil || *tokens[0].extra.Fragment != "fragment" {
+		t.Errorf("expected fragment='fragment', got %v", tokens[0].extra.Fragment)
 	}
 
 	tokens = NewTokenizer().Tokenize("/reports/search_by_client?query#fragment")
-	if tokens[0].Query == nil || *tokens[0].Query != "query" {
+	if tokens[0].extra.Query == nil || *tokens[0].extra.Query != "query" {
 		t.Error("expected query='query'")
 	}
-	if tokens[0].Fragment == nil || *tokens[0].Fragment != "fragment" {
+	if tokens[0].extra.Fragment == nil || *tokens[0].extra.Fragment != "fragment" {
 		t.Error("expected fragment='fragment'")
 	}
 }
@@ -110,7 +110,7 @@ func TestTokenizePathQuerySpace(t *testing.T) {
 	if tokens[2].Type != TypePathQueryFragment {
 		t.Errorf("token[2] expected PathQueryFragment, got %v", tokens[2].Type)
 	}
-	if tokens[2].Query == nil || *tokens[2].Query != "param1=value1" {
+	if tokens[2].extra.Query == nil || *tokens[2].extra.Query != "param1=value1" {
 		t.Errorf("token[2] expected query 'param1=value1'")
 	}
 }
@@ -380,8 +380,8 @@ func TestTokenizeIPv4(t *testing.T) {
 	if len(tokens) != 1 || tokens[0].Type != TypeAuthority {
 		t.Errorf("expected Authority for IP:port, got %v", tok(tokens))
 	}
-	if !tokens[0].HasPort || tokens[0].Port != 40032 {
-		t.Errorf("expected port 40032, got port=%d hasPort=%v", tokens[0].Port, tokens[0].HasPort)
+	if !tokens[0].extra.HasPort || tokens[0].extra.Port != 40032 {
+		t.Errorf("expected port 40032, got port=%d hasPort=%v", tokens[0].extra.Port, tokens[0].extra.HasPort)
 	}
 
 	// @IP
@@ -403,7 +403,7 @@ func TestTokenizeIPv4FromSlash(t *testing.T) {
 	tokens := NewTokenizer().Tokenize("connection from /172.20.162.38:40032 is closed")
 	found := false
 	for _, tok := range tokens {
-		if tok.Type == TypeAuthority && tok.HasPort {
+		if tok.Type == TypeAuthority && tok.extra.HasPort {
 			found = true
 			break
 		}
@@ -425,26 +425,26 @@ func TestTokenizeHexDump(t *testing.T) {
 		dumpTokens(t, "0010: DB 8A")
 		t.Fatal("expected HexDump token")
 	}
-	if tokens[0].DispLen != 4 {
-		t.Errorf("expected DispLen=4, got %d", tokens[0].DispLen)
+	if tokens[0].extra.DispLen != 4 {
+		t.Errorf("expected DispLen=4, got %d", tokens[0].extra.DispLen)
 	}
-	if tokens[0].HasASCII {
+	if tokens[0].extra.HasASCII {
 		t.Error("expected HasASCII=false")
 	}
 
 	tokens = tokenizer.Tokenize("00000000: 02 f3 82 00")
-	if tokens[0].Type != TypeHexDump || tokens[0].DispLen != 8 {
+	if tokens[0].Type != TypeHexDump || tokens[0].extra.DispLen != 8 {
 		t.Errorf("expected HexDump with DispLen=8")
 	}
 
 	tokens = tokenizer.Tokenize("0000: AA AA AA")
-	if tokens[0].Type != TypeHexDump || tokens[0].DispLen != 4 {
+	if tokens[0].Type != TypeHexDump || tokens[0].extra.DispLen != 4 {
 		t.Errorf("expected HexDump with DispLen=4")
 	}
 
 	tokens = tokenizer.Tokenize("1C40: 82 0B A2")
-	if tokens[0].Type != TypeHexDump || tokens[0].DispLen != 4 {
-		t.Errorf("expected HexDump '1C40: 82 0B A2' with DispLen=4, got type=%v dl=%d", tokens[0].Type, tokens[0].DispLen)
+	if tokens[0].Type != TypeHexDump || tokens[0].extra.DispLen != 4 {
+		t.Errorf("expected HexDump '1C40: 82 0B A2' with DispLen=4, got type=%v dl=%d", tokens[0].Type, tokens[0].extra.DispLen)
 	}
 }
 
@@ -457,7 +457,7 @@ func TestTokenizeHexDumpWithAscii(t *testing.T) {
 		dumpTokens(t, "00000000: 01 02 03 04 05 Ascii")
 		t.Fatal("expected HexDump token")
 	}
-	if !tokens[0].HasASCII {
+	if !tokens[0].extra.HasASCII {
 		t.Error("expected HasASCII=true")
 	}
 
@@ -466,7 +466,7 @@ func TestTokenizeHexDumpWithAscii(t *testing.T) {
 		dumpTokens(t, "0010: DB 8A 8E 01 00 .....")
 		t.Fatal("expected HexDump")
 	}
-	if !tokens[0].HasASCII {
+	if !tokens[0].extra.HasASCII {
 		t.Error("expected HasASCII=true for '.....''")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Various optimizations to the pattern library:

- No double alloc for TokenListSignature
- Remove token.values
- ClusterResult move and not allocate
- No more pattern / signature in results
- Single cluster sample (TBD if we fully remove them)
- Cluster tags are lazy initiated (TBD if we remove them as well)
- Split token struct for private / public access and reduce accumulated memory

#### Benchmark

Scenario benchmark, inused memory for tokenizer (MiB, 10x average):

| Scenario |  Before | After |
| - | - | - |
| Food delivery | 11.142 | 10.936 |
| Postmark | 40.592 | 37.330 |

Log extraction benchmark (BenchmarkLogExtraction_SeriesCount):
Series Count | Metric | Before | After | Delta | % Change
-- | -- | -- | -- | -- | --
series=50 | time/op | 2.78ms | 1.46ms | -1.32ms | -90.4%
  | B/op | 1,451,420 | 465,695 | -985,725 | -211.5%
  | allocs | 5,604 | 5,281 | -323 | -6.1%
series=200 | time/op | 11.26ms | 6.20ms | -5.06ms | -81.6%
  | B/op | 5,773,306 | 1,845,582 | -3,927,724 | -212.8%
  | allocs | 22,186 | 20,933 | -1,253 | -6.0%
series=500 | time/op | 21.95ms | 15.44ms | -6.51ms | -42.2%
  | B/op | 14,574,145 | 4,753,167 | -9,820,978 | -206.6%
  | allocs | 55,339 | 52,214 | -3,125 | -6.0%
series=2000 | time/op | 87.56ms | 60.53ms | -27.03ms | -44.6%
  | B/op | 58,630,783 | 19,531,364 | -39,099,419 | -200.0%
  | allocs | 220,972 | 208,591 | -12,381 | -5.9%

Log extraction benchmark (BenchmarkLogExtraction_DiversePatterns):

Series Count | Metric | Before | After | Delta | % Change
-- | -- | -- | -- | -- | --
series=50 | time/op | 2.53ms | 2.09ms | -0.44ms | -17.4%
  | B/op | 1,479,187 | 470,439 | -1,008,748 | -68.2%
  | allocs | 5,931 | 5,556 | -375 | -6.3%
series=200 | time/op | 9.66ms | 6.61ms | -3.05ms | -31.6%
  | B/op | 5,862,893 | 1,882,651 | -3,980,242 | -67.9%
  | allocs | 22,917 | 21,550 | -1,367 | -6.0%
series=500 | time/op | 24.25ms | 15.93ms | -8.32ms | -34.3%
  | B/op | 14,647,991 | 4,715,852 | -9,932,139 | -67.8%
  | allocs | 56,668 | 53,521 | -3,147 | -5.6%
series=2000 | time/op | 90.98ms | 62.28ms | -28.70ms | -31.5%
  | B/op | 58,681,225 | 19,319,143 | -39,362,082 | -67.1%
  | allocs | 225,235 | 213,375 | -11,860 | -5.3%

### Motivation

### Describe how you validated your changes

### Additional Notes
