### PR TITLE
refactor(profiler): Extract defaultProfileDuration constant in TestTimeout

### DIFF
--- a/comp/core/profiler/impl/profiler_test.go
+++ b/comp/core/profiler/impl/profiler_test.go
@@ -147,13 +147,13 @@ func TestProfileSetting(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
+	const defaultProfileDuration = 10 * time.Second
 	baseTimeout := 10 * time.Minute
 
-	// On Linux, discovery.enabled defaults to true which auto-enables system-probe,
-	// adding 2*profileDuration to the timeout.
+	// On Linux, discovery.enabled defaults to true which auto-enables system-probe.
 	var discoveryTimeout time.Duration
 	if runtime.GOOS == "linux" {
-		discoveryTimeout = 2 * (10 * time.Second)
+		discoveryTimeout = 2 * defaultProfileDuration
 	}
 
 	scenarios := []struct {
@@ -167,8 +167,8 @@ func TestTimeout(t *testing.T) {
 			name:            "Base Enabled Case",
 			extraCfgs:       map[string]interface{}{},
 			extraSysCfgs:    map[string]interface{}{},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 4*(10*time.Second) + discoveryTimeout,
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 4*defaultProfileDuration + discoveryTimeout,
 		},
 		{
 			name:            "Base Disabled Case",
@@ -183,8 +183,8 @@ func TestTimeout(t *testing.T) {
 				"apm_config.enabled": true,
 			},
 			extraSysCfgs:    map[string]interface{}{},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 4*(10*time.Second) + discoveryTimeout + 2*(4*time.Second), // APM default runtime has a ceiling of 4
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 4*defaultProfileDuration + discoveryTimeout + 2*(4*time.Second), // APM default runtime has a ceiling of 4
 		},
 		{
 			name: "APM Enabled, Small Runtime",
@@ -193,8 +193,8 @@ func TestTimeout(t *testing.T) {
 				"apm_config.receiver_timeout": 20,
 			},
 			extraSysCfgs:    map[string]interface{}{},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 6*(10*time.Second) + discoveryTimeout, // APM timeout is floored to the profile duration
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 6*defaultProfileDuration + discoveryTimeout, // APM timeout is floored to the profile duration
 		},
 		{
 			name: "APM Enabled, Large Runtime",
@@ -203,15 +203,15 @@ func TestTimeout(t *testing.T) {
 				"apm_config.receiver_timeout": 5,
 			},
 			extraSysCfgs:    map[string]interface{}{},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 4*(10*time.Second) + discoveryTimeout + 2*(5*time.Second), // APM timeout is the ceiling, limiting profile duration
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 4*defaultProfileDuration + discoveryTimeout + 2*(5*time.Second), // APM timeout is the ceiling, limiting profile duration
 		},
 		{
 			name:            "Process Agent Checks in Core Agent",
 			extraCfgs:       map[string]interface{}{},
 			extraSysCfgs:    map[string]interface{}{},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 4*(10*time.Second) + discoveryTimeout,
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 4*defaultProfileDuration + discoveryTimeout,
 		},
 		{
 			name:      "SysProbe Explicitly Disabled",
@@ -220,8 +220,8 @@ func TestTimeout(t *testing.T) {
 				"system_probe_config.enabled": false,
 				"discovery.enabled":           false,
 			},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 4*(10*time.Second),
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 4*defaultProfileDuration,
 		},
 		{
 			name:      "Process Agent Enabled, via NPM",
@@ -230,8 +230,8 @@ func TestTimeout(t *testing.T) {
 				"network_config.enabled":      true,
 				"system_probe_config.enabled": true,
 			},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 8*(10*time.Second),
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 8*defaultProfileDuration,
 		},
 		{
 			name:      "Process Agent Enabled, via USM",
@@ -240,8 +240,8 @@ func TestTimeout(t *testing.T) {
 				"service_monitoring_config.enabled": true,
 				"system_probe_config.enabled":       true,
 			},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 8*(10*time.Second),
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 8*defaultProfileDuration,
 		},
 		{
 			name:      "SysProbe Enabled",
@@ -249,8 +249,8 @@ func TestTimeout(t *testing.T) {
 			extraSysCfgs: map[string]interface{}{
 				"system_probe_config.enabled": true,
 			},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 8*(10*time.Second), // config enables NPM, which enables process agent
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 8*defaultProfileDuration, // config enables NPM, which enables process agent
 		},
 		{
 			name: "Everything Enabled",
@@ -262,8 +262,8 @@ func TestTimeout(t *testing.T) {
 			extraSysCfgs: map[string]interface{}{
 				"system_probe_config.enabled": true,
 			},
-			profileDuration: 10 * time.Second,
-			expTimeout:      baseTimeout + 10*(10*time.Second),
+			profileDuration: defaultProfileDuration,
+			expTimeout:      baseTimeout + 10*defaultProfileDuration,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Extracts a `defaultProfileDuration` constant in `TestTimeout` to replace repeated `10 * time.Second` literals across all test scenarios. Also removes a redundant comment that restated what the code already expressed.

### Motivation

Follow-up cleanup requested in PR #48000 [review comment](https://github.com/DataDog/datadog-agent/pull/48000#discussion_r2961373286) by @rahulkaukuntla.

### Describe how you validated your changes

All profiler tests pass: `dda inv test --targets=./comp/core/profiler/impl/...`

### Additional Notes

Test-only change — no agent binary code is affected.