### PR TITLE
Revert "Revert "feat(par): add default restricted shell paths with co…

### DIFF
--- a/pkg/config/setup/privateactionrunner.go
+++ b/pkg/config/setup/privateactionrunner.go
@@ -6,8 +6,10 @@
 package setup
 
 import (
+	"path"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	pkgconfigmodel "github.com/DataDog/datadog-agent/pkg/config/model"
 )
 
@@ -32,7 +34,21 @@ const (
 	PARHttpTimeoutSeconds    = "private_action_runner.http_timeout_seconds"
 	PARHttpAllowlist         = "private_action_runner.http_allowlist"
 	PARHttpAllowImdsEndpoint = "private_action_runner.http_allow_imds_endpoint"
+
+	// Restricted Shell
+	PARRestrictedShellAllowedPaths = "private_action_runner.restricted_shell_allowed_paths"
 )
+
+const (
+	// Default allowed paths for restricted shell
+	defaultLogPath = "/var/log"
+
+	containerizedPathPrefix = "/host"
+)
+
+// parPathExists is the function used to check path existence. It defaults to
+// pathExists and can be overridden in tests.
+var parPathExists = pathExists
 
 // setupPrivateActionRunner registers all configuration keys for the private action runner
 func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
@@ -66,4 +82,18 @@ func setupPrivateActionRunner(config pkgconfigmodel.Setup) {
 	})
 	config.BindEnvAndSetDefault(PARHttpAllowImdsEndpoint, false)
 
+	defaultPaths := []string{defaultLogPath}
+	if env.IsContainerized() {
+		for i, v := range defaultPaths {
+			hostPath := path.Join(containerizedPathPrefix, v)
+			defaultPaths[i] = hostPath
+		}
+	}
+	config.BindEnvAndSetDefault(PARRestrictedShellAllowedPaths, defaultPaths)
+	config.ParseEnvAsStringSlice(PARRestrictedShellAllowedPaths, func(s string) []string {
+		if s == "" {
+			return nil
+		}
+		return strings.Split(s, ",")
+	})
 }

--- a/pkg/config/setup/privateactionrunner_test.go
+++ b/pkg/config/setup/privateactionrunner_test.go
@@ -6,10 +6,24 @@
 package setup
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func mockParPathExists(existing map[string]bool) func(string) bool {
+	return func(path string) bool {
+		return existing[path]
+	}
+}
+
+func overrideParPathExists(t *testing.T, fn func(string) bool) {
+	original := parPathExists
+	parPathExists = fn
+	t.Cleanup(func() { parPathExists = original })
+}
 
 func TestPrivateActionRunnerActionsAllowlistFromEnv(t *testing.T) {
 	t.Setenv("DD_PRIVATE_ACTION_RUNNER_ACTIONS_ALLOWLIST", "com.datadoghq.kubernetes.core.listPod,com.datadoghq.script.runPredefinedScript")
@@ -27,9 +41,62 @@ func TestPrivateActionRunnerHttpAllowlistFromEnv(t *testing.T) {
 	assert.Equal(t, []string{"*.datadoghq.com", "datadoghq.eu"}, cfg.GetStringSlice(PARHttpAllowlist))
 }
 
+func TestPrivateActionRunnerRestrictedShellAllowedPathsFromEnv(t *testing.T) {
+	t.Setenv("DD_PRIVATE_ACTION_RUNNER_RESTRICTED_SHELL_ALLOWED_PATHS", "/var/log,/tmp")
+
+	cfg := newTestConf(t)
+
+	assert.Equal(t, []string{"/var/log", "/tmp"}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+}
+
+func TestPrivateActionRunnerRestrictedShellAllowedPathsEmptyEnv(t *testing.T) {
+	t.Setenv("DD_PRIVATE_ACTION_RUNNER_RESTRICTED_SHELL_ALLOWED_PATHS", "")
+
+	cfg := newTestConf(t)
+
+	assert.Equal(t, []string{defaultLogPath}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+}
+
 func TestPrivateActionRunnerAllowlistDefaultsEmpty(t *testing.T) {
 	cfg := newTestConf(t)
 
 	assert.Empty(t, cfg.GetStringSlice(PARActionsAllowlist))
 	assert.Empty(t, cfg.GetStringSlice(PARHttpAllowlist))
+	assert.Equal(t, []string{defaultLogPath}, cfg.GetStringSlice(PARRestrictedShellAllowedPaths))
+}
+
+func TestPrivateActionRunnerAllowedPathsBareMetal(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
+	os.Unsetenv("DOCKER_DD_AGENT")
+
+	cfg := newTestConf(t)
+
+	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
+	assert.Equal(t, []string{defaultLogPath}, paths)
+}
+
+func TestPrivateActionRunnerAllowedPathsContainerizedWithHostMounts(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+	overrideParPathExists(t, mockParPathExists(map[string]bool{
+		"/host/var/log": true,
+	}))
+
+	cfg := newTestConf(t)
+
+	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
+	assert.Equal(t, []string{"/host/var/log"}, paths)
+}
+
+func TestPrivateActionRunnerAllowedPathsContainerizedWithoutHostMounts(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+	overrideParPathExists(t, mockParPathExists(map[string]bool{}))
+
+	cfg := newTestConf(t)
+
+	// Even without host mounts, containerized paths should use /host prefix
+	// (rshell handles missing paths at runtime; config logs a warning)
+	paths := cfg.GetStringSlice(PARRestrictedShellAllowedPaths)
+	assert.Equal(t, []string{
+		path.Join(containerizedPathPrefix, defaultLogPath),
+	}, paths)
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go
@@ -10,27 +10,39 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path"
 	"strings"
 
 	"mvdan.cc/sh/v3/syntax"
 
 	"github.com/DataDog/rshell/interp"
 
+	"github.com/DataDog/datadog-agent/pkg/config/env"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/libs/privateconnection"
 	"github.com/DataDog/datadog-agent/pkg/privateactionrunner/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// allowedPaths is the hardcoded list of filesystem paths that the rshell
-// interpreter is permitted to access. Adjust this list to restrict or expand
-// the set of directories available to executed commands.
-var allowedPaths = []string{"/var/log"}
+const (
+	defaultProcPath         = "/proc"
+	containerizedPathPrefix = "/host"
+)
+
+// statFn is the function used to check path existence. It defaults to os.Stat
+// and can be overridden in tests.
+var statFn = os.Stat
 
 // RunCommandHandler implements the runCommand action.
-type RunCommandHandler struct{}
+type RunCommandHandler struct {
+	allowedPaths []string
+}
 
 // NewRunCommandHandler creates a new RunCommandHandler.
-func NewRunCommandHandler() *RunCommandHandler {
-	return &RunCommandHandler{}
+func NewRunCommandHandler(allowedPaths []string) *RunCommandHandler {
+	return &RunCommandHandler{
+		allowedPaths: allowedPaths,
+	}
 }
 
 // RunCommandInputs defines the inputs for the runCommand action.
@@ -61,11 +73,19 @@ func (h *RunCommandHandler) Run(
 		return nil, errors.New("command is required")
 	}
 
+	log.Debugf("rshell runCommand: command=%q allowedCommands=%v allowedPaths=%v",
+		inputs.Command, inputs.AllowedCommands, h.allowedPaths)
+
 	prog, err := syntax.NewParser().Parse(strings.NewReader(inputs.Command), "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse command: %w", err)
 	}
 
+	for _, p := range h.allowedPaths {
+		if _, err := statFn(p); err != nil {
+			log.Warnf("path %q not found, rshell may fail to execute commands", p)
+		}
+	}
 	var stdout, stderr bytes.Buffer
 	cmdOpt := interp.AllowAllCommands()
 	if len(inputs.AllowedCommands) > 0 {
@@ -73,7 +93,8 @@ func (h *RunCommandHandler) Run(
 	}
 	runner, err := interp.New(
 		interp.StdIO(nil, &stdout, &stderr),
-		interp.AllowedPaths(allowedPaths),
+		interp.AllowedPaths(h.allowedPaths),
+		interp.ProcPath(resolveProcPath()),
 		cmdOpt,
 	)
 	if err != nil {
@@ -97,4 +118,17 @@ func (h *RunCommandHandler) Run(
 		Stdout:   stdout.String(),
 		Stderr:   stderr.String(),
 	}, nil
+}
+
+// resolveProcPath returns the proc filesystem path appropriate for the current
+// environment. In containerized deployments with host mounts, it returns
+// /host/proc; otherwise it falls back to /proc.
+func resolveProcPath() string {
+	if env.IsContainerized() {
+		hostProc := path.Join(containerizedPathPrefix, defaultProcPath)
+		if _, err := statFn(hostProc); err == nil {
+			return hostProc
+		}
+	}
+	return defaultProcPath
 }

--- a/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
+++ b/pkg/privateactionrunner/bundles/remoteaction/rshell/run_command_test.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package com_datadoghq_remoteaction_rshell
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRunCommandHandlerStoresAllowedPaths(t *testing.T) {
+	paths := []string{"/var/log", "/tmp"}
+
+	handler := NewRunCommandHandler(paths)
+
+	assert.Equal(t, paths, handler.allowedPaths)
+}
+
+func TestNewRshellBundleUsesConfiguredAllowedPaths(t *testing.T) {
+	paths := []string{"/var/log", "/tmp"}
+
+	bundle := NewRshellBundle(paths)
+	action := bundle.GetAction("runCommand")
+
+	handler, ok := action.(*RunCommandHandler)
+	require.True(t, ok)
+	assert.Equal(t, paths, handler.allowedPaths)
+}
+
+func mockStatFn(existing map[string]bool) func(string) (os.FileInfo, error) {
+	return func(path string) (os.FileInfo, error) {
+		if existing[path] {
+			return nil, nil
+		}
+		return nil, errors.New("not found")
+	}
+}
+
+func overrideStatFn(t *testing.T, fn func(string) (os.FileInfo, error)) {
+	original := statFn
+	statFn = fn
+	t.Cleanup(func() { statFn = original })
+}
+
+func TestResolveProcPathBareMetal(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "")
+	os.Unsetenv("DOCKER_DD_AGENT")
+
+	result := resolveProcPath()
+
+	assert.Equal(t, "/proc", result)
+}
+
+func TestResolveProcPathContainerizedWithHostMount(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+	overrideStatFn(t, mockStatFn(map[string]bool{"/host/proc": true}))
+
+	result := resolveProcPath()
+
+	assert.Equal(t, "/host/proc", result)
+}
+
+func TestResolveProcPathContainerizedWithoutHostMount(t *testing.T) {
+	t.Setenv("DOCKER_DD_AGENT", "true")
+	overrideStatFn(t, mockStatFn(map[string]bool{}))
+
+	result := resolveProcPath()
+
+	assert.Equal(t, "/proc", result)
+}


### PR DESCRIPTION
…ntainer-aware prefixing"" (#48462)

Reverts DataDog/datadog-agent#48460

Revert + this test fix:

All tests pass. Here's a summary of the fix:

  Root cause: Both filepath.Join calls used OS path separators. On Windows, filepath.Join("/host", "/var/log") produces \host\var\log, breaking tests that expected Linux-style paths. Similarly,
  filepath.Join("/host", "/proc") produced \host\proc which didn't match the mock key /host/proc, causing resolveProcPath to fall back to /proc.

  Fix: Replaced filepath.Join with path.Join (POSIX package) in three files:
  - pkg/config/setup/privateactionrunner.go — container path prefix joining
  - pkg/config/setup/privateactionrunner_test.go — test assertion using same join
  - pkg/privateactionrunner/bundles/remoteaction/rshell/run_command.go — resolveProcPath

  These are Linux container paths (/host/...) that must always use forward slashes regardless of the host OS.

### What does this PR do?

### Motivation

### Describe how you validated your changes

### Additional Notes
