### PR TITLE
[Backport 7.78.x] [CWS] Reduce memory usage of process snapshot and event replay

### DIFF
--- a/pkg/security/probe/probe_ebpf.go
+++ b/pkg/security/probe/probe_ebpf.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -37,6 +36,7 @@ import (
 	"github.com/DataDog/datadog-go/v5/statsd"
 	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/ebpf-manager/tracefs"
+	gopsutilprocess "github.com/shirou/gopsutil/v4/process"
 
 	"github.com/DataDog/datadog-agent/pkg/config/env"
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
@@ -57,6 +57,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/probe/eventstream/ringbuffer"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/kfilters"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/procfs"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/sysctl"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
@@ -836,18 +837,24 @@ func (p *EBPFProbe) replayEvents(notifyConsumers bool) {
 
 		events = append(events, event)
 
-		// Replay bound sockets from entry snapshot data
-		for _, s := range entry.SnapshottedBoundSockets {
-			bindEvent := p.newBindEventFromReplay(entry, s)
-			bindEvent.Source = model.EventSourceReplay
-			events = append(events, bindEvent)
-		}
+		// Replay mmaped files (only needed if SBOM resolver is enabled)
+		if p.config.RuntimeSecurity.SBOMResolverEnabled {
+			proc, err := gopsutilprocess.NewProcess(int32(entry.Pid))
+			if err != nil {
+				return
+			}
 
-		// Replay mmaped files from entry snapshot data
-		for _, f := range entry.SnapshottedMmapedFiles {
-			openEvent := p.newOpenEventFromReplay(entry, f)
-			openEvent.Source = model.EventSourceReplay
-			events = append(events, openEvent)
+			mmapedFiles, err := procfs.GetMmapedFiles(proc)
+			if err != nil {
+				seclog.Debugf("mmaped files snapshot failed for (pid: %v): %s", entry.Pid, err)
+				return
+			}
+
+			for _, f := range mmapedFiles {
+				openEvent := p.newOpenEventFromReplay(entry, f)
+				openEvent.Source = model.EventSourceReplay
+				events = append(events, openEvent)
+			}
 		}
 	}
 
@@ -3525,30 +3532,6 @@ func (p *EBPFProbe) newEBPFPooledEventFromPCE(entry *model.ProcessCacheEntry) *m
 	event.ProcessCacheEntry = entry
 	event.ProcessContext = &entry.ProcessContext
 	event.Exec.Process = &entry.Process
-
-	return event
-}
-
-// newBindEventFromReplay returns a new bind event with a process context
-func (p *EBPFProbe) newBindEventFromReplay(entry *model.ProcessCacheEntry, snapshottedBind model.SnapshottedBoundSocket) *model.Event {
-	event := p.getPoolEvent()
-	event.Timestamp = time.Now()
-	event.TimestampRaw = uint64(p.Resolvers.TimeResolver.ComputeMonotonicTimestamp(event.Timestamp))
-	event.Type = uint32(model.BindEventType)
-	event.ProcessCacheEntry = entry
-	event.ProcessContext = &entry.ProcessContext
-	event.AddToFlags(model.EventFlagsFromReplay)
-
-	event.Bind.SyscallEvent.Retval = 0
-	event.Bind.AddrFamily = snapshottedBind.Family
-	event.Bind.Addr.IPNet.IP = snapshottedBind.IP
-	event.Bind.Protocol = snapshottedBind.Protocol
-	if snapshottedBind.Family == unix.AF_INET {
-		event.Bind.Addr.IPNet.Mask = net.CIDRMask(32, 32)
-	} else {
-		event.Bind.Addr.IPNet.Mask = net.CIDRMask(128, 128)
-	}
-	event.Bind.Addr.Port = snapshottedBind.Port
 
 	return event
 }

--- a/pkg/security/resolvers/process/resolver_ebpf.go
+++ b/pkg/security/resolvers/process/resolver_ebpf.go
@@ -34,7 +34,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/config"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/managerhelper"
-	"github.com/DataDog/datadog-agent/pkg/security/probe/procfs"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/cgroup"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/envvars"
 	"github.com/DataDog/datadog-agent/pkg/security/resolvers/mount"
@@ -1348,17 +1347,6 @@ func (p *EBPFResolver) newEntryFromProcfs(proc *process.Process, filledProc *uti
 	if err := p.enrichEventFromProcfs(entry, proc, filledProc); err != nil {
 		seclog.Trace(err)
 		return nil
-	}
-
-	var err error
-	entry.SnapshottedMmapedFiles, err = procfs.GetMmapedFiles(proc)
-	if err != nil {
-		seclog.Debugf("mmaped files snapshot failed for (pid: %v): %s", proc.Pid, err)
-	}
-
-	entry.SnapshottedBoundSockets, err = procfs.NewBoundSocketSnapshotter().GetBoundSockets(proc)
-	if err != nil {
-		seclog.Debugf("error while listing sockets (pid: %v): %s", proc.Pid, err)
 	}
 
 	// use the inode from the pid context if set so that we don't propagate a potentially wrong inode

--- a/pkg/security/secl/model/event_deep_copy_unix.go
+++ b/pkg/security/secl/model/event_deep_copy_unix.go
@@ -200,8 +200,6 @@ func deepCopyProcessCacheEntryPtr(fieldToCopy *ProcessCacheEntry) *ProcessCacheE
 	}
 	copied := &ProcessCacheEntry{}
 	copied.ProcessContext = deepCopyProcessContext(fieldToCopy.ProcessContext)
-	copied.SnapshottedBoundSockets = deepCopySnapshottedBoundSocketArr(fieldToCopy.SnapshottedBoundSockets)
-	copied.SnapshottedMmapedFiles = deepCopySnapshottedMmapedFileArr(fieldToCopy.SnapshottedMmapedFiles)
 	return copied
 }
 func deepCopyProcessContext(fieldToCopy ProcessContext) ProcessContext {
@@ -488,49 +486,6 @@ func deepCopyProcess(fieldToCopy Process) Process {
 	copied.UserSession = deepCopyUserSessionContext(fieldToCopy.UserSession)
 	return copied
 }
-func deepCopySnapshottedBoundSocketArr(fieldToCopy []SnapshottedBoundSocket) []SnapshottedBoundSocket {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]SnapshottedBoundSocket, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = deepCopySnapshottedBoundSocket(fieldToCopy[i])
-	}
-	return copied
-}
-func deepCopybyteArr(fieldToCopy []byte) []byte {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]byte, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = fieldToCopy[i]
-	}
-	return copied
-}
-func deepCopySnapshottedBoundSocket(fieldToCopy SnapshottedBoundSocket) SnapshottedBoundSocket {
-	copied := SnapshottedBoundSocket{}
-	copied.Family = fieldToCopy.Family
-	copied.IP = deepCopybyteArr(fieldToCopy.IP)
-	copied.Port = fieldToCopy.Port
-	copied.Protocol = fieldToCopy.Protocol
-	return copied
-}
-func deepCopySnapshottedMmapedFileArr(fieldToCopy []SnapshottedMmapedFile) []SnapshottedMmapedFile {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]SnapshottedMmapedFile, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = deepCopySnapshottedMmapedFile(fieldToCopy[i])
-	}
-	return copied
-}
-func deepCopySnapshottedMmapedFile(fieldToCopy SnapshottedMmapedFile) SnapshottedMmapedFile {
-	copied := SnapshottedMmapedFile{}
-	copied.Path = fieldToCopy.Path
-	return copied
-}
 func deepCopyProcessContextPtr(fieldToCopy *ProcessContext) *ProcessContext {
 	if fieldToCopy == nil {
 		return nil
@@ -776,6 +731,16 @@ func deepCopyExitEvent(fieldToCopy ExitEvent) ExitEvent {
 func deepCopyFailedDNSEvent(fieldToCopy FailedDNSEvent) FailedDNSEvent {
 	copied := FailedDNSEvent{}
 	copied.Payload = deepCopybyteArr(fieldToCopy.Payload)
+	return copied
+}
+func deepCopybyteArr(fieldToCopy []byte) []byte {
+	if fieldToCopy == nil {
+		return nil
+	}
+	copied := make([]byte, len(fieldToCopy))
+	for i := range fieldToCopy {
+		copied[i] = fieldToCopy[i]
+	}
 	return copied
 }
 func deepCopyIMDSEvent(fieldToCopy IMDSEvent) IMDSEvent {

--- a/pkg/security/secl/model/event_deep_copy_windows.go
+++ b/pkg/security/secl/model/event_deep_copy_windows.go
@@ -67,8 +67,6 @@ func deepCopyProcessCacheEntryPtr(fieldToCopy *ProcessCacheEntry) *ProcessCacheE
 	}
 	copied := &ProcessCacheEntry{}
 	copied.ProcessContext = deepCopyProcessContext(fieldToCopy.ProcessContext)
-	copied.SnapshottedBoundSockets = deepCopySnapshottedBoundSocketArr(fieldToCopy.SnapshottedBoundSockets)
-	copied.SnapshottedMmapedFiles = deepCopySnapshottedMmapedFileArr(fieldToCopy.SnapshottedMmapedFiles)
 	return copied
 }
 func deepCopyProcessContext(fieldToCopy ProcessContext) ProcessContext {
@@ -173,49 +171,6 @@ func deepCopyProcess(fieldToCopy Process) Process {
 	copied.ScrubbedCmdLineResolved = fieldToCopy.ScrubbedCmdLineResolved
 	copied.TracerTags = deepCopystringArr(fieldToCopy.TracerTags)
 	copied.User = fieldToCopy.User
-	return copied
-}
-func deepCopySnapshottedBoundSocketArr(fieldToCopy []SnapshottedBoundSocket) []SnapshottedBoundSocket {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]SnapshottedBoundSocket, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = deepCopySnapshottedBoundSocket(fieldToCopy[i])
-	}
-	return copied
-}
-func deepCopybyteArr(fieldToCopy []byte) []byte {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]byte, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = fieldToCopy[i]
-	}
-	return copied
-}
-func deepCopySnapshottedBoundSocket(fieldToCopy SnapshottedBoundSocket) SnapshottedBoundSocket {
-	copied := SnapshottedBoundSocket{}
-	copied.Family = fieldToCopy.Family
-	copied.IP = deepCopybyteArr(fieldToCopy.IP)
-	copied.Port = fieldToCopy.Port
-	copied.Protocol = fieldToCopy.Protocol
-	return copied
-}
-func deepCopySnapshottedMmapedFileArr(fieldToCopy []SnapshottedMmapedFile) []SnapshottedMmapedFile {
-	if fieldToCopy == nil {
-		return nil
-	}
-	copied := make([]SnapshottedMmapedFile, len(fieldToCopy))
-	for i := range fieldToCopy {
-		copied[i] = deepCopySnapshottedMmapedFile(fieldToCopy[i])
-	}
-	return copied
-}
-func deepCopySnapshottedMmapedFile(fieldToCopy SnapshottedMmapedFile) SnapshottedMmapedFile {
-	copied := SnapshottedMmapedFile{}
-	copied.Path = fieldToCopy.Path
 	return copied
 }
 func deepCopyProcessContextPtr(fieldToCopy *ProcessContext) *ProcessContext {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -535,10 +535,6 @@ type SnapshottedMmapedFile struct {
 // ProcessCacheEntry this struct holds process context kept in the process tree
 type ProcessCacheEntry struct {
 	ProcessContext
-
-	// Snapshot data (only populated during initial snapshot, used for event replay)
-	SnapshottedBoundSockets []SnapshottedBoundSocket `field:"-"`
-	SnapshottedMmapedFiles  []SnapshottedMmapedFile  `field:"-"`
 }
 
 // IsContainerRoot returns whether this is a top level process in the container ID

--- a/pkg/security/seclwin/model/model.go
+++ b/pkg/security/seclwin/model/model.go
@@ -535,10 +535,6 @@ type SnapshottedMmapedFile struct {
 // ProcessCacheEntry this struct holds process context kept in the process tree
 type ProcessCacheEntry struct {
 	ProcessContext
-
-	// Snapshot data (only populated during initial snapshot, used for event replay)
-	SnapshottedBoundSockets []SnapshottedBoundSocket `field:"-"`
-	SnapshottedMmapedFiles  []SnapshottedMmapedFile  `field:"-"`
 }
 
 // IsContainerRoot returns whether this is a top level process in the container ID


### PR DESCRIPTION
Backport e0517183e545099f5a0fdecdfd38538df2a482e5 from #48444.

 ___

### What does this PR do?

- Removes `SnapshottedMmapedFiles` and `SnapshottedBoundSockets` fields from `ProcessCacheEntry`, which were introduced in #46219 and stored permanently in the process cache even though they are only needed during event replay.
- Remove the calls to GetMmapedFiles and GetBoundSockets on procfs fallbacks
- Mmaped files are now read on-the-fly from `/proc` during `replayEvents` and discarded immediately after, and these events are gated behind `runtime_security_config.sbom.enabled` (which is disabled by default).
- Removes the unused `SnapshottedBoundSockets` map, `SyncBoundSockets` method, and `newBindEventFromReplay` helper, since the map was never populated and no bind replay events were ever generated before #46219. The PR reintroduced these events for no obvious reason, which already caused increased memory usage in the past #34766

### Motivation

Reduce the memory usage of system-probe by removing unused, yet memory-intensive operations.

### Describe how you validated your changes

Deployed to staging env

### Additional Notes
