### PR TITLE
[EBPF-1051] gpu: add validation task against live metrics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -742,6 +742,7 @@
 /tasks/system_probe.py                  @DataDog/ebpf-platform
 /tasks/ebpf.py                          @DataDog/ebpf-platform
 /tasks/kmt.py                           @DataDog/ebpf-platform
+/tasks/gpu.py                           @DataDog/ebpf-platform
 /tasks/kernel_matrix_testing/           @DataDog/ebpf-platform
 /tasks/ebpf_verifier/                   @DataDog/ebpf-platform
 /tasks/trace_agent.py                   @DataDog/agent-apm
@@ -754,6 +755,7 @@
 /tasks/sbomgen.py                       @DataDog/agent-security
 /tasks/libs/build/                      @DataDog/agent-build
 /tasks/libs/cws/                        @DataDog/agent-security
+/tasks/libs/gpu/                        @DataDog/ebpf-platform
 /tasks/systray.py                       @DataDog/windows-products
 /tasks/winbuildscripts/                 @DataDog/windows-products
 /tasks/winbuild.py                      @DataDog/windows-products

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -138,10 +138,8 @@ architectures:
       unsupported_fields_by_device_mode:
         - device_modes: [physical, mig, vgpu]
           fields:
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
-            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
             - FI_DEV_NVLINK_THROUGHPUT_DATA_TX
             - FI_DEV_NVLINK_THROUGHPUT_RAW_RX

--- a/pkg/collector/corechecks/gpu/spec/architectures.yaml
+++ b/pkg/collector/corechecks/gpu/spec/architectures.yaml
@@ -20,7 +20,6 @@ architectures:
           fields:
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
@@ -46,7 +45,6 @@ architectures:
             - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
@@ -72,7 +70,6 @@ architectures:
             - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
@@ -96,7 +93,6 @@ architectures:
             - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
@@ -119,7 +115,6 @@ architectures:
             - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX
@@ -154,6 +149,7 @@ architectures:
           fields:
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
+            - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
     unsupported_device_modes:
       - mig
   blackwell:
@@ -166,7 +162,6 @@ architectures:
             - FI_DEV_NVSWITCH_CONNECTED_LINK_COUNT
             - FI_DEV_PCIE_REPLAY_COUNTER
             - FI_DEV_PERF_POLICY_THERMAL
-            - FI_DEV_NVLINK_LINK_COUNT
             - FI_DEV_NVLINK_SPEED_MBPS_COMMON
             - FI_DEV_NVLINK_GET_SPEED
             - FI_DEV_NVLINK_THROUGHPUT_DATA_RX

--- a/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
+++ b/pkg/collector/corechecks/gpu/spec/gpu_metrics.yaml
@@ -42,7 +42,7 @@ metrics:
       device_modes:
         mig: false
         physical: true
-        vgpu: true
+        vgpu: false
   clock.speed.memory:
     tagsets:
       - device
@@ -60,7 +60,7 @@ metrics:
       device_modes:
         mig: false
         physical: true
-        vgpu: true
+        vgpu: false
   clock.speed.sm:
     tagsets:
       - device
@@ -78,7 +78,7 @@ metrics:
       device_modes:
         mig: false
         physical: true
-        vgpu: true
+        vgpu: false
   clock.speed.video:
     tagsets:
       - device
@@ -98,7 +98,7 @@ metrics:
       device_modes:
         mig: false
         physical: true
-        vgpu: true
+        vgpu: false
   clock.throttle_reasons.applications_clocks_setting:
     tagsets:
       - device
@@ -438,11 +438,10 @@ metrics:
         - fermi
         - kepler
         - maxwell
-        - ada
       device_modes:
         mig: false
         physical: true
-        vgpu: false
+        vgpu: true
   nvlink.count.inactive:
     tagsets:
       - device
@@ -451,11 +450,10 @@ metrics:
         - fermi
         - kepler
         - maxwell
-        - ada
       device_modes:
         mig: false
         physical: true
-        vgpu: false
+        vgpu: true
   nvlink.count.total:
     tagsets:
       - device
@@ -464,11 +462,10 @@ metrics:
         - fermi
         - kepler
         - maxwell
-        - ada
       device_modes:
         mig: false
         physical: true
-        vgpu: false
+        vgpu: true
   nvlink.errors.crc.data:
     tagsets:
       - device
@@ -543,7 +540,6 @@ metrics:
         - kepler
         - maxwell
         - pascal
-        - ada
       device_modes:
         mig: false
         physical: true

--- a/pkg/gpu/testutil/mocks.go
+++ b/pkg/gpu/testutil/mocks.go
@@ -151,10 +151,6 @@ func (o deviceOptions) hasUnsupportedField(fieldID uint32) bool {
 	return found
 }
 
-func (o deviceOptions) hasUnsupportedNVLinkFields() bool {
-	return o.hasUnsupportedField(nvml.FI_DEV_NVLINK_SPEED_MBPS_COMMON)
-}
-
 func (o deviceOptions) effectiveArchitecture() (nvml.DeviceArchitecture, int, int) {
 	if o.archSet {
 		return o.architecture, o.computeMajor, o.computeMinor
@@ -291,7 +287,7 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			return DefaultMemoryBusWidth, nvml.SUCCESS
 		},
 		GetMaxClockInfoFunc: func(clockType nvml.ClockType) (uint32, nvml.Return) {
-			if isMIGUnsupported {
+			if isMIGOrVGPUUnsupported {
 				return 0, nvml.ERROR_NOT_SUPPORTED
 			}
 			rate, ok := DefaultMaxClockRates[clockType]
@@ -377,7 +373,7 @@ func getDeviceMockWithOptions(deviceIdx int, opts deviceOptions) *nvmlmock.Devic
 			return 0, 0, false, false, nvml.SUCCESS
 		},
 		GetNvLinkStateFunc: func(_ int) (nvml.EnableState, nvml.Return) {
-			if isMIGUnsupported || opts.hasUnsupportedNVLinkFields() {
+			if isMIGUnsupported {
 				return 0, nvml.ERROR_NOT_SUPPORTED
 			}
 			return nvml.FEATURE_ENABLED, nvml.SUCCESS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,25 +17,16 @@ exclude = [
     "venv",
     "dev",
     "third_party",
-    "cmd/system-probe/subcommands/usm/debug_scripts",  # Standalone scripts for customer debugging
+    "cmd/system-probe/subcommands/usm/debug_scripts", # Standalone scripts for customer debugging
 ]
 line-length = 120
 
 [tool.ruff.lint]
 # All the rules can be found here: https://beta.ruff.rs/docs/rules/
-select = [
-    "B",
-    "C",
-    "E",
-    "F",
-    "G",
-    "I",
-    "U",
-    "W",
-]
+select = ["B", "C", "E", "F", "G", "I", "U", "W"]
 ignore = [
-    "E501", # line-too-long
-    "C901", # complex-structure
+    "E501",  # line-too-long
+    "C901",  # complex-structure
     "UP033", # Ignore the lru_cache for now
     "UP017", # Ignore datetime.UTC for now
 ]
@@ -83,11 +74,11 @@ disable_error_code = [
 ]
 
 [[tool.mypy.overrides]]
-module = "tasks.kernel_matrix_testing.*,tasks.kmt"
+module = "tasks.kernel_matrix_testing.*,tasks.kmt,tasks.libs.gpu.*,tasks.gpu"
 disable_error_code = []
 
 [tool.vulture]
-ignore_decorators = ["@task"]
+ignore_decorators = ["@task", "@field_validator"]
 ignore_names = ["test_*", "Test*", "model_config"]
 paths = ["tasks"]
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -38,6 +38,7 @@ from tasks import (
     gitlab_helpers,
     go,
     go_deps,
+    gpu,
     host_profiler,
     installer,
     invoke_unit_tests,
@@ -222,6 +223,7 @@ ns.add_collection(github_tasks, "github")
 ns.add_collection(gitlab_helpers, "gitlab")
 ns.add_collection(issue)
 ns.add_collection(loader)
+ns.add_collection(gpu)
 ns.add_collection(package)
 ns.add_collection(pipeline)
 ns.add_collection(quality_gates)

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+# Run with:
+# dda inv --dep "datadog-api-client>=2.52.0" --dep "pydantic>=2.0" --dep "pyyaml>=6.0" --dep "tabulate>=0.9.0"
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from tasks.libs.common.auth import dd_auth_api_app_keys
+from tasks.libs.gpu.render import render_results
+from tasks.libs.gpu.types import ValidationResults
+from tasks.libs.gpu.validation import compute_validation, require_api_keys, resolve_spec_paths
+
+
+@task(
+    name="validate-metrics-single-org",
+    help={
+        "spec": "Path to gpu_metrics.yaml",
+        "architectures": "Path to architectures.yaml",
+        "site": "Datadog site (defaults to datadoghq.com)",
+        "lookback_seconds": "Metrics lookback window in seconds",
+    },
+)
+def validate_metrics_single_org(_, spec=None, architectures=None, site="datadoghq.com", lookback_seconds=3600):
+    """
+    Validate live GPU metrics by architecture/device-mode combinations for one org.
+    """
+    require_api_keys()
+    spec_path, architectures_path = resolve_spec_paths(spec, architectures)
+    result = compute_validation(spec_path, architectures_path, site, int(lookback_seconds), progress_writer=print)
+    render_results(result)
+    if result.failing_count > 0:
+        raise Exit(code=1)
+
+
+@task(
+    name="validate-metrics-all-dd",
+    help={
+        "spec": "Path to gpu_metrics.yaml",
+        "architectures": "Path to architectures.yaml",
+        "lookback_seconds": "Metrics lookback window in seconds",
+    },
+)
+def validate_metrics_all_dd(ctx, spec=None, architectures=None, lookback_seconds=3600):
+    """
+    Validate live GPU metrics for Datadog prod and staging using dd-auth credentials.
+    """
+    spec_path, architectures_path = resolve_spec_paths(spec, architectures)
+    orgs = [("prod", "app.datadoghq.com"), ("staging", "ddstaging.datadoghq.com")]
+
+    results: ValidationResults | None = None
+    org_errors: list[str] = []
+    for org_name, dd_auth_domain in orgs:
+        print(f"\n== Running GPU validation for {org_name} ({dd_auth_domain}) ==")
+        try:
+            with dd_auth_api_app_keys(ctx, dd_auth_domain):
+                require_api_keys()
+                result = compute_validation(
+                    spec_path,
+                    architectures_path,
+                    "datadoghq.com",
+                    int(lookback_seconds),
+                    progress_writer=print,
+                )
+                if results is None:
+                    results = result
+                else:
+                    results.update(result)
+        except Exception as e:
+            org_errors.append(f"{org_name}: {e}")
+            print(f"[ERROR] {org_name} failed: {e}")
+
+
+    if results:
+        render_results(results)
+
+    if org_errors:
+        print("\nOrg execution errors:")
+        for err in org_errors:
+            print(f"  - {err}")
+        raise Exit(code=1)
+
+    if results and results.failing_count > 0:
+        raise Exit(code=1)

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -12,40 +12,28 @@ from tasks.libs.gpu.validation import compute_validation, require_api_keys, reso
 
 
 @task(
-    name="validate-metrics-single-org",
-    help={
-        "spec": "Path to gpu_metrics.yaml",
-        "architectures": "Path to architectures.yaml",
-        "site": "Datadog site (defaults to datadoghq.com)",
-        "lookback_seconds": "Metrics lookback window in seconds",
-    },
-)
-def validate_metrics_single_org(_, spec=None, architectures=None, site="datadoghq.com", lookback_seconds=3600):
-    """
-    Validate live GPU metrics by architecture/device-mode combinations for one org.
-    """
-    require_api_keys()
-    spec_path, architectures_path = resolve_spec_paths(spec, architectures)
-    result = compute_validation(spec_path, architectures_path, site, int(lookback_seconds), progress_writer=print)
-    render_results(result)
-    if result.failing_count > 0:
-        raise Exit(code=1)
-
-
-@task(
-    name="validate-metrics-all-dd",
+    name="validate-metrics",
     help={
         "spec": "Path to gpu_metrics.yaml",
         "architectures": "Path to architectures.yaml",
         "lookback_seconds": "Metrics lookback window in seconds",
+        "org": "Datadog org filter: prod, staging. If not provided, use all configured orgs",
     },
 )
-def validate_metrics_all_dd(ctx, spec=None, architectures=None, lookback_seconds=3600):
+def validate_metrics(ctx, spec=None, architectures=None, lookback_seconds=3600, org: str | None = None):
     """
-    Validate live GPU metrics for Datadog prod and staging using dd-auth credentials.
+    Validate live GPU metrics for the selected Datadog org(s).
     """
     spec_path, architectures_path = resolve_spec_paths(spec, architectures)
-    orgs = [("prod", "app.datadoghq.com"), ("staging", "ddstaging.datadoghq.com")]
+    orgs_by_name = {
+        "prod": ("prod", "app.datadoghq.com"),
+        "staging": ("staging", "ddstaging.datadoghq.com"),
+    }
+
+    if org is not None:
+        orgs = [orgs_by_name[org]]
+    else:
+        orgs = list(orgs_by_name.values())
 
     results: ValidationResults | None = None
     org_errors: list[str] = []

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -6,9 +6,6 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from tasks.libs.common.auth import dd_auth_api_app_keys
-from tasks.libs.gpu.render import render_results
-from tasks.libs.gpu.types import ValidationResults
-from tasks.libs.gpu.validation import compute_validation, require_api_keys, resolve_spec_paths
 
 
 @task(
@@ -24,6 +21,11 @@ def validate_metrics(ctx, spec=None, architectures=None, lookback_seconds=3600, 
     """
     Validate live GPU metrics for the selected Datadog org(s).
     """
+    # Import here to avoid bringing in dependencies that are not always installed
+    from tasks.libs.gpu.render import render_results
+    from tasks.libs.gpu.types import ValidationResults
+    from tasks.libs.gpu.validation import compute_validation, require_api_keys, resolve_spec_paths
+
     spec_path, architectures_path = resolve_spec_paths(spec, architectures)
     orgs_by_name = {
         "prod": ("prod", "app.datadoghq.com"),

--- a/tasks/gpu.py
+++ b/tasks/gpu.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
+
 # Run with:
 # dda inv --dep "datadog-api-client>=2.52.0" --dep "pydantic>=2.0" --dep "pyyaml>=6.0" --dep "tabulate>=0.9.0"
-
 from invoke import task
 from invoke.exceptions import Exit
 
@@ -58,7 +58,6 @@ def validate_metrics(ctx, spec=None, architectures=None, lookback_seconds=3600, 
         except Exception as e:
             org_errors.append(f"{org_name}: {e}")
             print(f"[ERROR] {org_name} failed: {e}")
-
 
     if results:
         render_results(results)

--- a/tasks/libs/common/auth.py
+++ b/tasks/libs/common/auth.py
@@ -1,3 +1,7 @@
+import os
+import shlex
+from contextlib import contextmanager
+
 from tasks.libs.common.utils import running_in_ci
 
 
@@ -35,3 +39,41 @@ def get_aws_vault_env(ctx, account: str):
             key, value = line.split("=", 1)
             env[key] = value
     return env
+
+
+
+@contextmanager
+def dd_auth_api_app_keys(ctx, domain: str):
+    """
+    Fetch API/App keys from dd-auth for a given domain and temporarily set them in env.
+    """
+    res = ctx.run(f"dd-auth --domain {shlex.quote(domain)} --output", hide=True, warn=True)
+    if not res.ok:
+        raise RuntimeError(f"dd-auth failed for domain {domain}")
+
+    output_vars = {}
+    for line in res.stdout.splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            output_vars[key] = value
+
+    env_vars = ['DD_API_KEY', 'DD_APP_KEY']
+    new_values, prev_values = {}, {}
+    for env_var in env_vars:
+        if env_var not in output_vars:
+            raise RuntimeError(f"dd-auth output does not contain {env_var}")
+
+        new_values[env_var] = output_vars[env_var]
+        prev_values[env_var] = os.environ.get(env_var)
+
+    for env_var in env_vars:
+        os.environ[env_var] = new_values[env_var]
+
+    try:
+        yield
+    finally:
+        for env_var in env_vars:
+            if prev_values[env_var] is None:
+                os.environ.pop(env_var, None)
+            else:
+                os.environ[env_var] = prev_values[env_var]

--- a/tasks/libs/common/auth.py
+++ b/tasks/libs/common/auth.py
@@ -41,7 +41,6 @@ def get_aws_vault_env(ctx, account: str):
     return env
 
 
-
 @contextmanager
 def dd_auth_api_app_keys(ctx, domain: str):
     """

--- a/tasks/libs/gpu/api.py
+++ b/tasks/libs/gpu/api.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import  Any
+
+from tasks.libs.gpu.types import GPUConfig
+
+from datadog_api_client.v2.api.metrics_api import MetricsApi as MetricsApiV2
+from datadog_api_client.v2.model.metrics_scalar_query import MetricsScalarQuery
+
+
+NULLISH_GROUP_VALUES = {"", "none", "null", "n/a"}
+
+
+@dataclass(slots=True)
+class ScalarColumns:
+    group: dict[str, list]
+    number: dict[str, list]
+
+
+def normalize_group_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        if not value:
+            return None
+        first = value[0]
+        if first is None:
+            return None
+        return str(first)
+    return str(value)
+
+
+def normalize_device_mode(slicing_mode: str | None, virtualization_mode: str | None) -> str:
+    if (slicing_mode or "").lower() == "mig":
+        return "mig"
+    if (virtualization_mode or "").lower() == "vgpu":
+        return "vgpu"
+    return "physical"
+
+
+def _build_scalar_query(name: str, query: str) -> 'MetricsScalarQuery':
+    from datadog_api_client.v2.model.metrics_aggregator import MetricsAggregator
+    from datadog_api_client.v2.model.metrics_data_source import MetricsDataSource
+    from datadog_api_client.v2.model.metrics_scalar_query import MetricsScalarQuery
+
+    return MetricsScalarQuery(
+        name=name,
+        aggregator=MetricsAggregator.AVG,
+        data_source=MetricsDataSource.METRICS,
+        query=query,
+    )
+
+
+def _run_scalar_queries(api: "MetricsApiV2", queries: list[Any], from_ts: int, to_ts: int) -> ScalarColumns:
+    from datadog_api_client.v2.model.scalar_formula_query_request import ScalarFormulaQueryRequest
+    from datadog_api_client.v2.model.scalar_formula_request import ScalarFormulaRequest
+    from datadog_api_client.v2.model.scalar_formula_request_attributes import ScalarFormulaRequestAttributes
+    from datadog_api_client.v2.model.scalar_formula_request_queries import ScalarFormulaRequestQueries
+    from datadog_api_client.v2.model.scalar_formula_request_type import ScalarFormulaRequestType
+
+    body = ScalarFormulaQueryRequest(
+        data=ScalarFormulaRequest(
+            attributes=ScalarFormulaRequestAttributes(
+                _from=from_ts * 1000,
+                to=to_ts * 1000,
+                queries=ScalarFormulaRequestQueries(queries),
+            ),
+            type=ScalarFormulaRequestType.SCALAR_REQUEST,
+        )
+    )
+    response = api.query_scalar_data(body=body)
+    return _split_scalar_columns(response.data.attributes.columns or [])
+
+
+def _split_scalar_columns(columns: list[Any]) -> ScalarColumns:
+    group_columns: dict[str, list] = {}
+    number_columns: dict[str, list] = {}
+    for column in columns:
+        col_type = str(column.type).lower()
+        col_name = column.name
+        col_values = column.values or []
+        if col_type == "group":
+            group_columns[col_name] = col_values
+        elif col_type == "number":
+            number_columns[col_name] = col_values
+    return ScalarColumns(group=group_columns, number=number_columns)
+
+
+def query_scalar_data(api: "MetricsApiV2", query: str, from_ts: int, to_ts: int) -> ScalarColumns:
+    return _run_scalar_queries(api, [_build_scalar_query("q0", query)], from_ts, to_ts)
+
+
+def query_device_count(api: "MetricsApiV2", gpu_config: GPUConfig, from_ts: int, to_ts: int) -> int:
+    columns = query_scalar_data(
+        api,
+        f"avg:gpu.device.total{{{gpu_config.to_tag_filter()}}} by {{gpu_uuid}}",
+        from_ts,
+        to_ts,
+    )
+    values = columns.number.get("q0", [])
+    return sum(1 for value in values if value is not None and value > 0)
+
+
+def discover_live_gpu_configs(api: "MetricsApiV2", from_ts: int, to_ts: int) -> set[tuple[str, str]]:
+    columns = query_scalar_data(
+        api,
+        "avg:gpu.device.total{*} by {gpu_architecture,gpu_slicing_mode,gpu_virtualization_mode}",
+        from_ts,
+        to_ts,
+    )
+    values = columns.number.get("q0", [])
+    gpu_configs: set[tuple[str, str]] = set()
+    for row_idx, value in enumerate(values):
+        if value is None or value <= 0:
+            continue
+        arch_values = columns.group.get("gpu_architecture", [])
+        slicing_values = columns.group.get("gpu_slicing_mode", [])
+        virtualization_values = columns.group.get("gpu_virtualization_mode", [])
+        arch = normalize_group_value(arch_values[row_idx]) if row_idx < len(arch_values) else None
+        slicing_mode = normalize_group_value(slicing_values[row_idx]) if row_idx < len(slicing_values) else None
+        virtualization_mode = (
+            normalize_group_value(virtualization_values[row_idx]) if row_idx < len(virtualization_values) else None
+        )
+        if not arch:
+            continue
+        arch = arch.strip().lower()
+        if arch in {"n/a", "na", "none", "unknown", ""}:
+            continue
+        gpu_configs.add((arch, normalize_device_mode(slicing_mode, virtualization_mode)))
+    return gpu_configs
+
+
+def query_expected_metrics_presence_for_gpu_config(
+    api: "MetricsApiV2",
+    metric_names: list[str],
+    expected_tags_by_metric: dict[str, set[str]],
+    gpu_config_query_filter: str,
+    from_ts: int,
+    to_ts: int,
+) -> tuple[set[str], dict[str, list[str]]]:
+    if not metric_names:
+        return set(), {}
+
+    queries: list[Any] = []
+    query_name_to_metric: dict[str, str] = {}
+    for idx, metric_name in enumerate(metric_names):
+        query_name = f"q{idx}"
+        query = f"avg:{metric_name}{{{gpu_config_query_filter}}}"
+        expected_tags = expected_tags_by_metric.get(metric_name, set())
+        if expected_tags:
+            query = f"{query} by {{{','.join(expected_tags)}}}"
+        queries.append(_build_scalar_query(query_name, query))
+        query_name_to_metric[query_name] = metric_name
+
+    columns = _run_scalar_queries(api, queries, from_ts, to_ts)
+
+    present_metrics: set[str] = set()
+    tag_failures: dict[str, list[str]] = {}
+    for query_name, metric_name in query_name_to_metric.items():
+        values = columns.number.get(query_name, [])
+        present_row_indexes = [row_idx for row_idx, value in enumerate(values) if value is not None]
+        if not present_row_indexes:
+            continue
+        present_metrics.add(metric_name)
+        expected_tags = expected_tags_by_metric.get(metric_name, set())
+        if not expected_tags:
+            continue
+        non_null_seen = {tag: False for tag in expected_tags}
+        for row_idx in present_row_indexes:
+            for tag in expected_tags:
+                tag_values = columns.group.get(tag, [])
+                if row_idx >= len(tag_values):
+                    continue
+                normalized_value = normalize_group_value(tag_values[row_idx])
+                if normalized_value is None:
+                    continue
+                if normalized_value.strip().lower() not in NULLISH_GROUP_VALUES:
+                    non_null_seen[tag] = True
+        missing_tags = [tag for tag, seen in non_null_seen.items() if not seen]
+        if missing_tags:
+            tag_failures[metric_name] = missing_tags
+    return present_metrics, tag_failures
+
+
+def list_observed_gpu_metrics_for_gpu_config(
+    api: "MetricsApiV2", gpu_config: GPUConfig, lookback: int, metric_prefix: str
+) -> set[str]:
+    metrics: set[str] = set()
+    filter_expr = gpu_config.to_filter_expression()
+    page_cursor = None
+    while True:
+        kwargs = {
+            "filter_tags": filter_expr,
+            "filter_queried": True,
+            "window_seconds": max(lookback, 3600),
+            "page_size": 1000,
+        }
+        if page_cursor:
+            kwargs["page_cursor"] = page_cursor
+        response = api.list_tag_configurations(**kwargs)
+        for item in response.data or []:
+            metric_name = item.id
+            if metric_name.startswith(f"{metric_prefix}."):
+                metrics.add(metric_name)
+        page_cursor = response.meta.pagination.next_cursor if response.meta and response.meta.pagination else None
+        if not page_cursor:
+            break
+    return metrics

--- a/tasks/libs/gpu/api.py
+++ b/tasks/libs/gpu/api.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import  Any
-
-from tasks.libs.gpu.types import GPUConfig
+from typing import Any
 
 from datadog_api_client.v2.api.metrics_api import MetricsApi as MetricsApiV2
 from datadog_api_client.v2.model.metrics_scalar_query import MetricsScalarQuery
 
+from tasks.libs.gpu.types import GPUConfig
 
 NULLISH_GROUP_VALUES = {"", "none", "null", "n/a"}
 
@@ -39,7 +38,7 @@ def normalize_device_mode(slicing_mode: str | None, virtualization_mode: str | N
     return "physical"
 
 
-def _build_scalar_query(name: str, query: str) -> 'MetricsScalarQuery':
+def _build_scalar_query(name: str, query: str) -> MetricsScalarQuery:
     from datadog_api_client.v2.model.metrics_aggregator import MetricsAggregator
     from datadog_api_client.v2.model.metrics_data_source import MetricsDataSource
     from datadog_api_client.v2.model.metrics_scalar_query import MetricsScalarQuery
@@ -52,7 +51,7 @@ def _build_scalar_query(name: str, query: str) -> 'MetricsScalarQuery':
     )
 
 
-def _run_scalar_queries(api: "MetricsApiV2", queries: list[Any], from_ts: int, to_ts: int) -> ScalarColumns:
+def _run_scalar_queries(api: MetricsApiV2, queries: list[Any], from_ts: int, to_ts: int) -> ScalarColumns:
     from datadog_api_client.v2.model.scalar_formula_query_request import ScalarFormulaQueryRequest
     from datadog_api_client.v2.model.scalar_formula_request import ScalarFormulaRequest
     from datadog_api_client.v2.model.scalar_formula_request_attributes import ScalarFormulaRequestAttributes
@@ -87,11 +86,11 @@ def _split_scalar_columns(columns: list[Any]) -> ScalarColumns:
     return ScalarColumns(group=group_columns, number=number_columns)
 
 
-def query_scalar_data(api: "MetricsApiV2", query: str, from_ts: int, to_ts: int) -> ScalarColumns:
+def query_scalar_data(api: MetricsApiV2, query: str, from_ts: int, to_ts: int) -> ScalarColumns:
     return _run_scalar_queries(api, [_build_scalar_query("q0", query)], from_ts, to_ts)
 
 
-def query_device_count(api: "MetricsApiV2", gpu_config: GPUConfig, from_ts: int, to_ts: int) -> int:
+def query_device_count(api: MetricsApiV2, gpu_config: GPUConfig, from_ts: int, to_ts: int) -> int:
     columns = query_scalar_data(
         api,
         f"avg:gpu.device.total{{{gpu_config.to_tag_filter()}}} by {{gpu_uuid}}",
@@ -102,7 +101,7 @@ def query_device_count(api: "MetricsApiV2", gpu_config: GPUConfig, from_ts: int,
     return sum(1 for value in values if value is not None and value > 0)
 
 
-def discover_live_gpu_configs(api: "MetricsApiV2", from_ts: int, to_ts: int) -> set[tuple[str, str]]:
+def discover_live_gpu_configs(api: MetricsApiV2, from_ts: int, to_ts: int) -> set[tuple[str, str]]:
     columns = query_scalar_data(
         api,
         "avg:gpu.device.total{*} by {gpu_architecture,gpu_slicing_mode,gpu_virtualization_mode}",
@@ -132,7 +131,7 @@ def discover_live_gpu_configs(api: "MetricsApiV2", from_ts: int, to_ts: int) -> 
 
 
 def query_expected_metrics_presence_for_gpu_config(
-    api: "MetricsApiV2",
+    api: MetricsApiV2,
     metric_names: list[str],
     expected_tags_by_metric: dict[str, set[str]],
     gpu_config_query_filter: str,
@@ -184,7 +183,7 @@ def query_expected_metrics_presence_for_gpu_config(
 
 
 def list_observed_gpu_metrics_for_gpu_config(
-    api: "MetricsApiV2", gpu_config: GPUConfig, lookback: int, metric_prefix: str
+    api: MetricsApiV2, gpu_config: GPUConfig, lookback: int, metric_prefix: str
 ) -> set[str]:
     metrics: set[str] = set()
     filter_expr = gpu_config.to_filter_expression()

--- a/tasks/libs/gpu/render.py
+++ b/tasks/libs/gpu/render.py
@@ -11,7 +11,8 @@ def color_status(status: GPUConfigValidationState) -> str:
         GPUConfigValidationState.MISSING: Color.ORANGE,
         GPUConfigValidationState.UNKNOWN: Color.ORANGE,
     }
-    return color_message(status.value, colors[status]) if status in colors else status.value
+    name = status.name.lower()
+    return color_message(name, colors[status]) if status in colors else name
 
 
 def color_metric_counts(missing: int, known: int, unknown: int) -> str:

--- a/tasks/libs/gpu/render.py
+++ b/tasks/libs/gpu/render.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from tasks.libs.common.color import Color, color_message
+from tasks.libs.gpu.types import GPUConfigValidationResult, GPUConfigValidationState, ValidationResults
+
+
+def color_status(status: GPUConfigValidationState) -> str:
+    colors = {
+        GPUConfigValidationState.OK: Color.GREEN,
+        GPUConfigValidationState.FAIL: Color.RED,
+        GPUConfigValidationState.MISSING: Color.ORANGE,
+        GPUConfigValidationState.UNKNOWN: Color.ORANGE,
+    }
+    return color_message(status.value, colors[status]) if status in colors else status.value
+
+
+def color_metric_counts(missing: int, known: int, unknown: int) -> str:
+    missing_str = color_message(str(missing), Color.RED) if missing > 0 else str(missing)
+    known_str = color_message(str(known), Color.GREEN) if known > 0 else str(known)
+    unknown_str = color_message(str(unknown), Color.ORANGE) if unknown > 0 else str(unknown)
+    return f"{missing_str}/{known_str}/{unknown_str}"
+
+
+def color_tag_failures(count: int) -> str:
+    return color_message(str(count), Color.RED) if count > 0 else str(count)
+
+
+def print_summary_table(title: str, results: list[GPUConfigValidationResult]) -> None:
+    from tabulate import tabulate
+
+    rows = [
+        [
+            row.config.architecture,
+            row.config.device_mode,
+            color_status(row.state),
+            row.device_count,
+            color_metric_counts(len(row.missing_metrics), len(row.present_metrics), len(row.unknown_metrics)),
+            color_tag_failures(len(row.tag_failures)),
+        ]
+        for row in results
+    ]
+
+    print(f"\n{title}:")
+    print(
+        tabulate(
+            rows,
+            headers=[
+                "architecture",
+                "device mode",
+                "status",
+                "found devices",
+                "missing/known/unknown metrics",
+                "tag failures",
+            ],
+            tablefmt="github",
+        )
+    )
+
+
+def print_result_details(results: list[GPUConfigValidationResult]) -> None:
+    print("\nValidation details (showing only failures on configs with devices present):")
+    for result in results:
+        if not result.has_failures or result.device_count == 0:
+            continue
+        print(f"\n-- {result.config.architecture} {result.config.device_mode} --")
+        print(f"  found devices: {result.device_count}")
+        if result.missing_metrics:
+            print("  missing metric names:")
+            for name in result.missing_metrics:
+                print(f"    - MISSING {name}")
+        if result.unknown_metrics:
+            print("  unknown metric names:")
+            for name in result.unknown_metrics:
+                print(f"    - UNKNOWN {name}")
+        if result.tag_failures:
+            print("  tag failure details:")
+            for metric_name, tags in result.tag_failures.items():
+                print(f"    - TAG FAIL {metric_name}: missing/non-null [{', '.join(tags)}]")
+
+
+def render_results(result: ValidationResults) -> None:
+    print(f"Loaded metrics spec: {result.metrics_count} entries")
+    print(f"Loaded architecture spec: {result.architectures_count} architectures")
+    print(f"Target site: {result.site}")
+    print_summary_table("Summary", result.results)
+    print_result_details(result.results)
+    print(f"\nTotal combinations with metric/tag failures (and devices present): {result.failing_count}")

--- a/tasks/libs/gpu/types.py
+++ b/tasks/libs/gpu/types.py
@@ -21,8 +21,7 @@ class Support(BaseModel):
         invalid_modes = sorted(set(value.keys()) - allowed_modes)
         if invalid_modes:
             raise ValueError(
-                f"invalid device modes: {', '.join(invalid_modes)} "
-                f"(expected {', '.join(sorted(allowed_modes))})"
+                f"invalid device modes: {', '.join(invalid_modes)} " f"(expected {', '.join(sorted(allowed_modes))})"
             )
         return value
 
@@ -122,7 +121,7 @@ class GPUConfigValidationResult:
             len(self.missing_metrics) + len(self.unknown_metrics) + len(self.tag_failures) > 0
         )
 
-    def update(self, other: "GPUConfigValidationResult") -> None:
+    def update(self, other: GPUConfigValidationResult) -> None:
         status_precedence = {
             GPUConfigValidationState.FAIL: 0,
             GPUConfigValidationState.OK: 1,
@@ -152,7 +151,7 @@ class ValidationResults:
     architectures_count: int
     failing_count: int
 
-    def update(self, other: "ValidationResults") -> None:
+    def update(self, other: ValidationResults) -> None:
         self.metrics_count = max(self.metrics_count, other.metrics_count)
         self.architectures_count = max(self.architectures_count, other.architectures_count)
         self.failing_count += other.failing_count

--- a/tasks/libs/gpu/types.py
+++ b/tasks/libs/gpu/types.py
@@ -12,7 +12,6 @@ class Support(BaseModel):
     model_config = ConfigDict(extra="forbid")
     unsupported_architectures: list[str] = Field(default_factory=list)
     device_modes: dict[str, bool] = Field(default_factory=dict)
-    process_data: bool = False
 
     @field_validator("device_modes")
     @classmethod
@@ -33,7 +32,6 @@ class Metric(BaseModel):
     custom_tags: list[str] = Field(default_factory=list)
     support: Support = Field(default_factory=Support)
     deprecated: bool = False
-    replaced_by: str = ""
 
 
 class Tagset(BaseModel):

--- a/tasks/libs/gpu/types.py
+++ b/tasks/libs/gpu/types.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+DEVICE_MODES = ("physical", "mig", "vgpu")
+
+
+class Support(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    unsupported_architectures: list[str] = Field(default_factory=list)
+    device_modes: dict[str, bool] = Field(default_factory=dict)
+    process_data: bool = False
+
+    @field_validator("device_modes")
+    @classmethod
+    def validate_device_modes(cls, value: dict[str, bool]) -> dict[str, bool]:
+        allowed_modes = set(DEVICE_MODES)
+        invalid_modes = sorted(set(value.keys()) - allowed_modes)
+        if invalid_modes:
+            raise ValueError(
+                f"invalid device modes: {', '.join(invalid_modes)} "
+                f"(expected {', '.join(sorted(allowed_modes))})"
+            )
+        return value
+
+
+class Metric(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: str | None = None
+    tagsets: list[str]
+    custom_tags: list[str] = Field(default_factory=list)
+    support: Support = Field(default_factory=Support)
+    deprecated: bool = False
+    replaced_by: str = ""
+
+
+class Tagset(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    tags: list[str]
+
+
+class Spec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    metric_prefix: str
+    tagsets: dict[str, Tagset]
+    metrics: dict[str, Metric]
+
+
+class Architecture(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+    unsupported_device_modes: list[str] = Field(default_factory=list)
+
+
+@dataclass(slots=True)
+class GPUConfig:
+    architecture: str
+    device_mode: str
+    is_known: bool = True
+
+    def to_tag_filter(self) -> str:
+        parts = [f"gpu_architecture:{self.architecture}"]
+        if self.device_mode == "mig":
+            parts.append("gpu_slicing_mode:mig")
+        elif self.device_mode == "vgpu":
+            parts.append("gpu_virtualization_mode:vgpu")
+        else:
+            parts.append("gpu_virtualization_mode:passthrough")
+        return ",".join(parts)
+
+    def to_filter_expression(self) -> str:
+        parts = [f"gpu_architecture:{self.architecture}"]
+        if self.device_mode == "mig":
+            parts.append("gpu_slicing_mode:mig")
+        elif self.device_mode == "vgpu":
+            parts.append("gpu_virtualization_mode:vgpu")
+        else:
+            parts.append("gpu_virtualization_mode:passthrough")
+        return " AND ".join(parts)
+
+
+class ArchitecturesSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    architectures: dict[str, Architecture]
+
+    def build_combinations(self) -> list[GPUConfig]:
+        combos: list[GPUConfig] = []
+        for arch_name, arch in self.architectures.items():
+            unsupported = {x.lower() for x in arch.unsupported_device_modes}
+            for mode in DEVICE_MODES:
+                if mode not in unsupported:
+                    combos.append(GPUConfig(architecture=arch_name.lower(), device_mode=mode, is_known=True))
+        return combos
+
+
+class GPUConfigValidationState(Enum):
+    UNKNOWN = "unknown"
+    MISSING = "missing"
+    FAIL = "fail"
+    OK = "ok"
+
+
+@dataclass(slots=True)
+class GPUConfigValidationResult:
+    config: GPUConfig
+    device_count: int
+    expected_metrics: set[str]
+    state: GPUConfigValidationState = GPUConfigValidationState.UNKNOWN
+    present_metrics: set[str] = field(default_factory=set)
+    unknown_metrics: set[str] = field(default_factory=set)
+    tag_failures: dict[str, list[str]] = field(default_factory=dict)
+
+    @property
+    def missing_metrics(self) -> set[str]:
+        return self.expected_metrics - self.present_metrics
+
+    @property
+    def has_failures(self) -> bool:
+        return self.device_count > 0 and (
+            len(self.missing_metrics) + len(self.unknown_metrics) + len(self.tag_failures) > 0
+        )
+
+    def update(self, other: "GPUConfigValidationResult") -> None:
+        status_precedence = {
+            GPUConfigValidationState.FAIL: 0,
+            GPUConfigValidationState.OK: 1,
+            GPUConfigValidationState.UNKNOWN: 2,
+            GPUConfigValidationState.MISSING: 3,
+        }
+        other_status = status_precedence[other.state]
+        self_status = status_precedence[self.state]
+        if other_status < self_status:
+            self.state = other.state
+
+        self.present_metrics.update(other.present_metrics)
+        self.unknown_metrics.update(other.unknown_metrics)
+        self.tag_failures.update(other.tag_failures)
+        self.device_count += other.device_count
+
+    @property
+    def index_key(self) -> tuple[str, str]:
+        return (self.config.architecture, self.config.device_mode)
+
+
+@dataclass
+class ValidationResults:
+    results: list[GPUConfigValidationResult]
+    site: str
+    metrics_count: int
+    architectures_count: int
+    failing_count: int
+
+    def update(self, other: "ValidationResults") -> None:
+        self.metrics_count = max(self.metrics_count, other.metrics_count)
+        self.architectures_count = max(self.architectures_count, other.architectures_count)
+        self.failing_count += other.failing_count
+
+        result_index = {result.index_key: result for result in self.results}
+        for other_result in other.results:
+            if other_result.index_key in result_index:
+                result_index[other_result.index_key].update(other_result)
+            else:
+                result_index[other_result.index_key] = other_result
+
+        self.results = list(result_index.values())

--- a/tasks/libs/gpu/types.py
+++ b/tasks/libs/gpu/types.py
@@ -20,7 +20,7 @@ class Support(BaseModel):
         invalid_modes = sorted(set(value.keys()) - allowed_modes)
         if invalid_modes:
             raise ValueError(
-                f"invalid device modes: {', '.join(invalid_modes)} " f"(expected {', '.join(sorted(allowed_modes))})"
+                f"invalid device modes: {', '.join(invalid_modes)} (expected {', '.join(sorted(allowed_modes))})"
             )
         return value
 
@@ -93,10 +93,10 @@ class ArchitecturesSpec(BaseModel):
 
 
 class GPUConfigValidationState(Enum):
-    UNKNOWN = "unknown"
-    MISSING = "missing"
-    FAIL = "fail"
-    OK = "ok"
+    FAIL = 0
+    OK = 1
+    UNKNOWN = 2
+    MISSING = 3
 
 
 @dataclass(slots=True)
@@ -120,15 +120,7 @@ class GPUConfigValidationResult:
         )
 
     def update(self, other: GPUConfigValidationResult) -> None:
-        status_precedence = {
-            GPUConfigValidationState.FAIL: 0,
-            GPUConfigValidationState.OK: 1,
-            GPUConfigValidationState.UNKNOWN: 2,
-            GPUConfigValidationState.MISSING: 3,
-        }
-        other_status = status_precedence[other.state]
-        self_status = status_precedence[self.state]
-        if other_status < self_status:
+        if other.state.value < self.state.value:
             self.state = other.state
 
         self.present_metrics.update(other.present_metrics)

--- a/tasks/libs/gpu/validation.py
+++ b/tasks/libs/gpu/validation.py
@@ -50,6 +50,7 @@ def resolve_spec_paths(spec: str | None, architectures: str | None) -> tuple[str
         raise Exit(f"Architectures file not found: {architectures_path}", code=1)
     return spec_path, architectures_path
 
+
 def load_yaml_model[ModelT: BaseModel](path: str, model_cls: type[ModelT]) -> ModelT:
     import yaml
     from pydantic import ValidationError

--- a/tasks/libs/gpu/validation.py
+++ b/tasks/libs/gpu/validation.py
@@ -51,9 +51,9 @@ def resolve_spec_paths(spec: str | None, architectures: str | None) -> tuple[str
     return spec_path, architectures_path
 
 
-def load_yaml_model(path: str, model_cls: "type[BaseModel]") -> Any:
-    from pydantic import ValidationError
+def load_yaml_model(path: str, model_cls: type[BaseModel]) -> Any:
     import yaml
+    from pydantic import ValidationError
 
     with open(path) as f:
         raw = yaml.safe_load(f)
@@ -95,7 +95,9 @@ def _build_expected_tags_by_metric(spec_model: Spec, expected_metrics_map: dict[
     expected_tags_by_metric: dict[str, set[str]] = {}
     for metric_name in expected_metrics_map:
         relative_name = metric_name.removeprefix(f"{spec_model.metric_prefix}.")
-        expected_tags_by_metric[metric_name] = get_expected_tags_for_metric(spec_model, spec_model.metrics[relative_name])
+        expected_tags_by_metric[metric_name] = get_expected_tags_for_metric(
+            spec_model, spec_model.metrics[relative_name]
+        )
     return expected_tags_by_metric
 
 
@@ -108,7 +110,7 @@ def determine_result_state(result: GPUConfigValidationResult) -> GPUConfigValida
 
 
 def validate_gpu_config(
-    metrics_api_v2: "MetricsApiV2",
+    metrics_api_v2: MetricsApiV2,
     spec_model: Spec,
     gpu_config: GPUConfig,
     from_ts: int,

--- a/tasks/libs/gpu/validation.py
+++ b/tasks/libs/gpu/validation.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from invoke.exceptions import Exit
+
+from tasks.libs.gpu.api import (
+    discover_live_gpu_configs,
+    list_observed_gpu_metrics_for_gpu_config,
+    query_device_count,
+    query_expected_metrics_presence_for_gpu_config,
+)
+from tasks.libs.gpu.types import (
+    ArchitecturesSpec,
+    GPUConfig,
+    GPUConfigValidationResult,
+    GPUConfigValidationState,
+    Metric,
+    Spec,
+    ValidationResults,
+)
+
+if TYPE_CHECKING:
+    from datadog_api_client.v2.api.metrics_api import MetricsApi as MetricsApiV2
+    from pydantic import BaseModel
+
+
+SCALAR_QUERY_BATCH_SIZE = 50
+
+
+def require_api_keys() -> None:
+    if not os.environ.get("DD_API_KEY"):
+        raise Exit("DD_API_KEY environment variable is required", code=1)
+    if not os.environ.get("DD_APP_KEY"):
+        raise Exit("DD_APP_KEY environment variable is required", code=1)
+
+
+def resolve_spec_paths(spec: str | None, architectures: str | None) -> tuple[str, str]:
+    repo_root = Path(__file__).resolve().parents[3]
+    spec_path = spec or str(repo_root / "pkg" / "collector" / "corechecks" / "gpu" / "spec" / "gpu_metrics.yaml")
+    architectures_path = architectures or str(
+        repo_root / "pkg" / "collector" / "corechecks" / "gpu" / "spec" / "architectures.yaml"
+    )
+    if not Path(spec_path).exists():
+        raise Exit(f"Spec file not found: {spec_path}", code=1)
+    if not Path(architectures_path).exists():
+        raise Exit(f"Architectures file not found: {architectures_path}", code=1)
+    return spec_path, architectures_path
+
+
+def load_yaml_model(path: str, model_cls: "type[BaseModel]") -> Any:
+    from pydantic import ValidationError
+    import yaml
+
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+    try:
+        return model_cls.model_validate(raw)
+    except ValidationError as e:
+        raise ValueError(f"Invalid schema in {path}:\n{e}") from e
+
+
+def get_expected_metrics_for_gpu_config(spec_model: Spec, gpu_config: GPUConfig) -> dict[str, Metric]:
+    expected: dict[str, Metric] = {}
+    for metric_name, metric in spec_model.metrics.items():
+        if metric.deprecated:
+            continue
+        if gpu_config.architecture in metric.support.unsupported_architectures:
+            continue
+        mode_support = metric.support.device_modes.get(gpu_config.device_mode)
+        if not mode_support:
+            continue
+        expected[f"{spec_model.metric_prefix}.{metric_name}"] = metric
+    return expected
+
+
+def get_expected_tags_for_metric(spec_model: Spec, metric: Metric) -> set[str]:
+    tags: set[str] = set()
+    for tagset_name in metric.tagsets:
+        tagset = spec_model.tagsets.get(tagset_name)
+        if tagset:
+            tags.update(tagset.tags)
+    tags.update(metric.custom_tags)
+    return tags
+
+
+def batch_items(items: list[str], chunk_size: int) -> list[list[str]]:
+    return [items[i : i + chunk_size] for i in range(0, len(items), chunk_size)]
+
+
+def _build_expected_tags_by_metric(spec_model: Spec, expected_metrics_map: dict[str, Metric]) -> dict[str, set[str]]:
+    expected_tags_by_metric: dict[str, set[str]] = {}
+    for metric_name in expected_metrics_map:
+        relative_name = metric_name.removeprefix(f"{spec_model.metric_prefix}.")
+        expected_tags_by_metric[metric_name] = get_expected_tags_for_metric(spec_model, spec_model.metrics[relative_name])
+    return expected_tags_by_metric
+
+
+def determine_result_state(result: GPUConfigValidationResult) -> GPUConfigValidationState:
+    if not result.config.is_known:
+        return GPUConfigValidationState.UNKNOWN
+    if result.missing_metrics or result.unknown_metrics or result.tag_failures:
+        return GPUConfigValidationState.FAIL
+    return GPUConfigValidationState.OK
+
+
+def validate_gpu_config(
+    metrics_api_v2: "MetricsApiV2",
+    spec_model: Spec,
+    gpu_config: GPUConfig,
+    from_ts: int,
+    to_ts: int,
+    scalar_query_batch_size: int = SCALAR_QUERY_BATCH_SIZE,
+) -> GPUConfigValidationResult:
+    expected_metrics_map = get_expected_metrics_for_gpu_config(spec_model, gpu_config)
+    expected_metrics = list(expected_metrics_map.keys())
+    device_count = query_device_count(metrics_api_v2, gpu_config, from_ts, to_ts)
+    query_filter = gpu_config.to_tag_filter()
+
+    result = GPUConfigValidationResult(
+        config=gpu_config,
+        device_count=device_count,
+        expected_metrics=set(expected_metrics),
+    )
+
+    if device_count == 0:
+        result.state = GPUConfigValidationState.MISSING
+        return result
+
+    expected_tags_by_metric = _build_expected_tags_by_metric(spec_model, expected_metrics_map)
+
+    for metric_batch in batch_items(expected_metrics, scalar_query_batch_size):
+        batch_present, batch_failures = query_expected_metrics_presence_for_gpu_config(
+            metrics_api_v2,
+            metric_batch,
+            expected_tags_by_metric,
+            query_filter,
+            from_ts,
+            to_ts,
+        )
+        result.present_metrics.update(batch_present)
+        result.tag_failures.update(batch_failures)
+
+    live_gpu_metrics = list_observed_gpu_metrics_for_gpu_config(
+        metrics_api_v2,
+        gpu_config,
+        max(to_ts - from_ts, 0),
+        spec_model.metric_prefix,
+    )
+    result.unknown_metrics = live_gpu_metrics - set(expected_metrics)
+    result.state = determine_result_state(result)
+    return result
+
+
+def combine_known_and_live_gpu_configs(
+    known_gpu_configs: list[GPUConfig],
+    live_gpu_config_keys: set[tuple[str, str]],
+) -> list[GPUConfig]:
+    by_key: dict[tuple[str, str], GPUConfig] = {(c.architecture, c.device_mode): c for c in known_gpu_configs}
+    for key in sorted(live_gpu_config_keys):
+        if key not in by_key:
+            by_key[key] = GPUConfig(architecture=key[0], device_mode=key[1], is_known=False)
+    return sorted(by_key.values(), key=lambda gpu_config: (gpu_config.architecture, gpu_config.device_mode))
+
+
+def compute_validation(
+    spec_path: str,
+    architectures_path: str,
+    site: str,
+    lookback_seconds: int,
+    progress_writer: Any | None = None,
+) -> ValidationResults:
+    from datadog_api_client import ApiClient, Configuration
+    from datadog_api_client.v2.api.metrics_api import MetricsApi as MetricsApiV2
+
+    spec_model = load_yaml_model(spec_path, Spec)
+    architectures_model = load_yaml_model(architectures_path, ArchitecturesSpec)
+    now = int(time.time())
+    from_ts = now - int(lookback_seconds)
+    known_gpu_configs = architectures_model.build_combinations()
+    failing_count = 0
+
+    config = Configuration()
+    config.server_variables["site"] = site
+    results: list[GPUConfigValidationResult] = []
+    with ApiClient(config) as api_client:
+        metrics_api_v2 = MetricsApiV2(api_client)
+        live_gpu_config_keys = discover_live_gpu_configs(metrics_api_v2, from_ts, now)
+        gpu_configs = combine_known_and_live_gpu_configs(known_gpu_configs, live_gpu_config_keys)
+
+        if progress_writer is not None:
+            progress_writer(f"Validating {len(gpu_configs)} GPU configs...")
+
+        for gpu_config in gpu_configs:
+            result = validate_gpu_config(metrics_api_v2, spec_model, gpu_config, from_ts, now, SCALAR_QUERY_BATCH_SIZE)
+
+            if not gpu_config.is_known and result.device_count == 0:
+                continue
+
+            results.append(result)
+
+            if gpu_config.is_known and result.has_failures:
+                failing_count += 1
+
+    return ValidationResults(
+        site=site,
+        metrics_count=len(spec_model.metrics),
+        architectures_count=len(architectures_model.architectures),
+        results=results,
+        failing_count=failing_count,
+    )

--- a/tasks/libs/gpu/validation.py
+++ b/tasks/libs/gpu/validation.py
@@ -50,8 +50,7 @@ def resolve_spec_paths(spec: str | None, architectures: str | None) -> tuple[str
         raise Exit(f"Architectures file not found: {architectures_path}", code=1)
     return spec_path, architectures_path
 
-
-def load_yaml_model(path: str, model_cls: type[BaseModel]) -> Any:
+def load_yaml_model[ModelT: BaseModel](path: str, model_cls: type[ModelT]) -> ModelT:
     import yaml
     from pydantic import ValidationError
 

--- a/tasks/libs/gpu/validation.py
+++ b/tasks/libs/gpu/validation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from invoke.exceptions import Exit
 
@@ -51,7 +51,10 @@ def resolve_spec_paths(spec: str | None, architectures: str | None) -> tuple[str
     return spec_path, architectures_path
 
 
-def load_yaml_model[ModelT: BaseModel](path: str, model_cls: type[ModelT]) -> ModelT:
+ModelT = TypeVar("ModelT", bound=BaseModel)
+
+
+def load_yaml_model(path: str, model_cls: type[ModelT]) -> ModelT:
     import yaml
     from pydantic import ValidationError
 


### PR DESCRIPTION
### What does this PR do?

Adds task `gpu.validate-metrics` to check the specification against metrics sent to Datadog.

Most of the code is placed in `tasks/libs/gpu` for separation, additionally it guards against importing packages that are not present by default in `dda` installation.

This is a re-application of #46885, that got reverted because unit tests regarding the YAML spec did not run on the PR and failed on `main`.

### Motivation

Help validation by ensuring the behavior of the agent in production matches what is in the specification.

### Describe how you validated your changes

Tested manually, only python code for auxiliary tasks. Validated that unit tests regarding the spec run successfully.

### Additional Notes

Some of the metric specifications are updated to match what's being actually emitted.

There were also some changes in pyproject.toml to ensure typing is enforced in the new code, and to avoid a `vulture` error with `pydantic` schemas. 