### PR TITLE
Add .gitignore rule for new test artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,7 +156,7 @@ packer.json
 devenv/iso
 devenv/output-virtualbox-iso/
 devenv/packer_cache
-test_output.json
+test_output*.json
 module_test_output.json
 e2e_test_output.json
 e2e_test_output.json.*.part
@@ -249,6 +249,3 @@ AUTO_JIRA.md
 
 # Zed config
 .zed
-
-# dda inv test artifacts (test_output.json, test_output_unified.json)
-/test_output*.json

--- a/.gitignore
+++ b/.gitignore
@@ -251,4 +251,4 @@ AUTO_JIRA.md
 .zed
 
 # dda inv test artifacts (test_output.json, test_output_unified.json)
-test_output*.json
+/test_output*.json

--- a/.gitignore
+++ b/.gitignore
@@ -249,3 +249,6 @@ AUTO_JIRA.md
 
 # Zed config
 .zed
+
+# dda inv test artifacts (test_output.json, test_output_unified.json)
+test_output*.json


### PR DESCRIPTION
### What does this PR do?
Adds a new .gitignore rule `test_output*.json` intending to at cover `test_output.json`, `test_output_unified.json`

### Motivation
New artifacts introduced by https://github.com/DataDog/datadog-agent/pull/47621 and not wanting to accidentally commit them 😺 

### Describe how you validated your changes

### Additional Notes
