### PR TITLE
add separate Postgres credentials for data observability actions

### DIFF
--- a/comp/dataobs/queryactions/impl/config.go
+++ b/comp/dataobs/queryactions/impl/config.go
@@ -44,7 +44,9 @@ func init() {
 }
 
 // toInstanceMap converts a DODatabaseConfig to a map[string]any using the same keys
-// as dbCredentialAllowList. Only non-zero fields are included.
+// as dbCredentialAllowList. Fields typed as `any` (interface) are included whenever
+// non-nil, even if the underlying value is a zero like false or 0. Concrete-typed
+// fields (string, int) are included only when non-zero.
 func (d *DODatabaseConfig) toInstanceMap() map[string]any {
 	out := make(map[string]any)
 	v := reflect.ValueOf(d).Elem()
@@ -54,7 +56,13 @@ func (d *DODatabaseConfig) toInstanceMap() map[string]any {
 			continue
 		}
 		field := v.Field(idx)
-		if field.IsZero() {
+		// For interface (any) fields, check IsNil rather than IsZero so that
+		// explicit false / 0 values (e.g. tls_verify: false) are preserved.
+		if field.Kind() == reflect.Interface {
+			if field.IsNil() {
+				continue
+			}
+		} else if field.IsZero() {
 			continue
 		}
 		out[key] = field.Interface()
@@ -64,6 +72,8 @@ func (d *DODatabaseConfig) toInstanceMap() map[string]any {
 
 // matchesIdentifier checks if this database config matches the given DB identifier
 // by host and dbname, same logic as the existing matchesIdentifier for postgres instances.
+// Port is intentionally not checked — the RC payload's DBIdentifier does not carry a port,
+// and the existing postgres-check matching also ignores port.
 func (d *DODatabaseConfig) matchesIdentifier(dbID *DBIdentifier) bool {
 	return d.Host == dbID.Host && d.DBName == dbID.DBName
 }

--- a/comp/dataobs/queryactions/impl/config.go
+++ b/comp/dataobs/queryactions/impl/config.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package queryactionsimpl
+
+import "reflect"
+
+// DODatabaseConfig represents a single database credential entry configured under
+// data_observability.query_actions.databases in datadog.yaml.
+type DODatabaseConfig struct {
+	Host                  string `mapstructure:"host"`
+	Port                  int    `mapstructure:"port"`
+	DBName                string `mapstructure:"dbname"`
+	Username              string `mapstructure:"username"`
+	Password              string `mapstructure:"password"`
+	SSL                   any    `mapstructure:"ssl"`
+	SSLMode               string `mapstructure:"ssl_mode"`
+	SSLCert               string `mapstructure:"ssl_cert"`
+	SSLKey                string `mapstructure:"ssl_key"`
+	SSLRootCert           string `mapstructure:"ssl_root_cert"`
+	TLS                   any    `mapstructure:"tls"`
+	TLSVerify             any    `mapstructure:"tls_verify"`
+	TLSCert               string `mapstructure:"tls_cert"`
+	TLSKey                string `mapstructure:"tls_key"`
+	TLSCACert             string `mapstructure:"tls_ca_cert"`
+	AWS                   any    `mapstructure:"aws"`
+	ManagedAuthentication any    `mapstructure:"managed_authentication"`
+}
+
+// fieldByMapstructureTag maps mapstructure tag names to struct field indices for DODatabaseConfig.
+var fieldByMapstructureTag map[string]int
+
+func init() {
+	fieldByMapstructureTag = make(map[string]int)
+	t := reflect.TypeOf(DODatabaseConfig{})
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("mapstructure")
+		if tag != "" {
+			fieldByMapstructureTag[tag] = i
+		}
+	}
+}
+
+// toInstanceMap converts a DODatabaseConfig to a map[string]any using the same keys
+// as dbCredentialAllowList. Only non-zero fields are included.
+func (d *DODatabaseConfig) toInstanceMap() map[string]any {
+	out := make(map[string]any)
+	v := reflect.ValueOf(d).Elem()
+	for _, key := range dbCredentialAllowList {
+		idx, ok := fieldByMapstructureTag[key]
+		if !ok {
+			continue
+		}
+		field := v.Field(idx)
+		if field.IsZero() {
+			continue
+		}
+		out[key] = field.Interface()
+	}
+	return out
+}
+
+// matchesIdentifier checks if this database config matches the given DB identifier
+// by host and dbname, same logic as the existing matchesIdentifier for postgres instances.
+func (d *DODatabaseConfig) matchesIdentifier(dbID *DBIdentifier) bool {
+	return d.Host == dbID.Host && d.DBName == dbID.DBName
+}

--- a/comp/dataobs/queryactions/impl/config_test.go
+++ b/comp/dataobs/queryactions/impl/config_test.go
@@ -38,6 +38,20 @@ func TestDODatabaseConfig_ToInstanceMap(t *testing.T) {
 	assert.False(t, hasAWS, "zero-value aws field should not be in output")
 }
 
+func TestDODatabaseConfig_ToInstanceMap_ExplicitFalse(t *testing.T) {
+	cfg := DODatabaseConfig{
+		Host:      "localhost",
+		Port:      5432,
+		TLSVerify: false, // explicit false must be preserved
+		SSL:       false, // explicit false must be preserved
+	}
+
+	m := cfg.toInstanceMap()
+
+	assert.Equal(t, false, m["tls_verify"], "explicit false for tls_verify must be preserved")
+	assert.Equal(t, false, m["ssl"], "explicit false for ssl must be preserved")
+}
+
 func TestDODatabaseConfig_ToInstanceMap_WithNestedAWS(t *testing.T) {
 	cfg := DODatabaseConfig{
 		Host:     "mydb.rds.amazonaws.com",
@@ -79,6 +93,15 @@ func TestDODatabaseConfig_ToInstanceMap_OnlyAllowlistKeys(t *testing.T) {
 			}
 		}
 		assert.True(t, found, "key %q in output is not in dbCredentialAllowList", key)
+	}
+}
+
+func TestDBCredentialAllowList_AllHaveMatchingStructTag(t *testing.T) {
+	// Every entry in dbCredentialAllowList must have a corresponding mapstructure tag
+	// in DODatabaseConfig. This catches drift between the two.
+	for _, key := range dbCredentialAllowList {
+		_, ok := fieldByMapstructureTag[key]
+		assert.True(t, ok, "dbCredentialAllowList entry %q has no matching mapstructure tag in DODatabaseConfig", key)
 	}
 }
 

--- a/comp/dataobs/queryactions/impl/config_test.go
+++ b/comp/dataobs/queryactions/impl/config_test.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2026-present Datadog, Inc.
+
+package queryactionsimpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDODatabaseConfig_ToInstanceMap(t *testing.T) {
+	cfg := DODatabaseConfig{
+		Host:     "localhost",
+		Port:     5432,
+		DBName:   "testdb",
+		Username: "do_reader",
+		Password: "secret",
+		SSLMode:  "require",
+	}
+
+	m := cfg.toInstanceMap()
+
+	assert.Equal(t, "localhost", m["host"])
+	assert.Equal(t, 5432, m["port"])
+	assert.Equal(t, "testdb", m["dbname"])
+	assert.Equal(t, "do_reader", m["username"])
+	assert.Equal(t, "secret", m["password"])
+	assert.Equal(t, "require", m["ssl_mode"])
+
+	// Zero-value fields should be omitted
+	_, hasSSL := m["ssl"]
+	assert.False(t, hasSSL, "zero-value ssl field should not be in output")
+	_, hasAWS := m["aws"]
+	assert.False(t, hasAWS, "zero-value aws field should not be in output")
+}
+
+func TestDODatabaseConfig_ToInstanceMap_WithNestedAWS(t *testing.T) {
+	cfg := DODatabaseConfig{
+		Host:     "mydb.rds.amazonaws.com",
+		Port:     5432,
+		Username: "datadog",
+		AWS: map[string]any{
+			"instance_endpoint": "my-rds-instance",
+			"region":            "us-east-1",
+		},
+	}
+
+	m := cfg.toInstanceMap()
+
+	assert.Equal(t, "mydb.rds.amazonaws.com", m["host"])
+	awsMap, ok := m["aws"].(map[string]any)
+	require.True(t, ok, "aws should be a map[string]any")
+	assert.Equal(t, "my-rds-instance", awsMap["instance_endpoint"])
+	assert.Equal(t, "us-east-1", awsMap["region"])
+}
+
+func TestDODatabaseConfig_ToInstanceMap_OnlyAllowlistKeys(t *testing.T) {
+	// All fields in the struct should map to dbCredentialAllowList keys.
+	// If a new struct field is added without a corresponding allowlist entry,
+	// toInstanceMap won't emit it (by design).
+	cfg := DODatabaseConfig{
+		Host:     "h",
+		Port:     1,
+		DBName:   "d",
+		Username: "u",
+		Password: "p",
+	}
+	m := cfg.toInstanceMap()
+	for key := range m {
+		found := false
+		for _, allowed := range dbCredentialAllowList {
+			if key == allowed {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "key %q in output is not in dbCredentialAllowList", key)
+	}
+}
+
+func TestDODatabaseConfig_MatchesIdentifier(t *testing.T) {
+	cfg := DODatabaseConfig{Host: "localhost", DBName: "mydb"}
+
+	t.Run("exact match", func(t *testing.T) {
+		assert.True(t, cfg.matchesIdentifier(&DBIdentifier{Host: "localhost", DBName: "mydb"}))
+	})
+
+	t.Run("host mismatch", func(t *testing.T) {
+		assert.False(t, cfg.matchesIdentifier(&DBIdentifier{Host: "otherhost", DBName: "mydb"}))
+	})
+
+	t.Run("dbname mismatch", func(t *testing.T) {
+		assert.False(t, cfg.matchesIdentifier(&DBIdentifier{Host: "localhost", DBName: "otherdb"}))
+	})
+
+	t.Run("empty dbname matches empty", func(t *testing.T) {
+		emptyCfg := DODatabaseConfig{Host: "localhost"}
+		assert.True(t, emptyCfg.matchesIdentifier(&DBIdentifier{Host: "localhost", DBName: ""}))
+	})
+
+	t.Run("empty dbname does not match non-empty", func(t *testing.T) {
+		emptyCfg := DODatabaseConfig{Host: "localhost"}
+		assert.False(t, emptyCfg.matchesIdentifier(&DBIdentifier{Host: "localhost", DBName: "mydb"}))
+	})
+}

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -66,9 +66,9 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			continue
 		}
 
-		baseCfg, instance, err := c.findPostgresConfig(&payload.DBIdentifier)
+		auth, baseCfg, err := c.resolveCredentials(&payload.DBIdentifier)
 		if err != nil {
-			c.log.Warnf("No matching postgres config for %s: %v", configID, err)
+			c.log.Warnf("No matching credentials for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
 			c.collectUnschedule(configID, &changes)
 			continue
@@ -79,7 +79,7 @@ func (c *component) onRCUpdate(updates map[string]state.RawConfig, applyStatus f
 			remoteConfigID = configID
 		}
 
-		checkConfig, err := c.buildCheckConfig(&payload, baseCfg, instance, remoteConfigID)
+		checkConfig, err := c.buildCheckConfig(&payload, baseCfg, auth, remoteConfigID)
 		if err != nil {
 			c.log.Errorf("Failed to build check config for %s: %v", configID, err)
 			applyStatus(path, state.ApplyStatus{State: state.ApplyStateError, Error: err.Error()})
@@ -132,6 +132,34 @@ func (c *component) collectUnschedule(configID string, changes *integration.Conf
 
 	changes.Unschedule = append(changes.Unschedule, prev)
 	c.log.Infof("Unscheduled Data Observability query action check: %s", configID)
+}
+
+// resolveCredentials finds credentials for the given DB identifier.
+// It first checks DO-specific database configs from datadog.yaml, then falls back
+// to borrowing credentials from a matching postgres check config.
+func (c *component) resolveCredentials(dbID *DBIdentifier) (map[string]any, *integration.Config, error) {
+	// First: check dedicated DO database credentials
+	for i := range c.databases {
+		if c.databases[i].matchesIdentifier(dbID) {
+			baseCfg := &integration.Config{
+				Name:     "postgres",
+				Provider: "datadog.yaml",
+			}
+			return c.databases[i].toInstanceMap(), baseCfg, nil
+		}
+	}
+
+	// Fallback: borrow credentials from a matching postgres check instance
+	baseCfg, instance, err := c.findPostgresConfig(dbID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	c.log.Warnf("Using credentials from postgres check for DO query actions (host=%s, dbname=%s). "+
+		"Configure dedicated credentials under data_observability.query_actions.databases "+
+		"in datadog.yaml to avoid sharing credentials with DBM.", dbID.Host, dbID.DBName)
+
+	return extractDBAuthFromInstance(instance), baseCfg, nil
 }
 
 // findPostgresConfig finds a postgres config that matches the given identifier.
@@ -196,10 +224,10 @@ func extractDBAuthFromInstance(instance map[string]any) map[string]any {
 }
 
 // buildCheckConfig creates a check config for the do_query_actions check.
-// Returns an error if auth extraction or instance YAML serialization fails;
+// auth contains the database credential fields already resolved by resolveCredentials.
+// Returns an error if instance YAML serialization fails;
 // callers must report ApplyStateError to RC rather than scheduling the broken config.
-func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integration.Config, instance map[string]any, remoteConfigID string) (integration.Config, error) {
-	auth := extractDBAuthFromInstance(instance)
+func (c *component) buildCheckConfig(payload *DOQueryPayload, baseCfg *integration.Config, auth map[string]any, remoteConfigID string) (integration.Config, error) {
 
 	queries := make([]map[string]any, 0, len(payload.Queries))
 	for _, q := range payload.Queries {

--- a/comp/dataobs/queryactions/impl/handler.go
+++ b/comp/dataobs/queryactions/impl/handler.go
@@ -155,9 +155,13 @@ func (c *component) resolveCredentials(dbID *DBIdentifier) (map[string]any, *int
 		return nil, nil, err
 	}
 
-	c.log.Warnf("Using credentials from postgres check for DO query actions (host=%s, dbname=%s). "+
-		"Configure dedicated credentials under data_observability.query_actions.databases "+
-		"in datadog.yaml to avoid sharing credentials with DBM.", dbID.Host, dbID.DBName)
+	key := dbID.Host + ":" + dbID.DBName
+	if !c.warnedFallback[key] {
+		c.warnedFallback[key] = true
+		c.log.Warnf("Using credentials from postgres check for DO query actions (host=%s, dbname=%s); "+
+			"none of the %d entries in data_observability.query_actions.databases matched.",
+			dbID.Host, dbID.DBName, len(c.databases))
+	}
 
 	return extractDBAuthFromInstance(instance), baseCfg, nil
 }

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -48,6 +48,16 @@ func newTestComponentWithAC(t *testing.T, configs []integration.Config) *compone
 	}
 }
 
+func newTestComponentWithDatabases(t *testing.T, configs []integration.Config, databases []DODatabaseConfig) *component {
+	t.Helper()
+	return &component{
+		log:           logmock.New(t),
+		ac:            newMockAutodiscovery(t, configs),
+		databases:     databases,
+		activeConfigs: make(map[string]integration.Config),
+	}
+}
+
 func TestIsPostgresIntegration(t *testing.T) {
 	assert.True(t, isPostgresIntegration("postgres"))
 	assert.False(t, isPostgresIntegration("mysql"))
@@ -594,6 +604,72 @@ func TestOnRCUpdate_NoMatchingPostgres_ReportsError(t *testing.T) {
 	assert.Equal(t, state.ApplyStateError, statuses["path/cfg-nomatch"].State)
 	assert.Empty(t, changes.Schedule)
 	assert.Empty(t, c.activeConfigs)
+}
+
+// --- resolveCredentials tests ---
+
+func TestResolveCredentials_DOConfigTakesPriority(t *testing.T) {
+	// Both DO database config and postgres check exist — DO config should win.
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\nport: 5432\nusername: pg_user\npassword: pg_pass\ndbname: mydb\n")},
+	}
+	doDatabases := []DODatabaseConfig{
+		{Host: "localhost", Port: 5432, DBName: "mydb", Username: "do_reader", Password: "do_pass"},
+	}
+	c := newTestComponentWithDatabases(t, []integration.Config{postgresCfg}, doDatabases)
+
+	auth, baseCfg, err := c.resolveCredentials(&DBIdentifier{Host: "localhost", DBName: "mydb"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "do_reader", auth["username"], "should use DO config credentials, not postgres check")
+	assert.Equal(t, "do_pass", auth["password"])
+	assert.Equal(t, "datadog.yaml", baseCfg.Provider)
+}
+
+func TestResolveCredentials_FallbackToPostgres(t *testing.T) {
+	// No DO databases configured — should fall back to postgres check.
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\nport: 5432\nusername: pg_user\npassword: pg_pass\ndbname: mydb\n")},
+	}
+	c := newTestComponentWithDatabases(t, []integration.Config{postgresCfg}, nil)
+
+	auth, baseCfg, err := c.resolveCredentials(&DBIdentifier{Host: "localhost", DBName: "mydb"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "pg_user", auth["username"], "should fall back to postgres check credentials")
+	assert.Equal(t, "pg_pass", auth["password"])
+	assert.Equal(t, "file", baseCfg.Provider)
+}
+
+func TestResolveCredentials_DOConfigNoMatch_FallsBackToPostgres(t *testing.T) {
+	// DO databases configured but for a different host — should fall back to postgres check.
+	postgresCfg := integration.Config{
+		Name:      "postgres",
+		Provider:  "file",
+		Instances: []integration.Data{integration.Data("host: localhost\nport: 5432\nusername: pg_user\npassword: pg_pass\ndbname: mydb\n")},
+	}
+	doDatabases := []DODatabaseConfig{
+		{Host: "otherhost", Port: 5432, DBName: "otherdb", Username: "do_reader", Password: "do_pass"},
+	}
+	c := newTestComponentWithDatabases(t, []integration.Config{postgresCfg}, doDatabases)
+
+	auth, _, err := c.resolveCredentials(&DBIdentifier{Host: "localhost", DBName: "mydb"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "pg_user", auth["username"], "should fall back to postgres when DO config doesn't match")
+}
+
+func TestResolveCredentials_NoMatchAnywhere(t *testing.T) {
+	// No DO databases, no postgres configs — should return error.
+	c := newTestComponentWithDatabases(t, []integration.Config{}, nil)
+
+	_, _, err := c.resolveCredentials(&DBIdentifier{Host: "notfound", DBName: "mydb"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no postgres config found")
 }
 
 // TestOnRCUpdate_MalformedPostgresYAML_SurfacesParseError verifies that when a postgres

--- a/comp/dataobs/queryactions/impl/handler_test.go
+++ b/comp/dataobs/queryactions/impl/handler_test.go
@@ -537,6 +537,57 @@ func TestOnRCUpdate_ValidConfig_SchedulesCheck(t *testing.T) {
 	require.Contains(t, c.activeConfigs, "cfg-happy")
 }
 
+// TestOnRCUpdate_WithDODatabases_SchedulesCheck verifies the full path: a component with
+// dedicated DO database credentials receives an RC update and successfully schedules a check
+// using the DO credentials (not postgres check credentials).
+func TestOnRCUpdate_WithDODatabases_SchedulesCheck(t *testing.T) {
+	doDatabases := []DODatabaseConfig{
+		{Host: "localhost", Port: 5432, DBName: "mydb", Username: "do_reader", Password: "do_secret"},
+	}
+	c := newTestComponentWithDatabases(t, nil, doDatabases) // no postgres configs
+
+	payload := DOQueryPayload{
+		ConfigID:     "cfg-do-creds",
+		DBIdentifier: DBIdentifier{Type: "self-hosted", Host: "localhost", DBName: "mydb"},
+		Queries: []QuerySpec{
+			{
+				MonitorID:       99,
+				Type:            "run_query",
+				Query:           "SELECT count(*) FROM orders",
+				IntervalSeconds: 60,
+				TimeoutSeconds:  10,
+				Entity:          EntityMetadata{Platform: "postgres", Database: "mydb", Table: "orders"},
+			},
+		},
+	}
+	payloadJSON, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	updates := map[string]state.RawConfig{
+		"path/cfg-do": {Config: payloadJSON, Metadata: state.Metadata{ID: "rc-do-id"}},
+	}
+	statuses, changes := collectStatuses(c, updates)
+
+	require.Equal(t, state.ApplyStateAcknowledged, statuses["path/cfg-do"].State)
+	require.Len(t, changes.Schedule, 1)
+	assert.Equal(t, "do_query_actions", changes.Schedule[0].Name)
+	assert.Equal(t, "datadog.yaml", changes.Schedule[0].Provider, "should use synthetic provider from DO config")
+
+	var instance map[string]any
+	require.NoError(t, yaml.Unmarshal(changes.Schedule[0].Instances[0], &instance))
+	assert.Equal(t, "do_reader", instance["username"], "should use DO database credentials")
+	assert.Equal(t, "do_secret", instance["password"])
+	assert.Equal(t, "rc-do-id", instance["remote_config_id"])
+	assert.Equal(t, "localhost", instance["host"])
+
+	queries, ok := instance["queries"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, queries, 1)
+	assert.Equal(t, "SELECT count(*) FROM orders", queries[0].(map[string]interface{})["query"])
+
+	require.Contains(t, c.activeConfigs, "cfg-do-creds")
+}
+
 // TestOnRCUpdate_UpdateReplacesExistingCheck verifies that two sequential onRCUpdate calls
 // with the same config_id correctly unschedule the previous check and schedule the updated one.
 func TestOnRCUpdate_UpdateReplacesExistingCheck(t *testing.T) {
@@ -661,6 +712,21 @@ func TestResolveCredentials_DOConfigNoMatch_FallsBackToPostgres(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "pg_user", auth["username"], "should fall back to postgres when DO config doesn't match")
+}
+
+func TestResolveCredentials_SkipsNonMatchingEntry_UsesLaterMatch(t *testing.T) {
+	// First entry doesn't match, second does — should use second entry's credentials.
+	doDatabases := []DODatabaseConfig{
+		{Host: "otherhost", Port: 5432, DBName: "otherdb", Username: "wrong_user", Password: "wrong_pass"},
+		{Host: "localhost", Port: 5432, DBName: "mydb", Username: "correct_user", Password: "correct_pass"},
+	}
+	c := newTestComponentWithDatabases(t, nil, doDatabases)
+
+	auth, _, err := c.resolveCredentials(&DBIdentifier{Host: "localhost", DBName: "mydb"})
+	require.NoError(t, err)
+
+	assert.Equal(t, "correct_user", auth["username"], "should use the second matching entry")
+	assert.Equal(t, "correct_pass", auth["password"])
 }
 
 func TestResolveCredentials_NoMatchAnywhere(t *testing.T) {

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -21,6 +21,7 @@ import (
 	compdef "github.com/DataDog/datadog-agent/comp/def"
 	"github.com/DataDog/datadog-agent/comp/remote-config/rcclient"
 	"github.com/DataDog/datadog-agent/pkg/config/remote/data"
+	"github.com/DataDog/datadog-agent/pkg/config/structure"
 	"github.com/DataDog/datadog-agent/pkg/remoteconfig/state"
 )
 
@@ -44,6 +45,7 @@ type component struct {
 	ac              autodiscovery.Component
 	rcclient        rcclient.Component
 	enabled         bool
+	databases       []DODatabaseConfig
 	activeConfigs   map[string]integration.Config
 	activeConfigsMu sync.Mutex
 }
@@ -52,11 +54,19 @@ type component struct {
 func NewComponent(reqs Requires) (Provides, error) {
 	enabled := reqs.Config.GetBool("data_observability.query_actions.enabled")
 
+	var doConfig struct {
+		Databases []DODatabaseConfig `mapstructure:"databases"`
+	}
+	if err := structure.UnmarshalKey(reqs.Config, "data_observability.query_actions", &doConfig); err != nil {
+		reqs.Log.Warnf("Failed to parse data_observability.query_actions config: %v", err)
+	}
+
 	c := &component{
 		log:           reqs.Log,
 		ac:            reqs.Ac,
 		rcclient:      reqs.RcClient,
 		enabled:       enabled,
+		databases:     doConfig.Databases,
 		activeConfigs: make(map[string]integration.Config),
 	}
 
@@ -156,9 +166,8 @@ func (c *component) Stream(ctx context.Context) <-chan integration.ConfigChanges
 			close(outCh)
 		}()
 
-		// Check immediately: the file config provider runs before this one in LoadAndRun,
-		// so postgres is typically already available when Stream() is called.
-		if c.hasPostgresIntegration() {
+		// Subscribe immediately if we have dedicated database credentials or a postgres check.
+		if len(c.databases) > 0 || c.hasPostgresIntegration() {
 			subscribeAndWait()
 			return
 		}

--- a/comp/dataobs/queryactions/impl/queryactions.go
+++ b/comp/dataobs/queryactions/impl/queryactions.go
@@ -8,6 +8,7 @@ package queryactionsimpl
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -46,6 +47,7 @@ type component struct {
 	rcclient        rcclient.Component
 	enabled         bool
 	databases       []DODatabaseConfig
+	warnedFallback  map[string]bool // dedup fallback warnings by "host:dbname"
 	activeConfigs   map[string]integration.Config
 	activeConfigsMu sync.Mutex
 }
@@ -58,16 +60,17 @@ func NewComponent(reqs Requires) (Provides, error) {
 		Databases []DODatabaseConfig `mapstructure:"databases"`
 	}
 	if err := structure.UnmarshalKey(reqs.Config, "data_observability.query_actions", &doConfig); err != nil {
-		reqs.Log.Warnf("Failed to parse data_observability.query_actions config: %v", err)
+		return Provides{}, fmt.Errorf("failed to parse data_observability.query_actions config: %w", err)
 	}
 
 	c := &component{
-		log:           reqs.Log,
-		ac:            reqs.Ac,
-		rcclient:      reqs.RcClient,
-		enabled:       enabled,
-		databases:     doConfig.Databases,
-		activeConfigs: make(map[string]integration.Config),
+		log:            reqs.Log,
+		ac:             reqs.Ac,
+		rcclient:       reqs.RcClient,
+		enabled:        enabled,
+		databases:      doConfig.Databases,
+		warnedFallback: make(map[string]bool),
+		activeConfigs:  make(map[string]integration.Config),
 	}
 
 	reqs.Lc.Append(compdef.Hook{

--- a/comp/dataobs/queryactions/impl/queryactions_test.go
+++ b/comp/dataobs/queryactions/impl/queryactions_test.go
@@ -129,6 +129,28 @@ func TestStream_SubscribesImmediatelyWhenPostgresAvailable(t *testing.T) {
 	assert.NotNil(t, fn)
 }
 
+func TestStream_SubscribesImmediatelyWhenDatabasesConfigured(t *testing.T) {
+	// When dedicated DO database credentials are configured, Stream() must subscribe
+	// to RC immediately even without a postgres check.
+	rc := newMockRCClient()
+	c := &component{
+		log:      logmock.New(t),
+		ac:       newMockAutodiscovery(t, nil), // no postgres
+		rcclient: rc,
+		databases: []DODatabaseConfig{
+			{Host: "localhost", Port: 5432, DBName: "mydb", Username: "do_reader", Password: "secret"},
+		},
+		activeConfigs: make(map[string]integration.Config),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c.Stream(ctx)
+
+	fn := waitSubscribe(t, rc)
+	assert.NotNil(t, fn)
+}
+
 func TestStream_NoPostgresAvailable_DoesNotSubscribeImmediately(t *testing.T) {
 	// Without postgres, Subscribe must not be called before the first ticker tick (10s).
 	c, rc := newStreamComponent(t, nil)

--- a/pkg/config/setup/common_settings.go
+++ b/pkg/config/setup/common_settings.go
@@ -977,6 +977,7 @@ func initCoreAgentFull(config pkgconfigmodel.Setup) {
 
 	// Data Observability
 	config.BindEnvAndSetDefault("data_observability.query_actions.enabled", false)
+	config.SetKnown("data_observability.query_actions.databases") //nolint:forbidigo // TODO: replace by 'SetDefaultAndBindEnv'
 	bindEnvAndSetLogsConfigKeys(config, "data_observability.forwarder.")
 
 	// Reverse DNS Enrichment


### PR DESCRIPTION
### What does this PR do?

Adds optional dedicated database credentials for Data Observability query actions via `data_observability.query_actions.databases` in `datadog.yaml`. When configured and matching by host+dbname, these credentials are used instead of borrowing from an existing postgres check. The postgres check fallback is preserved for backwards compatibility.

### Motivation

The DBM team does not want DO query actions sharing credentials with the postgres DBM check. Dedicated credentials give operators explicit control over what the DO component connects with, and decouple it from DBM check configuration changes.

### Describe how you validated your changes

Unit tests cover the two-tier credential resolution (DO config priority, postgres fallback, no-match error), config parsing (`toInstanceMap` with explicit false preservation, nested maps, allowlist sync), and the immediate RC subscribe path when databases are configured. Validated end-to-end locally with a Podman-based agent + postgres setup: pushed an RC config via staging, confirmed the check scheduled, executed queries, and sent results to the `do-query-results` intake pipeline.

### Additional Notes

The `databases` config mirrors the same credential fields as the postgres check (`host`, `port`, `username`, `password`, SSL/TLS, `aws`, `managed_authentication`). An allowlist ensures only known auth fields are passed through, preventing accidental overwrites of programmatic keys like `remote_config_id` or `queries`.
