### PR TITLE
[CWS] fix e2e tests: use Fleet Automation API to check CWS status

### DIFF
--- a/test/new-e2e/tests/cws/api/client.go
+++ b/test/new-e2e/tests/cws/api/client.go
@@ -43,6 +43,7 @@ func NewClient() *Client {
 	)
 
 	cfg := datadog.NewConfiguration()
+        cfg.SetUnstableOperationEnabled("v2.ListFleetAgents", true)
 
 	return &Client{
 		api:    datadog.NewAPIClient(cfg),

--- a/test/new-e2e/tests/cws/api/client.go
+++ b/test/new-e2e/tests/cws/api/client.go
@@ -43,7 +43,7 @@ func NewClient() *Client {
 	)
 
 	cfg := datadog.NewConfiguration()
-        cfg.SetUnstableOperationEnabled("v2.ListFleetAgents", true)
+	cfg.SetUnstableOperationEnabled("v2.ListFleetAgents", true)
 
 	return &Client{
 		api:    datadog.NewAPIClient(cfg),

--- a/test/new-e2e/tests/cws/api/ddsql.go
+++ b/test/new-e2e/tests/cws/api/ddsql.go
@@ -8,6 +8,7 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -30,6 +31,7 @@ type DDSQLTableQueryParams struct {
 	DefaultEnd      int    `json:"default_end"`
 	DefaultInterval int    `json:"default_interval"`
 	Query           string `json:"query"`
+	Source          string `json:"source"`
 }
 
 // DDSQLTableResponse is a struct that represents a DDSQL table response
@@ -63,6 +65,7 @@ func (c *Client) TableQuery(query string) (*DDSQLTableResponse, error) {
 		DefaultEnd:      int(now.UnixMilli()),
 		DefaultInterval: 20000,
 		Query:           query,
+		Source:          "inventories",
 	}
 	payload := JSONAPIPayload[DDSQLTableQueryParams]{
 		Data: JSONAPIPayloadData[DDSQLTableQueryParams]{
@@ -94,6 +97,10 @@ func (c *Client) TableQuery(query string) (*DDSQLTableResponse, error) {
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("ddsql table query failed with status %d: %s", resp.StatusCode, string(data))
 	}
 
 	var ddSQLResp DDSQLTableResponse

--- a/test/new-e2e/tests/cws/api/fleet.go
+++ b/test/new-e2e/tests/cws/api/fleet.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+// IsProductEnabled returns true if the given product is listed in enabled_products
+// for the agent with the specified hostname, using the Fleet Automation API.
+func (c *Client) IsProductEnabled(hostname, product string) (bool, error) {
+	fleetAPI := datadogV2.NewFleetAutomationApi(c.api)
+
+	opts := datadogV2.NewListFleetAgentsOptionalParameters().
+		WithFilter("hostname:" + hostname)
+
+	resp, r, err := fleetAPI.ListFleetAgents(c.ctx, *opts)
+	if r != nil {
+		_ = r.Body.Close()
+	}
+	if err != nil {
+		return false, fmt.Errorf("fleet automation API request failed: %w", err)
+	}
+
+	for _, agent := range resp.Data.Attributes.GetAgents() {
+		if agent.GetHostname() != hostname {
+			continue
+		}
+		for _, p := range agent.GetEnabledProducts() {
+			if p == product {
+				return true, nil
+			}
+		}
+		return false, nil
+	}
+
+	return false, fmt.Errorf("no agent found with hostname %s", hostname)
+}

--- a/test/new-e2e/tests/cws/common.go
+++ b/test/new-e2e/tests/cws/common.go
@@ -293,50 +293,11 @@ func testRuleEvent(t assert.TestingT, ts testSuite, ruleID string, extraValidati
 }
 
 func testCwsEnabled(t assert.TestingT, ts testSuite) {
-	query := fmt.Sprintf("SELECT h.hostname, a.feature_cws_enabled FROM host h JOIN datadog_agent a USING (datadog_agent_key) WHERE h.hostname = '%s'", ts.Hostname())
-	resp, err := ts.Client().TableQuery(query)
-	if !assert.NoErrorf(t, err, "ddsql query failed") {
+	enabled, err := ts.Client().IsProductEnabled(ts.Hostname(), "cws")
+	if !assert.NoErrorf(t, err, "fleet automation API request failed for host %s", ts.Hostname()) {
 		return
 	}
-	if !assert.Len(t, resp.Data, 1, "ddsql query didn't returned a single row") {
-		return
-	}
-	if !assert.Len(t, resp.Data[0].Attributes.Columns, 2, "ddsql query didn't returned two columns") {
-		return
-	}
-
-	columnChecks := []struct {
-		name          string
-		expectedValue interface{}
-	}{
-		{
-			name:          "hostname",
-			expectedValue: ts.Hostname(),
-		},
-		{
-			name:          "feature_cws_enabled",
-			expectedValue: true,
-		},
-	}
-
-	for _, columnCheck := range columnChecks {
-		result := false
-		for _, column := range resp.Data[0].Attributes.Columns {
-			if column.Name == columnCheck.name {
-				if !assert.Len(t, column.Values, 1, "column %s should have a single value", columnCheck.name) {
-					return
-				}
-				if !assert.Equal(t, columnCheck.expectedValue, column.Values[0], "column %s should be equal", columnCheck.name) {
-					return
-				}
-				result = true
-				break
-			}
-		}
-		if !assert.Truef(t, result, "column %s isn't present or has an unexpected value", columnCheck.name) {
-			return
-		}
-	}
+	assert.Truef(t, enabled, "cws should be enabled for host %s", ts.Hostname())
 }
 
 func testSelftestsEvent(t assert.TestingT, ts testSuite, extraValidations ...eventValidationCb[*api.SelftestsEvent]) {


### PR DESCRIPTION
### What does this PR do?

Replace the DDSQL-based CWS activation check with the Fleet Automation
API (v2.ListFleetAgents). The client now explicitly opts into the
unstable operation via SetUnstableOperationEnabled so the call is not
rejected at runtime.

Also adds InstanceID support to test queries and switches the Fargate
suite to identify agents by instance tag instead of hostname.


### Motivation

### Describe how you validated your changes

### Additional Notes
