### PR TITLE
Make Bazel ignore `build` directories

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,7 @@
+# ignore_directories() in REPO.bazel does not yet reliably prevent Bazel from traversing symlinks:
+# https://github.com/bazelbuild/bazel/pull/24203#issuecomment-3499025997
+# Keep the symlink-prone entries here as well until that is resolved.
 .cache/
-target/
 # bazel convenience symlinks suddenly caused issues
 # inside of arm64 Linux containers.
 bazel-datadog-agent/

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,13 +23,13 @@
 /.vscode/                               @DataDog/agent-devx
 
 # Bazel configuration
+/*.bazel*                               @DataDog/agent-build
 /.adms/                                 @DataDog/agent-build
 /.bazel*                                @DataDog/agent-build
-/bazel/                                 @DataDog/agent-build
-/bazel/configs/rust.bazelrc               @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
-/MODULE.bazel*                          @DataDog/agent-build
-/deps/                                  @DataDog/agent-build
 /.buildifier.json                       @DataDog/agent-build
+/bazel/                                 @DataDog/agent-build
+/bazel/configs/rust.bazelrc             @DataDog/agent-discovery @DataDog/agent-runtimes @DataDog/agent-build
+/deps/                                  @DataDog/agent-build
 
 # The owner should really be to a team that does not exist yet. It would cover supply chain in general.
 # For now, agent-build are the experts in that.

--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,0 +1,6 @@
+ignore_directories([
+    "**/build",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251
+    ".cache",  # in-workspace cache: GitLab jobs, GitHub actions
+    "bazel-*",  # bazel convenience symlinks: suddenly caused issues inside arm64 Linux containers
+    "target",  # cargo build creates it where Cargo.toml lives
+])

--- a/tools/bazel
+++ b/tools/bazel
@@ -21,6 +21,7 @@ if [ ! -d "${XDG_CACHE_HOME:-}" ]; then
 fi
 
 # Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
+extra_args=()
 if [ -n "${XDG_CACHE_HOME:-}" ]; then
   if [[ "$XDG_CACHE_HOME" != /* ]]; then
     >&2 echo "🔴 XDG_CACHE_HOME ($XDG_CACHE_HOME) must denote an absolute path!"
@@ -29,19 +30,20 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
   unset GOCACHE                               # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
   export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
   unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
+  [ -n "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && extra_args+=(--config=ci)
+  # https://github.com/bazelbuild/bazel/issues/26384
+  [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
 fi
 
 # "--startup cmd ..." -> "--startup cmd --config=ci ..."
-if [[ $# -gt 0 && -n "${CI:-}" ]]; then
+if [[ $# -gt 0 && ${#extra_args[@]} -gt 0 ]]; then
   args=()
   cmd=
   for arg in "$@"; do
     args+=("$arg")
     if [[ -z "$cmd" && "$arg" != -* ]]; then
       cmd=$arg
-      [ -z "${GITHUB_ACTIONS:-}" ] && args+=(--config=ci)
-      # https://github.com/bazelbuild/bazel/issues/26384
-      [ "${XDG_CACHE_HOME:-}" = "$(dirname "$(dirname "$0")")/.cache" ] && args+=(--repo_contents_cache=)
+      args+=("${extra_args[@]}")
     fi
   done
   set -- "${args[@]}"

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -22,6 +22,7 @@ if not exist "%XDG_CACHE_HOME%" (
 )
 
 :: Ensure `bazel` & managed toolchains honor `XDG_CACHE_HOME` as per https://wiki.archlinux.org/title/XDG_Base_Directory
+set "extra_args="
 if defined XDG_CACHE_HOME (
   set "XDG_CACHE_HOME=!XDG_CACHE_HOME:/=\!"
   if "!XDG_CACHE_HOME:~1,2!" neq ":\" if "!XDG_CACHE_HOME:~0,2!" neq "\\" (
@@ -37,12 +38,15 @@ if defined XDG_CACHE_HOME (
   :: https://github.com/bazelbuild/bazel/issues/27808
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
-) else (
-  for %%i in ("%~dp0..\.cache") do set "XDG_CACHE_HOME=%%~fi"
+  if defined CI if not defined GITHUB_ACTIONS set "extra_args=--config=ci"
+  :: https://github.com/bazelbuild/bazel/issues/26384
+  for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" (
+    if defined extra_args (set "extra_args=!extra_args! --repo_contents_cache=") else set "extra_args=--repo_contents_cache="
+  )
 )
 
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions
-set "more_than_260_chars=!XDG_CACHE_HOME!\more-than-260-chars"
+for %%i in ("%~dp0..\.cache") do if defined XDG_CACHE_HOME (set "more_than_260_chars=!XDG_CACHE_HOME!") else set "more_than_260_chars=%%~fi"
 for /l %%i in (1,1,26) do set "more_than_260_chars=!more_than_260_chars!\123456789"
 if not exist "!more_than_260_chars!" (
   2>nul mkdir "!more_than_260_chars!"
@@ -55,20 +59,12 @@ if not exist "!more_than_260_chars!" (
 )
 
 set "args=%*"
-if defined args if defined CI (
-  set "ci_args="
-  if not defined GITHUB_ACTIONS set "ci_args=--config=ci"
-  :: https://github.com/bazelbuild/bazel/issues/26384
-  for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" (
-    if defined ci_args (set "ci_args=!ci_args! --repo_contents_cache=") else set "ci_args=--repo_contents_cache="
-  )
-  if defined ci_args call :inject_ci_args
-)
+if defined args if defined extra_args call :insert_extra_args
 "%BAZEL_REAL%" !bazel_home_startup_option! !args!
 exit /b !errorlevel!
 
 :: "--startup cmd ..." -> "--startup cmd --config=ci ..."
-:inject_ci_args
+:insert_extra_args
 set "startup_args="
 set "next_args=!args!"
 :parse_next_arg
@@ -81,7 +77,7 @@ for /f "tokens=1* delims= " %%i in ("!next_args!") do (
   ) else (
     if defined startup_args set "startup_args=!startup_args:~1! "
     set "cmd=%%i"
-    set "args=!startup_args!!cmd! !ci_args! %%j"
+    set "args=!startup_args!!cmd! !extra_args! %%j"
   )
 )
 if not defined cmd if defined next_args goto :parse_next_arg


### PR DESCRIPTION
### What does this PR do?
Add `**/build` to `REPO.bazel`'s `ignore_directories()`, partially replacing `.bazelignore`, and adjust `CODEOWNERS` accordingly.

### Motivation
When `bazel` runs inside a Linux container on macOS via Docker Desktop, the workspace is typically mounted on a case-insensitive filesystem where `BUILD` and `build` are indistinguishable (docker/desktop-feedback#251).
#48455 addressed this for `gazelle` by restricting it to `BUILD.bazel` files only.
Bazel's own directory traversal, however, remained exposed to the same confusion.

`REPO.bazel` gained `ignore_directories()` in Bazel **8.0** (bazelbuild/bazel#24203), introduced as a complement to `.bazelignore`
> to provide a migration path off of that weird single-purpose configuration file.

It supports Bazel's native `glob()` semantics, making `**/build` a natural fit.

Unfortunately (there's always a _but_...), it doesn't always work for symlinked directories ([example](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/1544684745#L117)):
```
ERROR: infinite symlink expansion detected
[start of symlink chain]
/go/src/github.com/DataDog/datadog-agent
/go/src/github.com/DataDog/datadog-agent/.cache/bazel/_bazel_root/8595a61ca643e2561dc364b98a410786/external/_main
[end of symlink chain]
```
... which was reported here: https://github.com/bazelbuild/bazel/pull/24203#issuecomment-3499025997
So, for the time being, we also have to keep `.bazelignore`, but shrunk down to the bare minimum, until the issue is fixed upstream.

### Additional Notes
Coming from Bazel 7, I was not aware of `REPO.bazel`, otherwise I would have added it in the first place instead of `.bazelignore` (#40153).

In `CODEOWNERS`, `/MODULE.bazel*` is replaced by `/*.bazel*` to cover `REPO.bazel` as well as any future root-level `.bazel` files.

In order to reproduce the `infinite symlink expansion detected` mentioned above, I had to configure my local `bazel` command line invocation as in CI, which surfaced the fact that `tools/bazel*` scripts had to be adjusted for this purpose. In particular, `--repo_contents_cache=` must be set when `XDG_CACHE_HOME=$PWD/.cache` (bazelbuild/bazel#26384). This is now fixed as well.