### PR TITLE
[autoscaling] Source containers list from WLM/K8s API server

### DIFF
--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers.go
@@ -577,16 +577,17 @@ func getPodResizeStatus(pod *workloadmeta.KubernetesPod, recommendationID string
 func fromAutoscalerToContainerResourcePatches(autoscalerInternal *model.PodAutoscalerInternal, pod *workloadmeta.KubernetesPod) []workloadpatcher.ContainerResourcePatch {
 	containersResources := autoscalerInternal.ScalingValues().Vertical.ContainerResources
 
-	// Build a set of containers that actually exist in the pod so we only patch
-	// containers present in the running pod, not every container in the recommendation.
-	podContainers := make(map[string]struct{}, len(pod.Containers))
-	for _, c := range pod.Containers {
-		podContainers[c.Name] = struct{}{}
+	// Build a map from container name to container resources.
+	recoByName := make(map[string]datadoghqcommon.DatadogPodAutoscalerContainerResources, len(containersResources))
+	for _, cr := range containersResources {
+		recoByName[cr.Name] = cr
 	}
 
+	// Build the list of patches ordered to API server pod container order.
 	patches := make([]workloadpatcher.ContainerResourcePatch, 0, len(containersResources))
-	for _, cr := range containersResources {
-		if _, ok := podContainers[cr.Name]; !ok {
+	for _, c := range pod.Containers {
+		cr, ok := recoByName[c.Name]
+		if !ok {
 			continue
 		}
 		patches = append(patches, workloadpatcher.ContainerResourcePatch{

--- a/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
+++ b/pkg/clusteragent/autoscaling/workload/controller_vertical_helpers_test.go
@@ -623,3 +623,36 @@ func TestApplyVerticalConstraints_ValidationErrors(t *testing.T) {
 	// Vertical values should be untouched
 	assert.Equal(t, "original-hash", vertical.ResourcesHash)
 }
+
+func TestFromAutoscalerToContainerResourcePatches_PreservesPodOrder(t *testing.T) {
+	sv := &model.VerticalScalingValues{
+		ResourcesHash: "r1",
+		ContainerResources: []datadoghqcommon.DatadogPodAutoscalerContainerResources{
+			{Name: "c3", Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m")}},
+			{Name: "c1", Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}},
+			{Name: "c2", Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")}},
+		},
+	}
+	ai := (&model.FakePodAutoscalerInternal{
+		Namespace:     "default",
+		Name:          "ai",
+		ScalingValues: model.ScalingValues{Vertical: sv},
+	}).Build()
+
+	pod := &workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{ID: "pod1"},
+		// Pod defines containers in a specific order that differs from the recommendation.
+		Containers: []workloadmeta.OrchestratorContainer{
+			{Name: "c1"},
+			{Name: "c2"},
+			{Name: "c3"},
+		},
+	}
+
+	patches := fromAutoscalerToContainerResourcePatches(&ai, pod)
+
+	require.Len(t, patches, 3)
+	assert.Equal(t, "c1", patches[0].Name, "patch order must follow pod container order")
+	assert.Equal(t, "c2", patches[1].Name)
+	assert.Equal(t, "c3", patches[2].Name)
+}


### PR DESCRIPTION
### What does this PR do?
Circumvents a bug where the `PodAutoscalerInternal` sometimes lists containers in the wrong order relative to the API server's view. This causes resize patches sent to the API server to fail with the message that "containers cannot be reordered on resize".

### Motivation
Fix this [warning log](https://ddstaging.datadoghq.com/logs?query=%22containers%20may%20not%20be%20renamed%20or%20reordered%20on%20resize%22&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1774628466343&to_ts=1774632066343&live=true)

### Describe how you validated your changes
CI

### Additional Notes
