### PR TITLE
filesystem: use unix instead of syscalls for rights_nix

### DIFF
--- a/pkg/util/filesystem/rights_nix.go
+++ b/pkg/util/filesystem/rights_nix.go
@@ -25,11 +25,11 @@ func CheckRights(path string, allowGroupExec bool) error {
 	}
 
 	if allowGroupExec {
-		if stat.Mode&(syscall.S_IWGRP|syscall.S_IRWXO) != 0 {
+		if stat.Mode&(unix.S_IWGRP|unix.S_IRWXO) != 0 {
 			return fmt.Errorf("invalid executable '%s', 'others' have rights on it or 'group' has write permissions on it", path)
 		}
 	} else {
-		if stat.Mode&(syscall.S_IRWXG|syscall.S_IRWXO) != 0 {
+		if stat.Mode&(unix.S_IRWXG|unix.S_IRWXO) != 0 {
 			return fmt.Errorf("invalid executable '%s', 'group' or 'others' have rights on it", path)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Switches to using consts defined in unix instead of syscall

### Motivation

Support BSDs and increase portability

### Describe how you validated your changes
tests in pkg/util/filesystem continue to pass, fixes an error seen compiling opentelemetry-collector-contrib on OpenBSD

### Additional Notes
