### PR TITLE
Enable `bazel --disk_cache` if XDG_CACHE_HOME set

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,6 +16,7 @@ startup --max_idle_secs=28800 # Keep the server alive for at most 8 hours of ina
 common --@rules_python//python/config_settings:bootstrap_impl=script # https://github.com/bazel-contrib/rules_python/blob/main/BZLMOD_SUPPORT.md
 common --check_direct_dependencies=error # Escalate any bypassed `bazel_dep` to a resolution failure
 common --enable_platform_specific_config # Supported OS identifiers are linux, macos, windows, freebsd, and openbsd
+common --experimental_disk_cache_gc_max_size=5G # Cap applied whenever --disk_cache is also set, no-op otherwise
 common --experimental_ui_max_stdouterr_bytes=1073741819 # why?
 common --http_timeout_scaling=3.0 # At least one attempt reaches 30s (3,6,12,24,30,30,30,30) instead of only 10s (1,2,4,8,10,10,10,10)
 common --incompatible_strict_action_env # Do not leak local environment variables into the build context

--- a/.github/actions/bazel-cache/action.yml
+++ b/.github/actions/bazel-cache/action.yml
@@ -19,6 +19,7 @@ runs:
         key: bazel-${{ hashFiles('.go-version', '.python-version') }}
         path: |
           .cache/bazel/*/cache
+          .cache/bazel/disk-cache
           .cache/go
           .cache/ms-go
           .cache/pip

--- a/.gitlab/build/bazel/defs.yml
+++ b/.gitlab/build/bazel/defs.yml
@@ -24,6 +24,7 @@
         files: [ .go-version, .python-version ]
       paths:
         - .cache/bazel/*/cache
+        - .cache/bazel/disk-cache
         - .cache/go
         - .cache/ms-go
         - .cache/pip

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -391,8 +391,8 @@
         "usagesDigest": "CKsn1dtme4oztWA0td45Tt6oCZK6MZnpIocVVZK14sU=",
         "recordedInputs": [
           "FILE:@@//.bazelversion 59b003a1f3465ae6084432329f8265e860cbaac0bd4a92a4f3ea6b979a6eed66",
-          "FILE:@@//tools/bazel 6804bf06e2253629bf30d0a777fc8baf943b50529d230a059f1dc46296dbf4d6",
-          "FILE:@@//tools/bazel.bat c2f0c08f179108517d08b1e34d19b3aabd80458d9e2575f9de08e640ba9b4ac3",
+          "FILE:@@//tools/bazel dc2842f9517355471b221492ddbad546ab70c6b9b3f22e4a2e9c5480bcaed720",
+          "FILE:@@//tools/bazel.bat 8d4b069aa2d353f11b16903dc189623220bd747d4492357fd8a06fa712a964a6",
           "FILE:@@//tools/bazelisk.md 184864dc41f9cd398f786ba7c7cd858942d19daa792203e0b18a1a3bfaf372f0"
         ],
         "generatedRepoSpecs": {}
@@ -411,18 +411,18 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "abseil-cpp": "20250512.1",
+                "abseil-cpp": "20250814.1",
                 "abseil-py": "2.1.0",
                 "apple_support": "2.3.0",
                 "aspect_bazel_lib": "2.22.5",
                 "aspect_tools_telemetry": "0.3.2",
-                "bazel_features": "1.36.0",
+                "bazel_features": "1.42.1",
                 "bazel_lib": "3.2.2",
                 "bazel_skylib": "1.9.0",
                 "bazel_worker_api": "0.0.8",
                 "bazel_worker_java": "0.0.8",
                 "buildifier_prebuilt": "7.3.1",
-                "buildozer": "7.1.2",
+                "buildozer": "8.5.1",
                 "bzip2": "1.0.8.bcr.3",
                 "gawk": "5.3.2.bcr.3",
                 "googletest": "1.17.0",
@@ -440,7 +440,7 @@
                 "rules_android": "0.6.4",
                 "rules_cc": "0.2.17",
                 "rules_flex": "0.4",
-                "rules_java": "8.14.0",
+                "rules_java": "9.0.3",
                 "rules_jvm_external": "6.7",
                 "rules_kotlin": "2.2.2",
                 "rules_m4": "0.3.bcr.1",

--- a/tools/bazel
+++ b/tools/bazel
@@ -30,9 +30,10 @@ if [ -n "${XDG_CACHE_HOME:-}" ]; then
   unset GOCACHE                               # https://pkg.go.dev/cmd/go#hdr-Build_and_test_caching
   export GOMODCACHE="$XDG_CACHE_HOME"/go/mod  # https://wiki.archlinux.org/title/XDG_Base_Directory#Partial
   unset PIP_CACHE_DIR                         # https://pip.pypa.io/en/stable/topics/caching/#default-paths
-  [ -n "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && extra_args+=(--config=ci)
+  extra_args+=(--disk_cache="$XDG_CACHE_HOME/bazel/disk-cache")
   # https://github.com/bazelbuild/bazel/issues/26384
   [ "$XDG_CACHE_HOME" = "$(dirname "$(dirname "$0")")/.cache" ] && extra_args+=(--repo_contents_cache=)
+  [ -n "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ] && extra_args+=(--config=ci)
 fi
 
 # "--startup cmd ..." -> "--startup cmd --config=ci ..."

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -38,11 +38,10 @@ if defined XDG_CACHE_HOME (
   :: https://github.com/bazelbuild/bazel/issues/27808
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
-  if defined CI if not defined GITHUB_ACTIONS set "extra_args=--config=ci"
+  set "extra_args=--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
-  for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" (
-    if defined extra_args (set "extra_args=!extra_args! --repo_contents_cache=") else set "extra_args=--repo_contents_cache="
-  )
+  for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
+  if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci"
 )
 
 :: Check legacy max path length of 260 characters got lifted, or fail with instructions

--- a/tools/bazel.bat
+++ b/tools/bazel.bat
@@ -38,7 +38,7 @@ if defined XDG_CACHE_HOME (
   :: https://github.com/bazelbuild/bazel/issues/27808
   set "bazel_home=%XDG_CACHE_HOME%\bazel"
   set bazel_home_startup_option="--output_user_root=!bazel_home!"
-  set "extra_args=--disk_cache=!bazel_home!\disk-cache"
+  set extra_args="--disk_cache=!bazel_home!\disk-cache"
   :: https://github.com/bazelbuild/bazel/issues/26384
   for %%i in ("%~dp0..\.cache") do if "!XDG_CACHE_HOME!" == "%%~fi" set "extra_args=!extra_args! --repo_contents_cache="
   if defined CI if not defined GITHUB_ACTIONS set "extra_args=!extra_args! --config=ci"


### PR DESCRIPTION
### What does this PR do?
Pass `--disk_cache=$XDG_CACHE_HOME/bazel/disk-cache` to every `bazel` invocation in `tools/bazel` and `tools/bazel.bat` whenever `XDG_CACHE_HOME` is defined.

### Motivation
The disk cache persists Bazel action results across invocations, benefiting both local incremental builds and CI runs.

On CI, the cache artifact is restored before the build (and saved after in `main`, as per our progressive cache definition), so unchanged actions are not re-executed across jobs.

`XDG_CACHE_HOME` is the single knob callers use to point Bazel at a persistent location, making the disk cache location consistent with the rest of the cache hierarchy.

### Additional Notes
`extra_args` get slightly reordered to group cache-related options.