### PR TITLE
Extend `REPO.bazel` ignored directories to all "hidden" roots

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,6 +1,6 @@
 ignore_directories([
     "**/build",  # avoid BUILD/build mess: https://github.com/docker/desktop-feedback/issues/251
-    ".cache",  # in-workspace cache: GitLab jobs, GitHub actions
+    ".*",  # hidden root directories: .cache, .claude, .cursor, .dda, .github, .gitlab, etc.
     "bazel-*",  # bazel convenience symlinks: suddenly caused issues inside arm64 Linux containers
     "target",  # cargo build creates it where Cargo.toml lives
 ])


### PR DESCRIPTION
### What does this PR do?
Replace the single `.cache` entry in `ignore_directories` of `REPO.bazel` with a `.*` glob that matches all "hidden" directories at the root of the workspace.

### Motivation
Several "hidden" directories live at the repo root, such as:
- .cache [1.]
- .claude
- .cursor
- .dda
- .ddqa
- .git
- .github
- .gitlab [2.]
- .idea
- .mypy_cache
- .ruff_cache
- .run
- .vscode
- etc.

Each one risks confusing `bazel`'s directory watcher and/or `gazelle`'s scope, and the list keeps growing as new tools drop directories there.

The `.*` glob covers all of them without requiring future additions, including:
1. `.cache`, which was already listed,
2. `.gitlab`, thus honoring https://github.com/DataDog/datadog-agent/pull/48279#discussion_r3002947341

### Additional Notes
Such exclusions are of course used by `bazel` itself, but also by `gazelle` ([source](https://github.com/bazel-contrib/bazel-gazelle/blob/4a7caee10fbd2da9bb059f3ce7c2cac8d0050e53/walk/config.go#L211-L217)) and probably other tools of the Bazel ecosystem.