### PR TITLE
fix(fleet): Downgrade TerminatePolicy registry warning to debug log

### DIFF
--- a/pkg/fleet/installer/packages/service/windows/impl.go
+++ b/pkg/fleet/installer/packages/service/windows/impl.go
@@ -57,13 +57,13 @@ func getTerminatePolicy() bool {
 		registry.ALL_ACCESS)
 	if err != nil {
 		// if the key isn't there, we might be running a standalone binary that wasn't installed through MSI
-		log.Debugf("Windows installation key root not found, using default")
+		log.Debug("Windows installation key root not found, using default")
 		return defaultTerminatePolicy
 	}
 	defer k.Close()
 	val, _, err := k.GetIntegerValue("TerminatePolicy")
 	if err != nil {
-		log.Warnf("Windows installation key TerminatePolicy not found, using default")
+		log.Debug("Windows installation key TerminatePolicy not found, using default")
 		return defaultTerminatePolicy
 	}
 	return val == 1


### PR DESCRIPTION
### What does this PR do?

Downgrades the `TerminatePolicy` registry key log messages in `getTerminatePolicy()` from `Warn`/`Debugf` to `Debug` level.

### Motivation

The `TerminatePolicy` registry key is primarily a test helper. With setup now showing log messages to users ([#46910](https://github.com/DataDog/datadog-agent/pull/46910)), this warning could surface during installation when a service has to be killed, which is confusing and unnecessary for end users.

[WINA-2531](https://datadoghq.atlassian.net/browse/WINA-2531)

### Describe how you validated your changes

Code-only log level change, no behavioral impact.

### Additional Notes

Also cleaned up `Debugf` → `Debug` on the other message since no format args are used.

[WINA-2531]: https://datadoghq.atlassian.net/browse/WINA-2531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ