### PR TITLE
feat(trace): integrate semantics registry for gRPC status code lookup

### DIFF
--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -143,12 +143,14 @@
     "rpc.grpc.status_code": {
       "canonical": "rpc.grpc.status_code",
       "fallbacks": [
-        {"name": "rpc.grpc.status_code", "provider": "otel", "type": "int64"},
-        {"name": "grpc.code", "provider": "datadog", "type": "int64"},
-        {"name": "rpc.grpc.status.code", "provider": "otel", "type": "int64"},
-        {"name": "grpc.status.code", "provider": "datadog", "type": "int64"},
-        {"name": "rpc.grpc.status_code", "provider": "otel", "type": "string"},
-        {"name": "grpc.code", "provider": "datadog", "type": "string"}
+        {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "string"},
+        {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "int64"},
+        {"name": "grpc.code",            "provider": "datadog", "type": "string"},
+        {"name": "grpc.code",            "provider": "datadog", "type": "int64"},
+        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "string"},
+        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "int64"},
+        {"name": "grpc.status.code",     "provider": "datadog", "type": "string"},
+        {"name": "grpc.status.code",     "provider": "datadog", "type": "int64"}
       ]
     },
     "span.kind": {

--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -144,12 +144,12 @@
       "canonical": "rpc.grpc.status_code",
       "fallbacks": [
         {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "string"},
-        {"name": "grpc.code",            "provider": "datadog", "type": "string"},
-        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "string"},
-        {"name": "grpc.status.code",     "provider": "datadog", "type": "string"},
         {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "int64"},
+        {"name": "grpc.code",            "provider": "datadog", "type": "string"},
         {"name": "grpc.code",            "provider": "datadog", "type": "int64"},
+        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "string"},
         {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "int64"},
+        {"name": "grpc.status.code",     "provider": "datadog", "type": "string"},
         {"name": "grpc.status.code",     "provider": "datadog", "type": "int64"}
       ]
     },

--- a/pkg/trace/semantics/mappings.json
+++ b/pkg/trace/semantics/mappings.json
@@ -144,12 +144,12 @@
       "canonical": "rpc.grpc.status_code",
       "fallbacks": [
         {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "string"},
-        {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "int64"},
         {"name": "grpc.code",            "provider": "datadog", "type": "string"},
-        {"name": "grpc.code",            "provider": "datadog", "type": "int64"},
         {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "string"},
-        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "int64"},
         {"name": "grpc.status.code",     "provider": "datadog", "type": "string"},
+        {"name": "rpc.grpc.status_code", "provider": "otel",    "type": "int64"},
+        {"name": "grpc.code",            "provider": "datadog", "type": "int64"},
+        {"name": "rpc.grpc.status.code", "provider": "otel",    "type": "int64"},
         {"name": "grpc.status.code",     "provider": "datadog", "type": "int64"}
       ]
     },

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -195,65 +195,37 @@ var grpcStatusMap = map[string]string{
 	"DATALOSS":           "15",
 }
 
-func getGRPCStatusCode(meta map[string]string, metrics map[string]float64) string {
-	// List of possible keys to check in order
-	statusCodeFields := []string{"rpc.grpc.status_code", "grpc.code", "rpc.grpc.status.code", "grpc.status.code"}
-
-	for _, key := range statusCodeFields {
-		if strC, exists := meta[key]; exists && strC != "" {
-			c, err := strconv.ParseUint(strC, 10, 32)
-			if err == nil {
-				return strconv.FormatUint(c, 10)
-			}
-			strC = strings.TrimPrefix(strC, "StatusCode.") // Some tracers send status code values prefixed by "StatusCode."
-			strCUpper := strings.ToUpper(strC)
-			if statusCode, exists := grpcStatusMap[strCUpper]; exists {
-				return statusCode
-			}
-
-			// If not integer or canceled or multi-word, check for valid gRPC status string
-			if codeNum, found := code.Code_value[strCUpper]; found {
-				return strconv.Itoa(int(codeNum))
-			}
-
-			return ""
-		}
+// parseGRPCStatusString converts a raw gRPC status string (numeric, enum name, or
+// "StatusCode."-prefixed) to its canonical numeric string form, or "" if unrecognized.
+func parseGRPCStatusString(strC string) string {
+	if c, err := strconv.ParseUint(strC, 10, 32); err == nil {
+		return strconv.FormatUint(c, 10)
 	}
-
-	for _, key := range statusCodeFields { // Check if gRPC status code is stored in metrics
-		if code, ok := metrics[key]; ok {
-			return strconv.FormatUint(uint64(code), 10)
-		}
+	strC = strings.TrimPrefix(strC, "StatusCode.") // Some tracers send status code values prefixed by "StatusCode."
+	strCUpper := strings.ToUpper(strC)
+	if statusCode, exists := grpcStatusMap[strCUpper]; exists {
+		return statusCode
 	}
-
+	if codeNum, found := code.Code_value[strCUpper]; found {
+		return strconv.Itoa(int(codeNum))
+	}
 	return ""
 }
 
-func getGRPCStatusCodeV1(s *idx.InternalSpan) string {
-	// List of possible keys to check in order
-	statusCodeFields := []string{"rpc.grpc.status_code", "grpc.code", "rpc.grpc.status.code", "grpc.status.code"}
-
-	for _, key := range statusCodeFields {
-		// TODO: could optimize this to use the Attribute directly to avoid the string conversion sometimes
-		if strC, exists := s.GetAttributeAsString(key); exists && strC != "" {
-			c, err := strconv.ParseUint(strC, 10, 32)
-			if err == nil {
-				return strconv.FormatUint(c, 10)
-			}
-			strC = strings.TrimPrefix(strC, "StatusCode.") // Some tracers send status code values prefixed by "StatusCode."
-			strCUpper := strings.ToUpper(strC)
-			if statusCode, exists := grpcStatusMap[strCUpper]; exists {
-				return statusCode
-			}
-
-			// If not integer or canceled or multi-word, check for valid gRPC status string
-			if codeNum, found := code.Code_value[strCUpper]; found {
-				return strconv.Itoa(int(codeNum))
-			}
-
-			return ""
-		}
+func getGRPCStatusCode(meta map[string]string, metrics map[string]float64) string {
+	a := semantics.NewDDSpanAccessor(meta, metrics)
+	strC := semantics.LookupString(ddRegistry, a, semantics.ConceptGRPCStatusCode)
+	if strC == "" {
+		return ""
 	}
+	return parseGRPCStatusString(strC)
+}
 
-	return ""
+func getGRPCStatusCodeV1(s *idx.InternalSpan) string {
+	a := semantics.NewDDSpanAccessorV1(s)
+	strC := semantics.LookupString(ddRegistry, a, semantics.ConceptGRPCStatusCode)
+	if strC == "" {
+		return ""
+	}
+	return parseGRPCStatusString(strC)
 }

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -175,6 +175,63 @@ func TestGetGRPCStatusCode(t *testing.T) {
 	}
 }
 
+func TestGetGRPCStatusCodeV1(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   *idx.InternalSpan
+		out  string
+	}{
+		{"empty", newTestInternalSpanV1(), ""},
+		{"int value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString("rpc.grpc.status_code", "10")
+			return s
+		}(), "10"},
+		{"numeric string value", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("rpc.grpc.status.code", "15")
+			return s
+		}(), "15"},
+		{"enum name", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("rpc.grpc.status_code", "aborted")
+			return s
+		}(), "10"},
+		{"StatusCode prefix", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("grpc.status.code", "StatusCode.ABORTED")
+			return s
+		}(), "10"},
+		{"CANCELLED", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("rpc.grpc.status.code", "CANCELLED")
+			return s
+		}(), "1"},
+		{"Canceled", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("rpc.grpc.status.code", "Canceled")
+			return s
+		}(), "1"},
+		{"InvalidArgument", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("rpc.grpc.status_code", "InvalidArgument")
+			return s
+		}(), "3"},
+		{"invalid unrecognized string", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetStringAttribute("grpc.status.code", "StatusCodee.ABORTED")
+			return s
+		}(), ""},
+		{"fallback key", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString("grpc.code", "7")
+			return s
+		}(), "7"},
+	} {
+		assert.Equal(t, tt.out, getGRPCStatusCodeV1(tt.in), tt.name)
+	}
+}
+
 func TestNewAggregation(t *testing.T) {
 	peerSvcOnlyHash := uint64(3430395298086625290)
 	peerTagsHash := uint64(9894752672193411515)

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -170,13 +170,13 @@ func TestGetGRPCStatusCode(t *testing.T) {
 			},
 			"3",
 		},
-		// Meta on a later fallback key wins over metrics on an earlier key.
+		// Earlier key wins regardless of whether the value comes from meta or metrics.
 		{
 			&pb.Span{
 				Meta:    map[string]string{"grpc.code": "7"},
 				Metrics: map[string]float64{"rpc.grpc.status_code": 10},
 			},
-			"7",
+			"10",
 		},
 	} {
 		assert.Equal(t, tt.out, getGRPCStatusCode(tt.in.Meta, tt.in.Metrics))
@@ -235,13 +235,13 @@ func TestGetGRPCStatusCodeV1(t *testing.T) {
 			s.SetAttributeFromString("grpc.code", "7")
 			return s
 		}(), "7"},
-		// String attribute on a later fallback key wins over int attribute on an earlier key.
-		{"string on later key beats int on earlier key", func() *idx.InternalSpan {
+		// Earlier key wins regardless of attribute storage type.
+		{"earlier key beats later key regardless of type", func() *idx.InternalSpan {
 			s := newTestInternalSpanV1()
 			s.SetAttributeFromString("rpc.grpc.status_code", "10")
 			s.SetStringAttribute("grpc.code", "7")
 			return s
-		}(), "7"},
+		}(), "10"},
 	} {
 		assert.Equal(t, tt.out, getGRPCStatusCodeV1(tt.in), tt.name)
 	}

--- a/pkg/trace/stats/aggregation_test.go
+++ b/pkg/trace/stats/aggregation_test.go
@@ -170,6 +170,14 @@ func TestGetGRPCStatusCode(t *testing.T) {
 			},
 			"3",
 		},
+		// Meta on a later fallback key wins over metrics on an earlier key.
+		{
+			&pb.Span{
+				Meta:    map[string]string{"grpc.code": "7"},
+				Metrics: map[string]float64{"rpc.grpc.status_code": 10},
+			},
+			"7",
+		},
 	} {
 		assert.Equal(t, tt.out, getGRPCStatusCode(tt.in.Meta, tt.in.Metrics))
 	}
@@ -225,6 +233,13 @@ func TestGetGRPCStatusCodeV1(t *testing.T) {
 		{"fallback key", func() *idx.InternalSpan {
 			s := newTestInternalSpanV1()
 			s.SetAttributeFromString("grpc.code", "7")
+			return s
+		}(), "7"},
+		// String attribute on a later fallback key wins over int attribute on an earlier key.
+		{"string on later key beats int on earlier key", func() *idx.InternalSpan {
+			s := newTestInternalSpanV1()
+			s.SetAttributeFromString("rpc.grpc.status_code", "10")
+			s.SetStringAttribute("grpc.code", "7")
 			return s
 		}(), "7"},
 	} {


### PR DESCRIPTION
### What does this PR do?

Replaces the ad-hoc gRPC status code key scanning in `getGRPCStatusCode` with `semantics.LookupString` via `DDSpanAccessor`. Adds the two missing string-typed fallbacks (`rpc.grpc.status.code`, `grpc.status.code`) to `mappings.json`.

Note: the fallbacks use interleaved ordering (string then int64 per key). For V1 spans this gives key-first resolution — first key found wins regardless of storage type, matching the original `GetAttributeAsString` loop. For V0 spans it gives per-key meta-before-metrics, which differs from the original "any meta key beats any metrics key" only in the contrived cross-key case (not a realistic scenario).

### Motivation

Centralize attribute fallback logic in the semantics registry.

### Describe how you validated your changes

All existing `TestGetGRPCStatusCode` cases pass unchanged. `TestGetGRPCStatusCodeV1` covers integer, numeric string, enum name, `StatusCode.`-prefixed, fallback keys, and cross-key precedence.